### PR TITLE
Adapt tests: image channel order enums don't depend on Kernel

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -13,7 +13,7 @@ vars = {
   'protobuf_revision': 'v21.12',
 
   're2_revision': 'ab7c5918b418428ed17dbe564e0d8402bd7d743d',
-  'spirv_headers_revision': 'e77d03080b90c5d361663a67834c57bb1fddaec2',
+  'spirv_headers_revision': 'd3c2a6fa95ad463ca8044d7fc45557db381a6a64',
 }
 
 deps = {

--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -340,56 +340,56 @@ INSTANTIATE_TEST_SUITE_P(
 // See SPIR-V Section 3.12 Image Channel Order
 INSTANTIATE_TEST_SUITE_P(
     ImageChannelOrder, EnumCapabilityTest,
-    Combine(
-        Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
-        ValuesIn(std::vector<EnumCapabilityCase>{
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::R, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::A, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RG, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RA, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGB, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGBA, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::BGRA, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::ARGB, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Intensity, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Luminance, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Rx, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGx, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGBx, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Depth, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::DepthStencil, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGB, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGBx, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGBA, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sBGRA, Kernel),
-            CASE1(IMAGE_CHANNEL_ORDER, ImageChannelOrder::ABGR, Kernel),
-        })));
+    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+            ValuesIn(std::vector<EnumCapabilityCase>{
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::R),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::A),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RG),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RA),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGB),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGBA),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::BGRA),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::ARGB),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Intensity),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Luminance),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Rx),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGx),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::RGBx),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::Depth),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::DepthStencil),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGB),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGBx),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sRGBA),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::sBGRA),
+                CASE0(IMAGE_CHANNEL_ORDER, ImageChannelOrder::ABGR),
+            })));
 
 // See SPIR-V Section 3.13 Image Channel Data Type
 INSTANTIATE_TEST_SUITE_P(
     ImageChannelDataType, EnumCapabilityTest,
-    Combine(Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
-            ValuesIn(std::vector<EnumCapabilityCase>{
-                // clang-format off
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SnormInt8, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SnormInt16, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt8, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt16, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormShort565, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormShort555, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt101010, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt8, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt16, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt32, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt8, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt16, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt32, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::HalfFloat, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::Float, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt24, Kernel),
-                CASE1(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt101010_2, Kernel),
-                // clang-format on
-            })));
+    Combine(
+        Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_1),
+        ValuesIn(std::vector<EnumCapabilityCase>{
+            // clang-format off
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SnormInt8),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SnormInt16),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt8),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt16),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormShort565),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormShort555),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt101010),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt8),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt16),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::SignedInt32),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt8),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt16),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnsignedInt32),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::HalfFloat),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::Float),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt24),
+                CASE0(IMAGE_CHANNEL_DATA_TYPE, ImageChannelDataType::UnormInt101010_2),
+            // clang-format on
+        })));
 
 // See SPIR-V Section 3.14 Image Operands
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Adapts to https://github.com/KhronosGroup/SPIRV-Headers/pull/413

Fixes: #5572