### PR TITLE
Remove redundant function declarations from `source/operand.h`

### DIFF
--- a/source/operand.h
+++ b/source/operand.h
@@ -57,12 +57,6 @@ spv_result_t spvOperandTableValueLookup(spv_target_env,
 // Gets the name string of the non-variable operand type.
 const char* spvOperandTypeStr(spv_operand_type_t type);
 
-// Returns true if the given type is concrete.
-bool spvOperandIsConcrete(spv_operand_type_t type);
-
-// Returns true if the given type is concrete and also a mask.
-bool spvOperandIsConcreteMask(spv_operand_type_t type);
-
 // Returns true if an operand of the given type is optional.
 bool spvOperandIsOptional(spv_operand_type_t type);
 


### PR DESCRIPTION
Flagged by `-Wredundant-decls`

I'm assuming the declarations in `libspirv.h` are part of the external interface and need to be kept.


Change-Id: I6b138d3322a7a4ee49ee33b0fbcf0ca35dd92261