### PR TITLE
Remove uses of std::system(nullptr)

### DIFF
--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -41,12 +41,6 @@ namespace {
 
 enum class FuzzingTarget { kSpirv, kWgsl };
 
-// Check that the std::system function can actually be used.
-bool CheckExecuteCommand() {
-  int res = std::system(nullptr);
-  return res != 0;
-}
-
 // Execute a command using the shell.
 // Returns true if and only if the command's exit status was 0.
 bool ExecuteCommand(const std::string& command) {
@@ -770,11 +764,6 @@ int main(int argc, const char** argv) {
       }
       break;
     case FuzzActions::SHRINK: {
-      if (!CheckExecuteCommand()) {
-        std::cerr << "could not find shell interpreter for executing a command"
-                  << std::endl;
-        return 1;
-      }
       if (!Shrink(target_env, fuzzer_options, validator_options, binary_in,
                   initial_facts, shrink_transformations_file,
                   shrink_temp_file_prefix, interestingness_test, &binary_out,

--- a/tools/reduce/reduce.cpp
+++ b/tools/reduce/reduce.cpp
@@ -30,12 +30,6 @@
 
 namespace {
 
-// Check that the std::system function can actually be used.
-bool CheckExecuteCommand() {
-  int res = std::system(nullptr);
-  return res != 0;
-}
-
 // Execute a command using the shell.
 // Returns true if and only if the command's exit status was 0.
 bool ExecuteCommand(const std::string& command) {
@@ -281,12 +275,6 @@ int main(int argc, const char** argv) {
 
   if (status.action == REDUCE_STOP) {
     return status.code;
-  }
-
-  if (!CheckExecuteCommand()) {
-    std::cerr << "could not find shell interpreter for executing a command"
-              << std::endl;
-    return 2;
   }
 
   spvtools::reduce::Reducer reducer(target_env);


### PR DESCRIPTION
Android's bionic library blows up on this, contrary to the standard.

If std::system can't find a shell, you already have bigger problems. Don't check specially for that condition. (That's the justification Android uses, and I'm not going to fight it.)