### PR TITLE
Add `SPIRV_TOOLS_EXPORT` to public C++ API

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -33,15 +33,19 @@ extern "C" {
 #else
 #define SPIRV_TOOLS_EXPORT __declspec(dllimport)
 #endif
+#define SPIRV_TOOLS_LOCAL
 #else
 #if defined(SPIRV_TOOLS_IMPLEMENTATION)
 #define SPIRV_TOOLS_EXPORT __attribute__((visibility("default")))
+#define SPIRV_TOOLS_LOCAL __attribute__((visibility("hidden")))
 #else
 #define SPIRV_TOOLS_EXPORT
+#define SPIRV_TOOLS_LOCAL
 #endif
 #endif
 #else
 #define SPIRV_TOOLS_EXPORT
+#define SPIRV_TOOLS_LOCAL
 #endif
 
 // Helpers

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -37,7 +37,7 @@ using InstructionParser =
     std::function<spv_result_t(const spv_parsed_instruction_t& instruction)>;
 
 // C++ RAII wrapper around the C context object spv_context.
-class Context {
+class SPIRV_TOOLS_EXPORT Context {
  public:
   // Constructs a context targeting the given environment |env|.
   //
@@ -73,7 +73,7 @@ class Context {
 };
 
 // A RAII wrapper around a validator options object.
-class ValidatorOptions {
+class SPIRV_TOOLS_EXPORT ValidatorOptions {
  public:
   ValidatorOptions() : options_(spvValidatorOptionsCreate()) {}
   ~ValidatorOptions() { spvValidatorOptionsDestroy(options_); }
@@ -163,7 +163,7 @@ class ValidatorOptions {
 };
 
 // A C++ wrapper around an optimization options object.
-class OptimizerOptions {
+class SPIRV_TOOLS_EXPORT OptimizerOptions {
  public:
   OptimizerOptions() : options_(spvOptimizerOptionsCreate()) {}
   ~OptimizerOptions() { spvOptimizerOptionsDestroy(options_); }
@@ -205,7 +205,7 @@ class OptimizerOptions {
 };
 
 // A C++ wrapper around a reducer options object.
-class ReducerOptions {
+class SPIRV_TOOLS_EXPORT ReducerOptions {
  public:
   ReducerOptions() : options_(spvReducerOptionsCreate()) {}
   ~ReducerOptions() { spvReducerOptionsDestroy(options_); }
@@ -236,7 +236,7 @@ class ReducerOptions {
 };
 
 // A C++ wrapper around a fuzzer options object.
-class FuzzerOptions {
+class SPIRV_TOOLS_EXPORT FuzzerOptions {
  public:
   FuzzerOptions() : options_(spvFuzzerOptionsCreate()) {}
   ~FuzzerOptions() { spvFuzzerOptionsDestroy(options_); }
@@ -283,7 +283,7 @@ class FuzzerOptions {
 // provides methods for assembling, disassembling, and validating.
 //
 // Instances of this class provide basic thread-safety guarantee.
-class SpirvTools {
+class SPIRV_TOOLS_EXPORT SpirvTools {
  public:
   enum {
     // Default assembling option used by assemble():
@@ -388,7 +388,8 @@ class SpirvTools {
   bool IsValid() const;
 
  private:
-  struct Impl;  // Opaque struct for holding the data fields used by this class.
+  struct SPIRV_TOOLS_LOCAL
+      Impl;  // Opaque struct for holding the data fields used by this class.
   std::unique_ptr<Impl> impl_;  // Unique pointer to implementation data.
 };
 

--- a/include/spirv-tools/linker.hpp
+++ b/include/spirv-tools/linker.hpp
@@ -24,7 +24,7 @@
 
 namespace spvtools {
 
-class LinkerOptions {
+class SPIRV_TOOLS_EXPORT LinkerOptions {
  public:
   // Returns whether a library or an executable should be produced by the
   // linking phase.
@@ -84,14 +84,15 @@ class LinkerOptions {
 // * Some entry points were defined multiple times;
 // * Some imported symbols did not have an exported counterpart;
 // * Possibly other reasons.
-spv_result_t Link(const Context& context,
-                  const std::vector<std::vector<uint32_t>>& binaries,
-                  std::vector<uint32_t>* linked_binary,
-                  const LinkerOptions& options = LinkerOptions());
-spv_result_t Link(const Context& context, const uint32_t* const* binaries,
-                  const size_t* binary_sizes, size_t num_binaries,
-                  std::vector<uint32_t>* linked_binary,
-                  const LinkerOptions& options = LinkerOptions());
+SPIRV_TOOLS_EXPORT spv_result_t
+Link(const Context& context, const std::vector<std::vector<uint32_t>>& binaries,
+     std::vector<uint32_t>* linked_binary,
+     const LinkerOptions& options = LinkerOptions());
+SPIRV_TOOLS_EXPORT spv_result_t
+Link(const Context& context, const uint32_t* const* binaries,
+     const size_t* binary_sizes, size_t num_binaries,
+     std::vector<uint32_t>* linked_binary,
+     const LinkerOptions& options = LinkerOptions());
 
 }  // namespace spvtools
 

--- a/include/spirv-tools/linter.hpp
+++ b/include/spirv-tools/linter.hpp
@@ -24,7 +24,7 @@ namespace spvtools {
 // provides a method for linting.
 //
 // Instances of this class provides basic thread-safety guarantee.
-class Linter {
+class SPIRV_TOOLS_EXPORT Linter {
  public:
   explicit Linter(spv_target_env env);
 
@@ -40,7 +40,7 @@ class Linter {
   bool Run(const uint32_t* binary, size_t binary_size);
 
  private:
-  struct Impl;
+  struct SPIRV_TOOLS_LOCAL Impl;
   std::unique_ptr<Impl> impl_;
 };
 }  // namespace spvtools

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -37,14 +37,14 @@ struct DescriptorSetAndBinding;
 // provides methods for registering optimization passes and optimizing.
 //
 // Instances of this class provides basic thread-safety guarantee.
-class Optimizer {
+class SPIRV_TOOLS_EXPORT Optimizer {
  public:
   // The token for an optimization pass. It is returned via one of the
   // Create*Pass() standalone functions at the end of this header file and
   // consumed by the RegisterPass() method. Tokens are one-time objects that
   // only support move; copying is not allowed.
   struct PassToken {
-    struct Impl;  // Opaque struct for holding internal data.
+    struct SPIRV_TOOLS_LOCAL Impl;  // Opaque struct for holding internal data.
 
     PassToken(std::unique_ptr<Impl>);
 
@@ -239,7 +239,7 @@ class Optimizer {
   Optimizer& SetValidateAfterAll(bool validate);
 
  private:
-  struct Impl;                  // Opaque struct for holding internal data.
+  struct SPIRV_TOOLS_LOCAL Impl;  // Opaque struct for holding internal data.
   std::unique_ptr<Impl> impl_;  // Unique pointer to internal data.
 };
 


### PR DESCRIPTION
In contrast to the C API, the C++ API did not have symbol visibility specified.  An application using the C++ API would fail to link against a shared SPIRV-Tools library built with `-fvisibility=hidden`; see e.g. https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2358

Mark all classes in the public `.hpp` files with `SPIRV_TOOLS_EXPORT`. Add `SPIRV_TOOLS_LOCAL` to hide nested structs containing implementation details.