### PR TITLE
Disable Wnonnull in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -366,6 +366,9 @@ config("spvtools_internal_config") {
       "-Wno-newline-eof",
       "-Wno-unreachable-code-break",
       "-Wno-unreachable-code-return",
+      # Workaround for Android NDK issue in spirv-fuzz and spirv-reduce
+      # https://crbug.com/1505825
+      "-Wno-nonnull",
     ]
   } else if (!is_win) {
     # Work around a false-positive on a Skia GCC 10 builder.


### PR DESCRIPTION
There is an issue in the latest Android NDK where the `std::system` is flagged as having a non-null parameter. This behaviour is currently used by spirv-reduce and spirv-fuzz (and is documented as being allowed).

In order to allow building with the latest NDK disable the `Wnonnull` warning in the BUILD.gn file.