### PR TITLE
[OPT] Zero-extend unsigned 16-bit integers when bitcasting

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -180,8 +180,17 @@ std::vector<uint32_t> GetWordsFromNumericScalarOrVectorConstant(
 const analysis::Constant* ConvertWordsToNumericScalarOrVectorConstant(
     analysis::ConstantManager* const_mgr, const std::vector<uint32_t>& words,
     const analysis::Type* type) {
-  if (type->AsInteger() || type->AsFloat())
-    return const_mgr->GetConstant(type, words);
+  const spvtools::opt::analysis::Integer* int_type = type->AsInteger();
+
+  if (int_type && int_type->width() < 32 && !int_type->IsSigned()) {
+    assert(words.size() == 1);
+    // Unsigned values smaller than 32-bit must have the high bits set to 0. See
+    // section 2.2.1 of the SPIR-V spec.
+    const std::vector<uint32_t> truncated = {words[0] & 0xFFFF};
+    return const_mgr->GetConstant(type, truncated);
+  }
+
+  if (int_type || type->AsFloat()) return const_mgr->GetConstant(type, words);
   if (const auto* vec_type = type->AsVector())
     return const_mgr->GetNumericVectorConstantWithWords(vec_type, words);
   return nullptr;

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -924,7 +924,7 @@ INSTANTIATE_TEST_SUITE_P(TestCase, IntegerInstructionFoldingTest,
             "%2 = OpBitcast %ushort %short_0xBC00\n" +
             "OpReturn\n" +
             "OpFunctionEnd",
-        2, 0xFFFFBC00),
+        2, 0xBC00),
     // Test case 53: Bit-cast half 1 to ushort
     InstructionFoldingCase<uint32_t>(
         Header() + "%main = OpFunction %void None %void_func\n" +


### PR DESCRIPTION
The folding rule `BitCastScalarOrVector` was incorrectly handling bitcasting to unsigned 16-bit integers. It was simply copying the entire 32-bit word containing the 16-bit integer. This conflicts with the requirement in section 2.2.1 of the SPIR-V spec which states that unsigned numeric types with a bit width less than 32-bits must have the high-order bits set to 0.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/6319.