### PR TITLE
Allow RTA in Uniform without BufferBlock in SPV1.4+

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "source/opcode.h"
+#include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
 #include "source/val/validate.h"
@@ -747,7 +748,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
                       "PhysicalStorageBuffer.";
           }
         } else if (storage_class == spv::StorageClass::Uniform) {
-          if (!_.HasDecoration(value_id, spv::Decoration::BufferBlock)) {
+          if (!_.HasDecoration(value_id, spv::Decoration::BufferBlock) && spvVersionForTargetEnv(_.context()->target_env) < SPV_SPIRV_VERSION_WORD(1, 4)) {
             return _.diag(SPV_ERROR_INVALID_ID, inst)
                    << _.VkErrorID(4680)
                    << "For Vulkan, an OpTypeStruct variable containing an "

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -748,7 +748,9 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
                       "PhysicalStorageBuffer.";
           }
         } else if (storage_class == spv::StorageClass::Uniform) {
-          if (!_.HasDecoration(value_id, spv::Decoration::BufferBlock) && spvVersionForTargetEnv(_.context()->target_env) < SPV_SPIRV_VERSION_WORD(1, 4)) {
+          if (!_.HasDecoration(value_id, spv::Decoration::BufferBlock) &&
+              spvVersionForTargetEnv(_.context()->target_env) <
+                  SPV_SPIRV_VERSION_WORD(1, 4)) {
             return _.diag(SPV_ERROR_INVALID_ID, inst)
                    << _.VkErrorID(4680)
                    << "For Vulkan, an OpTypeStruct variable containing an "

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -2810,7 +2810,8 @@ TEST_F(ValidateMemory, VulkanRTAInsideUniformStructWithoutBufferBlockBadSPV13) {
                         "%_ptr_Uniform__struct_4 Uniform\n"));
 }
 
-TEST_F(ValidateMemory, VulkanRTAInsideUniformStructWithoutBufferBlockGoodSPV14) {
+TEST_F(ValidateMemory,
+       VulkanRTAInsideUniformStructWithoutBufferBlockGoodSPV14) {
   std::string spirv = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450


### PR DESCRIPTION
My understanding on the BufferBlock vs Block deprecation is a bit fuzzy. But if Block hasn't replaced BufferBlock, seems like RTA cannot be used in a uniform anymore. So seems like Block has replaced it, hence this validation fix to allow the alternative decoration in SPV1.4+

Fixes #5628