### PR TITLE
Only install if PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ cmake_minimum_required(VERSION 3.17.2)
 
 project(spirv-tools)
 
+if (CMAKE_VERSION VERSION_LESS "3.21")
+    # https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
+    string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
+endif()
+
 # Avoid a bug in CMake 3.22.1. By default it will set -std=c++11 for
 # targets in test/*, when those tests need -std=c++17.
 # https://github.com/KhronosGroup/SPIRV-Tools/issues/5340
@@ -31,7 +36,9 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 enable_testing()
 set(SPIRV_TOOLS "SPIRV-Tools")
 
-include(GNUInstallDirs)
+if(PROJECT_IS_TOP_LEVEL)
+  include(GNUInstallDirs)
+endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -89,11 +96,6 @@ endif()
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
-option(SKIP_SPIRV_TOOLS_INSTALL "Skip installation" ${SKIP_SPIRV_TOOLS_INSTALL})
-if(NOT ${SKIP_SPIRV_TOOLS_INSTALL})
-  set(ENABLE_SPIRV_TOOLS_INSTALL ON)
 endif()
 
 option(SPIRV_BUILD_COMPRESSION "Build SPIR-V compressing codec" OFF)
@@ -283,7 +285,7 @@ else()
   endmacro()
 endif()
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   if(WIN32 AND NOT MINGW)
     macro(spvtools_config_package_dir TARGET PATH)
       set(${PATH} ${TARGET}/cmake)
