### PR TITLE
Skip entire test/ folder if SPIRV_SKIP_TESTS is set.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,22 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (${SPIRV_SKIP_TESTS})
+  return()
+endif()
+
+if (TARGET gmock_main)
+  message(STATUS "Found Google Mock, building tests.")
+else()
+  message(STATUS "Did not find googletest, tests will not be built. "
+    "To enable tests place googletest in '<spirv-dir>/external/googletest'.")
+endif()
+
 # Add a SPIR-V Tools unit test. Signature:
 #   add_spvtools_unittest(
 #     TARGET target_name
 #     SRCS   src_file.h src_file.cpp
 #     LIBS   lib1 lib2
 #   )
-
-if (NOT "${SPIRV_SKIP_TESTS}")
-  if (TARGET gmock_main)
-    message(STATUS "Found Google Mock, building tests.")
-  else()
-    message(STATUS "Did not find googletest, tests will not be built. "
-      "To enable tests place googletest in '<spirv-dir>/external/googletest'.")
-  endif()
-endif()
-
 function(add_spvtools_unittest)
   if (NOT "${SPIRV_SKIP_TESTS}" AND TARGET gmock_main)
     set(one_value_args TARGET PCH_FILE)


### PR DESCRIPTION
Without this (or similar filtering), the `spirv-tools_expect_unittests` and `spirv-tools_spirv_test_framework_unittests` Python tests at `test/tools/` get defined even when `SPIRV_SKIP_TESTS` is set.

In downstream projects this show up as extra irrelevant tests: 
![image](https://github.com/KhronosGroup/SPIRV-Tools/assets/4010439/f7f0215c-4565-457f-8085-bfe772c764a8)