### PR TITLE
opt: prevent meld to merge block with MaximalReconvergence

### DIFF
--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -104,7 +104,8 @@ bool CanMergeWithSuccessor(IRContext* context, BasicBlock* block) {
   // shader author expectations. Similarly, instructions in the loop construct
   // cannot be moved into the continue construct unless it can be proven that
   // invocations are always converged.
-  if (succ_is_merge && context->get_feature_mgr()->HasExtension(kSPV_KHR_maximal_reconvergence)) {
+  if (succ_is_merge && context->get_feature_mgr()->HasExtension(
+                           kSPV_KHR_maximal_reconvergence)) {
     return false;
   }
 

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -44,16 +44,6 @@ bool IsMerge(IRContext* context, uint32_t id) {
       });
 }
 
-bool IsMaximalReconvergenceExtEnabled(IRContext* context) {
-  for (auto extension : context->extensions()) {
-    if (extension.GetOperand(0).AsString() == "SPV_KHR_maximal_reconvergence") {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 // Returns true if |block| is the merge target of a merge instruction.
 bool IsMerge(IRContext* context, BasicBlock* block) {
   return IsMerge(context, block->id());

--- a/source/opt/block_merge_util.cpp
+++ b/source/opt/block_merge_util.cpp
@@ -114,7 +114,7 @@ bool CanMergeWithSuccessor(IRContext* context, BasicBlock* block) {
   // shader author expectations. Similarly, instructions in the loop construct
   // cannot be moved into the continue construct unless it can be proven that
   // invocations are always converged.
-  if (succ_is_merge && IsMaximalReconvergenceExtEnabled(context)) {
+  if (succ_is_merge && context->get_feature_mgr()->HasExtension(kSPV_KHR_maximal_reconvergence)) {
     return false;
   }
 


### PR DESCRIPTION
The extension SPV_KHR_maximal_reconvergence adds more constraints around the merge blocks, and how the control flow can be altered.

The one we address here is explained in the following part of the spec:

>  Note: This means that the instructions in a break block will execute as if
>  they were still diverged according to the loop iteration. This restricts
>  potential transformations an implementation may perform on the IR to match
>  shader author expectations. Similarly, instructions in the loop construct
>  cannot be moved into the continue construct unless it can be proven that
>  invocations are always converged.

Until the optimizer is clever enough to determine if the invocation have already converged, we shall not meld a block which branches to a merge block into it, as it might move some instructions outside of the convergence region.

This behavior being only required with the extension, this commit behavior change is gated by the extension.
This means using wave operations without the maximal reconvergence extension might lead to undefined behaviors.

Related to https://github.com/microsoft/DirectXShaderCompiler/issues/6222