@@ -356,7 +358,7 @@ add_subdirectory(tools)
 add_subdirectory(test)
 add_subdirectory(examples)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(
     FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-tools/libspirv.h
@@ -366,7 +368,7 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
       ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv-tools/instrument.hpp
     DESTINATION
       ${CMAKE_INSTALL_INCLUDEDIR}/spirv-tools/)
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()
 
 if (NOT "${SPIRV_SKIP_TESTS}")
   add_test(NAME spirv-tools-copyrights
@@ -403,7 +405,7 @@ add_custom_target(spirv-tools-shared-pkg-config ALL
         DEPENDS "CHANGES" "cmake/SPIRV-Tools-shared.pc.in" "cmake/write_pkg_config.cmake")
 
 # Install pkg-config file
-if (ENABLE_SPIRV_TOOLS_INSTALL)
+if (PROJECT_IS_TOP_LEVEL)
   install(
     FILES
       ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -424,7 +424,7 @@ if (ANDROID)
     endforeach()
 endif()
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets)
   export(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Target.cmake)
 
@@ -439,7 +439,7 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
     "    get_target_property(${SPIRV_TOOLS}_INCLUDE_DIRS ${SPIRV_TOOLS} INTERFACE_INCLUDE_DIRECTORIES)\n"
     "endif()\n")
   install(FILES ${CMAKE_BINARY_DIR}/${SPIRV_TOOLS}Config.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()
 
 if(MSVC AND (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")))
   # Enable parallel builds across four cores for this lib

--- a/source/diff/CMakeLists.txt
+++ b/source/diff/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(SPIRV-Tools-diff
 set_property(TARGET SPIRV-Tools-diff PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-diff)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS SPIRV-Tools-diff EXPORT SPIRV-Tools-diffTargets)
   export(EXPORT SPIRV-Tools-diffTargets FILE SPIRV-Tools-diffTargets.cmake)
 
@@ -48,4 +48,4 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 
   spvtools_generate_config_file(SPIRV-Tools-diff)
   install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-diffConfig.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -469,7 +469,7 @@ if(SPIRV_BUILD_FUZZER)
   set_property(TARGET SPIRV-Tools-fuzz PROPERTY FOLDER "SPIRV-Tools libraries")
   spvtools_check_symbol_exports(SPIRV-Tools-fuzz)
 
-  if(ENABLE_SPIRV_TOOLS_INSTALL)
+  if(PROJECT_IS_TOP_LEVEL)
       install(TARGETS SPIRV-Tools-fuzz EXPORT SPIRV-Tools-fuzzTargets)
       export(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTarget.cmake)
 
@@ -479,6 +479,6 @@ if(SPIRV_BUILD_FUZZER)
 
       spvtools_generate_config_file(SPIRV-Tools-fuzz)
       install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-fuzzConfig.cmake DESTINATION ${PACKAGE_DIR})
-  endif(ENABLE_SPIRV_TOOLS_INSTALL)
+  endif()
 
 endif(SPIRV_BUILD_FUZZER)

--- a/source/link/CMakeLists.txt
+++ b/source/link/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(SPIRV-Tools-link
 set_property(TARGET SPIRV-Tools-link PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-link)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS SPIRV-Tools-link EXPORT SPIRV-Tools-linkTargets)
   export(EXPORT SPIRV-Tools-linkTargets FILE SPIRV-Tools-linkTargets.cmake)
 
@@ -40,4 +40,4 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 
   spvtools_generate_config_file(SPIRV-Tools-link)
   install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-linkConfig.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()

--- a/source/lint/CMakeLists.txt
+++ b/source/lint/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(SPIRV-Tools-lint
 set_property(TARGET SPIRV-Tools-lint PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-lint)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS SPIRV-Tools-lint EXPORT SPIRV-Tools-lintTargets)
   export(EXPORT SPIRV-Tools-lintTargets FILE SPIRV-Tools-lintTargets.cmake)
 
@@ -55,4 +55,4 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 
   spvtools_generate_config_file(SPIRV-Tools-lint)
   install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-lintConfig.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -276,7 +276,7 @@ target_link_libraries(SPIRV-Tools-opt
 set_property(TARGET SPIRV-Tools-opt PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-opt)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS SPIRV-Tools-opt EXPORT SPIRV-Tools-optTargets)
   export(EXPORT SPIRV-Tools-optTargets FILE SPIRV-Tools-optTargets.cmake)
 
@@ -286,4 +286,4 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 
   spvtools_generate_config_file(SPIRV-Tools-opt)
   install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-optConfig.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -100,7 +100,7 @@ target_link_libraries(SPIRV-Tools-reduce
 set_property(TARGET SPIRV-Tools-reduce PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-reduce)
 
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(TARGETS SPIRV-Tools-reduce EXPORT SPIRV-Tools-reduceTargets)
   export(EXPORT SPIRV-Tools-reduceTargets FILE SPIRV-Tools-reduceTarget.cmake)
 
@@ -110,4 +110,4 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
 
   spvtools_generate_config_file(SPIRV-Tools-reduce)
   install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-reduceConfig.cmake DESTINATION ${PACKAGE_DIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -87,9 +87,9 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
   if(SPIRV_BUILD_FUZZER)
     add_spvtools_tool(TARGET spirv-fuzz SRCS fuzz/fuzz.cpp util/cli_consumer.cpp LIBS SPIRV-Tools-fuzz ${SPIRV_TOOLS_FULL_VISIBILITY})
     set(SPIRV_INSTALL_TARGETS ${SPIRV_INSTALL_TARGETS} spirv-fuzz)
-  endif(SPIRV_BUILD_FUZZER)
+  endif()
 
-  if(ENABLE_SPIRV_TOOLS_INSTALL)
+  if(PROJECT_IS_TOP_LEVEL)
     install(TARGETS ${SPIRV_INSTALL_TARGETS} EXPORT SPIRV-Tools-toolsTargets)
     export(EXPORT SPIRV-Tools-toolsTargets FILE SPIRV-Tools-toolsTargets.cmake)
 
@@ -104,5 +104,5 @@ if (NOT ${SPIRV_SKIP_EXECUTABLES})
       )
 
     install(FILES ${CMAKE_BINARY_DIR}/SPIRV-Tools-toolsConfig.cmake DESTINATION ${PACKAGE_DIR})
-  endif(ENABLE_SPIRV_TOOLS_INSTALL)
+  endif()
 endif()

--- a/tools/emacs/CMakeLists.txt
+++ b/tools/emacs/CMakeLists.txt
@@ -35,14 +35,18 @@
 # Note that symbol IDs are not preserved through a load/edit/save operation.
 # This may change if the ability is added to spirv-as.
 
-option(SPIRV_TOOLS_INSTALL_EMACS_HELPERS
-  "Install Emacs helper to disassemble/assemble SPIR-V binaries on file load/save."
-  ${SPIRV_TOOLS_INSTALL_EMACS_HELPERS})
-if (${SPIRV_TOOLS_INSTALL_EMACS_HELPERS})
-  if(EXISTS /etc/emacs/site-start.d)
-    if(ENABLE_SPIRV_TOOLS_INSTALL)
-      install(FILES 50spirv-tools.el DESTINATION /etc/emacs/site-start.d)
-    endif(ENABLE_SPIRV_TOOLS_INSTALL)
-  endif()
+option(SPIRV_TOOLS_INSTALL_EMACS_HELPERS "Install Emacs helper to disassemble/assemble SPIR-V binaries on file load/save.")
+if (NOT SPIRV_TOOLS_INSTALL_EMACS_HELPERS)
+  return()
 endif()
+
+if (NOT PROJECT_IS_TOP_LEVEL)
+  return()
+endif()
+
+if (NOT EXISTS /etc/emacs/site-start.d)
+  return()
+endif()
+
+install(FILES 50spirv-tools.el DESTINATION /etc/emacs/site-start.d)
 

--- a/tools/lesspipe/CMakeLists.txt
+++ b/tools/lesspipe/CMakeLists.txt
@@ -23,6 +23,6 @@
 # permissions.
 # We have a .sh extension because Windows users often configure
 # executable settings via filename extension.
-if(ENABLE_SPIRV_TOOLS_INSTALL)
+if(PROJECT_IS_TOP_LEVEL)
   install(PROGRAMS spirv-lesspipe.sh DESTINATION ${CMAKE_INSTALL_BINDIR})
-endif(ENABLE_SPIRV_TOOLS_INSTALL)
+endif()


### PR DESCRIPTION
This approach is currently being used in:
- Vulkan-Headers
- Spirv-Headers

Avoids polluting installation of clients who consume this project via add_subdirectory.

Removes the need to even have SKIP_SPIRV_TOOLS_INSTALL

The only time SPIRV_TOOLS should install files is if it is the TOP_LEVEL project.