### PR TITLE
Fix array removal for task/mesh in interface validation

### DIFF
--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -311,9 +311,15 @@ spv_result_t GetLocationsForVariable(
     }
   }
 
-  // Vulkan 14.1.3: Tessellation control and mesh per-vertex outputs and
-  // tessellation control, evaluation and geometry per-vertex inputs have a
-  // layer of arraying that is not included in interface matching.
+  // Vulkan 14.1.3: Some interfaces have a layer of arraying
+  // that is not included in interface matching:
+  // - Tessellation control input and output, except Patch decoration
+  // - Tessellation evaluation input, except Patch decoration
+  // - Geometry input
+  // - Fragment input with PerVertexKHR decoration
+  // - Task output, except PerTaskNV decoration
+  // - Mesh input, except PerTaskNV decoration
+  // - Mesh output
   bool is_arrayed = false;
   switch (entry_point->GetOperandAs<spv::ExecutionModel>(0)) {
     case spv::ExecutionModel::TessellationControl:
@@ -336,10 +342,23 @@ spv_result_t GetLocationsForVariable(
         is_arrayed = true;
       }
       break;
-    case spv::ExecutionModel::MeshNV:
+    case spv::ExecutionModel::TaskNV:
       if (is_output && !has_per_task_nv) {
         is_arrayed = true;
       }
+      break;
+    case spv::ExecutionModel::TaskEXT:
+      if (is_output) {
+        is_arrayed = true;
+      }
+      break;
+    case spv::ExecutionModel::MeshNV:
+      if (is_output || !has_per_task_nv) {
+        is_arrayed = true;
+      }
+      break;
+    case spv::ExecutionModel::MeshEXT:
+      is_arrayed = true;
       break;
     default:
       break;


### PR DESCRIPTION
The array removal in the interface validation wasn't correct for task and mesh shaders in a few ways:
- The SPV_NV_mesh_shader extension states that `PerTaskNV` is only permitted on task output and mesh input. The current code tests for it on mesh output instead, which is pointless.
- TaskNV, TaskEXT and MeshEXT shaders were not included. TaskEXT output and MeshEXT input do not have a `PerTaskNV` decoration, so they are always arrayed. MeshEXT output is also always arrayed.

Note that the Vulkan spec does not mention the special cases for task output and mesh input, because the arraying must always be matched on both sides of the interface, and therefore is irrelevant for merely *matching* the interface. But for the code here, which tries to retrieve the type that underlies the array, it still needs to be taken into account.