### PR TITLE
[OPT] Fix handling of analyses rebuild

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -88,6 +88,9 @@ void IRContext::BuildInvalidAnalyses(IRContext::Analysis set) {
   if (set & kAnalysisDebugInfo) {
     BuildDebugInfoManager();
   }
+  if (set & kAnalysisLiveness) {
+    BuildLivenessManager();
+  }
 }
 
 void IRContext::InvalidateAnalysesExceptFor(

--- a/source/opt/ir_context.h
+++ b/source/opt/ir_context.h
@@ -84,7 +84,7 @@ class IRContext {
     kAnalysisTypes = 1 << 15,
     kAnalysisDebugInfo = 1 << 16,
     kAnalysisLiveness = 1 << 17,
-    kAnalysisEnd = 1 << 17
+    kAnalysisEnd = 1 << 18
   };
 
   using ProcessFunction = std::function<bool(Function*)>;


### PR DESCRIPTION
All tests treat kAnalysisEnd like STL end iterators, which means its value must be greater than that of the last valid Analysis.


Change-Id: Ibfaaf60bb450c508af0528dbe9c0729e6aa07b3b