### PR TITLE
[OPT] Add removed unused interface var pass to legalization passes

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -676,7 +676,6 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // return unmodified.
   if (!AllExtensionsSupported()) return Status::SuccessWithoutChange;
 
-  std::cerr << "STEVEN: pass all prereq.\n";
   // Eliminate Dead functions.
   bool modified = EliminateDeadFunctions();
 

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -676,6 +676,7 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
   // return unmodified.
   if (!AllExtensionsSupported()) return Status::SuccessWithoutChange;
 
+  std::cerr << "STEVEN: pass all prereq.\n";
   // Eliminate Dead functions.
   bool modified = EliminateDeadFunctions();
 

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -167,6 +167,7 @@ Optimizer& Optimizer::RegisterLegalizationPasses(bool preserve_interface) {
           .RegisterPass(CreateDeadInsertElimPass())
           .RegisterPass(CreateReduceLoadSizePass())
           .RegisterPass(CreateAggressiveDCEPass(preserve_interface))
+          .RegisterPass(CreateRemoveUnusedInterfaceVariablesPass())
           .RegisterPass(CreateInterpolateFixupPass())
           .RegisterPass(CreateInvocationInterlockPlacementPass());
 }


### PR DESCRIPTION
DXC does not do a good job of recognizing which variables need to be
on the entry point for which functions. This is because it does not
want to have to walk the call tree to determine which instructions
are reachable from which entry points.

This is also useful if the same input variable gets used from two
different shader, but the uses in one get optimized away.

Will parially fix
https://github.com/microsoft/DirectXShaderCompiler/issues/4621. Will not
fix code compiled with -fcgl.
