### PR TITLE
Change CMake to avoid pkg-config file when there are no changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,8 @@ set(SPIRV_SHARED_LIBRARIES "-lSPIRV-Tools-shared")
 
 # Build pkg-config file
 # Use a first-class target so it's regenerated when relevant files are updated.
-add_custom_target(spirv-tools-pkg-config ALL
+add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc
         COMMAND ${CMAKE_COMMAND}
                       -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
                       -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools.pc.in
@@ -397,8 +398,9 @@ add_custom_target(spirv-tools-pkg-config ALL
                       -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                       -DSPIRV_LIBRARIES=${SPIRV_LIBRARIES}
                       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
-        DEPENDS "CHANGES" "cmake/SPIRV-Tools.pc.in" "cmake/write_pkg_config.cmake")
-add_custom_target(spirv-tools-shared-pkg-config ALL
+        DEPENDS "CHANGES" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools.pc.in" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake")
+add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools-shared.pc
         COMMAND ${CMAKE_COMMAND}
                       -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
                       -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools-shared.pc.in
@@ -408,7 +410,10 @@ add_custom_target(spirv-tools-shared-pkg-config ALL
                       -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
                       -DSPIRV_SHARED_LIBRARIES=${SPIRV_SHARED_LIBRARIES}
                       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
-        DEPENDS "CHANGES" "cmake/SPIRV-Tools-shared.pc.in" "cmake/write_pkg_config.cmake")
+        DEPENDS "CHANGES" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools-shared.pc.in" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake")
+add_custom_target(spirv-tools-pkg-config 
+        ALL 
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools-shared.pc ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc)
 
 # Install pkg-config file
 if (ENABLE_SPIRV_TOOLS_INSTALL)


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/4281

add_custom_target will run a command on every build, even when the output file doesn't need to be rebuilt. Using add_custom_command and specifying an output file for the command ensures that the output will only be regenerated when it's dependencies change, and we use a no-op custom target to require those outputs to be generated at least once.

This doesn't really change anything, but it does clean up the build output, particularly when taking in SPIRV tools as a subdirectory in a larger cmake project. It also changes the build output from something like:
``` 
"C:\Program Files\CMake\bin\cmake.EXE" --build e:/hotreload/build --config RelWithDebInfo --target all --
[2/2  50% :: 0.036] C:\WINDOWS\system32\cmd.exe /C "cd /D E:\hotreload\build\_deps\glslang-build\External\spirv-tools && "C:\Program Files\CMake\bin\cmake.exe" -DCHANGES_FILE=E:/hotreload/build/_deps/glslang-src/External/spirv-tools/CHANGES -DTEMPLATE_FILE=E:/hotreload/build/_deps/glslang-src/External/spirv-tools/cmake/SPIRV-Tools.pc.in -DOUT_FILE=E:/hotreload/build/_deps/glslang-build/External/spirv-tools/SPIRV-Tools.pc "-DCMAKE_INSTALL_PREFIX=C:/Program Files (x86)/HotReload" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_INCLUDEDIR=include "-DSPIRV_LIBRARIES=-lSPIRV-Tools-opt -lSPIRV-Tools -lSPIRV-Tools-link" -P E:/hotreload/build/_deps/glslang-src/External/spirv-tools/cmake/write_pkg_config.cmake"
[2/2 100% :: 0.037] C:\WINDOWS\system32\cmd.exe /C "cd /D E:\hotreload\build\_deps\glslang-build\External\spirv-tools && "C:\Program Files\CMake\bin\cmake.exe" -DCHANGES_FILE=E:/hotreload/build/_deps/glslang-src/External/spirv-tools/CHANGES -DTEMPLATE_FILE=E:/hotreload/build/_deps/glslang-src/External/spirv-tools/cmake/SPIRV-Tools-shared.pc.in -DOUT_FILE=E:/hotreload/build/_deps/glslang-build/External/spirv-tools/SPIRV-Tools-shared.pc "-DCMAKE_INSTALL_PREFIX=C:/Program Files (x86)/HotReload" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_INCLUDEDIR=include -DSPIRV_SHARED_LIBRARIES=-lSPIRV-Tools-shared -P E:/hotreload/build/_deps/glslang-src/External/spirv-tools/cmake/write_pkg_config.cmake"
```

to the much clearer
```
[3/8  12% :: 0.032] Generating SPIRV-Tools-shared.pc
[3/8  25% :: 0.032] Generating SPIRV-Tools.pc
[3/8  37% :: 0.105] Update build-version.inc in the SPIRV-Tools build directory (if necessary).
```