### PR TITLE
Add EXT_mesh_shader validation support

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -163,6 +163,7 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
     case spv::Decoration::Stream:
     case spv::Decoration::RestrictPointer:
     case spv::Decoration::AliasedPointer:
+    case spv::Decoration::PerPrimitiveEXT:
       if (target->opcode() != spv::Op::OpVariable &&
           target->opcode() != spv::Op::OpUntypedVariableKHR &&
           target->opcode() != spv::Op::OpFunctionParameter &&

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -122,7 +122,7 @@ typedef enum VUIDError_ {
   VUIDErrorMax,
 } VUIDError;
 
-const static uint32_t NumVUIDBuiltins = 39;
+const static uint32_t NumVUIDBuiltins = 40;
 
 typedef struct {
   spv::BuiltIn builtIn;
@@ -172,6 +172,8 @@ std::array<BuiltinVUIDMapping, NumVUIDBuiltins> builtinVUIDInfo = {{
     {spv::BuiltIn::PrimitivePointIndicesEXT,  {7041, 7043, 7044}},
     {spv::BuiltIn::PrimitiveLineIndicesEXT,   {7047, 7049, 7050}},
     {spv::BuiltIn::PrimitiveTriangleIndicesEXT, {7053, 7055, 7056}},
+    {spv::BuiltIn::CullPrimitiveEXT,          {7034, 7035, 7036}},
+
     // clang-format on
 }};
 
@@ -673,6 +675,37 @@ class BuiltInsValidator {
   // Updates inner working of the class. Is called sequentially for every
   // instruction.
   void Update(const Instruction& inst);
+
+  // Check if "inst" is an interface variable
+  // or type of a interface varibale of any mesh entry point
+  bool isMeshInterfaceVar(const Instruction& inst) {
+    auto getUnderlyingTypeId = [&](const Instruction* ifxVar) {
+      auto pointerTypeInst = _.FindDef(ifxVar->type_id());
+      auto typeInst = _.FindDef(pointerTypeInst->GetOperandAs<uint32_t>(2));
+      while (typeInst->opcode() == spv::Op::OpTypeArray) {
+        typeInst = _.FindDef(typeInst->GetOperandAs<uint32_t>(1));
+      };
+      return typeInst->id();
+    };
+
+    for (const uint32_t entry_point : _.entry_points()) {
+      const auto* models = _.GetExecutionModels(entry_point);
+      if (models->find(spv::ExecutionModel::MeshEXT) != models->end() ||
+          models->find(spv::ExecutionModel::MeshNV) != models->end()) {
+        for (const auto& desc : _.entry_point_descriptions(entry_point)) {
+          for (auto interface : desc.interfaces) {
+            if (inst.opcode() == spv::Op::OpTypeStruct) {
+              auto varInst = _.FindDef(interface);
+              if (inst.id() == getUnderlyingTypeId(varInst)) return true;
+            } else if (inst.id() == interface) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  }
 
   ValidationState_t& _;
 
@@ -2157,6 +2190,17 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveIdAtDefinition(
         return error;
       }
     }
+
+    if (_.HasCapability(spv::Capability::MeshShadingEXT)) {
+      if (isMeshInterfaceVar(inst) &&
+          !_.HasDecoration(inst.id(), spv::Decoration::PerPrimitiveEXT)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+               << _.VkErrorID(7040)
+               << "According to the Vulkan spec the variable decorated with "
+                  "Builtin PrimitiveId within the MeshEXT Execution Model must "
+                  "also be decorated with the PerPrimitiveEXT decoration. ";
+      }
+    }
   }
 
   // Seed at reference checks with this built-in.
@@ -2767,6 +2811,21 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtDefinition(
               })) {
         return error;
       }
+    }
+
+    if (isMeshInterfaceVar(inst) &&
+        _.HasCapability(spv::Capability::MeshShadingEXT) &&
+        !_.HasDecoration(inst.id(), spv::Decoration::PerPrimitiveEXT)) {
+      const spv::BuiltIn label = spv::BuiltIn(decoration.params()[0]);
+      uint32_t vkerrid = (label == spv::BuiltIn::Layer) ? 7039 : 7060;
+      return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+             << _.VkErrorID(vkerrid)
+             << "According to the Vulkan spec the variable decorated with "
+                "Builtin "
+             << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
+                                              decoration.params()[0])
+             << " within the MeshEXT Execution Model must also be decorated "
+                "with the PerPrimitiveEXT decoration. ";
     }
   }
 
@@ -3913,6 +3972,15 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtDefinition(
             })) {
       return error;
     }
+    if (isMeshInterfaceVar(inst) &&
+        _.HasCapability(spv::Capability::MeshShadingEXT) &&
+        !_.HasDecoration(inst.id(), spv::Decoration::PerPrimitiveEXT)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+             << _.VkErrorID(7059)
+             << "The variable decorated with PrimitiveShadingRateKHR "
+                "within the MeshEXT Execution Model must also be "
+                "decorated with the PerPrimitiveEXT decoration";
+    }
   }
 
   // Seed at reference checks with this built-in.
@@ -3950,7 +4018,7 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtReference(
                  << _.grammar().lookupOperandName(
                         SPV_OPERAND_TYPE_BUILT_IN,
                         (uint32_t)decoration.builtin())
-                 << " to be used only with Vertex, Geometry, or MeshNV "
+                 << " to be used only with Vertex, Geometry, MeshNV or MeshEXT "
                     "execution models. "
                  << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                      referenced_from_inst, execution_model);
@@ -4210,60 +4278,160 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtDefinition(
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::BuiltIn builtin = decoration.builtin();
     uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorType);
-    if (builtin == spv::BuiltIn::PrimitivePointIndicesEXT) {
-      if (spv_result_t error = ValidateI32Arr(
-              decoration, inst,
-              [this, &inst, &decoration,
-               &vuid](const std::string& message) -> spv_result_t {
-                return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                       << _.VkErrorID(vuid) << "According to the "
-                       << spvLogStringForEnv(_.context()->target_env)
-                       << " spec BuiltIn "
-                       << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN,
-                              (uint32_t)decoration.builtin())
-                       << " variable needs to be a 32-bit int array."
-                       << message;
-              })) {
+    switch (builtin) {
+      case spv::BuiltIn::PrimitivePointIndicesEXT:
+        if (spv_result_t error = ValidateI32Arr(
+                decoration, inst,
+                [this, &inst, &decoration,
+                 &vuid](const std::string& message) -> spv_result_t {
+                  return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                         << _.VkErrorID(vuid) << "According to the "
+                         << spvLogStringForEnv(_.context()->target_env)
+                         << " spec BuiltIn "
+                         << _.grammar().lookupOperandName(
+                                SPV_OPERAND_TYPE_BUILT_IN,
+                                (uint32_t)decoration.builtin())
+                         << " variable needs to be a 32-bit int array."
+                         << message;
+                })) {
+          return error;
+        }
+        break;
+      case spv::BuiltIn::PrimitiveLineIndicesEXT:
+        if (spv_result_t error = ValidateArrayedI32Vec(
+                decoration, inst, 2,
+                [this, &inst, &decoration,
+                 &vuid](const std::string& message) -> spv_result_t {
+                  return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                         << _.VkErrorID(vuid) << "According to the "
+                         << spvLogStringForEnv(_.context()->target_env)
+                         << " spec BuiltIn "
+                         << _.grammar().lookupOperandName(
+                                SPV_OPERAND_TYPE_BUILT_IN,
+                                (uint32_t)decoration.builtin())
+                         << " variable needs to be a 2-component 32-bit int "
+                            "array."
+                         << message;
+                })) {
+          return error;
+        }
+        break;
+      case spv::BuiltIn::PrimitiveTriangleIndicesEXT:
+        if (spv_result_t error = ValidateArrayedI32Vec(
+                decoration, inst, 3,
+                [this, &inst, &decoration,
+                 &vuid](const std::string& message) -> spv_result_t {
+                  return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                         << _.VkErrorID(vuid) << "According to the "
+                         << spvLogStringForEnv(_.context()->target_env)
+                         << " spec BuiltIn "
+                         << _.grammar().lookupOperandName(
+                                SPV_OPERAND_TYPE_BUILT_IN,
+                                (uint32_t)decoration.builtin())
+                         << " variable needs to be a 3-component 32-bit int "
+                            "array."
+                         << message;
+                })) {
+          return error;
+        }
+        break;
+      case spv::BuiltIn::CullPrimitiveEXT:
+        if (spv_result_t error = ValidateBool(
+                decoration, inst,
+                [this, &inst, &decoration,
+                 &vuid](const std::string& message) -> spv_result_t {
+                  return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                         << _.VkErrorID(vuid) << "According to the "
+                         << spvLogStringForEnv(_.context()->target_env)
+                         << " spec BuiltIn "
+                         << _.grammar().lookupOperandName(
+                                SPV_OPERAND_TYPE_BUILT_IN,
+                                (uint32_t)decoration.builtin())
+                         << " variable needs to be a boolean value "
+                            "array."
+                         << message;
+                })) {
+          return error;
+        }
+        if (!_.HasDecoration(inst.id(), spv::Decoration::PerPrimitiveEXT)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                 << _.VkErrorID(7038)
+                 << "The variable decorated with CullPrimitiveEXT within the "
+                    "MeshEXT Execution Model must also be decorated with the "
+                    "PerPrimitiveEXT decoration ";
+        }
+        break;
+      default:
+        assert(0 && "Unexpected mesh EXT builtin");
+    }
+    for (const uint32_t entry_point : _.entry_points()) {
+      const auto* modes = _.GetExecutionModes(entry_point);
+      uint64_t maxOutputPrimitives = _.GetOutputPrimitivesEXT(entry_point);
+      uint32_t underlying_type = 0;
+      if (spv_result_t error =
+              GetUnderlyingType(_, decoration, inst, &underlying_type)) {
         return error;
       }
-    }
-    if (builtin == spv::BuiltIn::PrimitiveLineIndicesEXT) {
-      if (spv_result_t error = ValidateArrayedI32Vec(
-              decoration, inst, 2,
-              [this, &inst, &decoration,
-               &vuid](const std::string& message) -> spv_result_t {
-                return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                       << _.VkErrorID(vuid) << "According to the "
-                       << spvLogStringForEnv(_.context()->target_env)
-                       << " spec BuiltIn "
-                       << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN,
-                              (uint32_t)decoration.builtin())
-                       << " variable needs to be a 2-component 32-bit int "
-                          "array."
-                       << message;
-              })) {
-        return error;
+
+      uint64_t primitiveArrayDim = 0;
+      if (_.GetIdOpcode(underlying_type) == spv::Op::OpTypeArray) {
+        underlying_type = _.FindDef(underlying_type)->word(3u);
+        if (!_.EvalConstantValUint64(underlying_type, &primitiveArrayDim)) {
+          assert(0 && "Array type definition is corrupt");
+        }
       }
-    }
-    if (builtin == spv::BuiltIn::PrimitiveTriangleIndicesEXT) {
-      if (spv_result_t error = ValidateArrayedI32Vec(
-              decoration, inst, 3,
-              [this, &inst, &decoration,
-               &vuid](const std::string& message) -> spv_result_t {
-                return _.diag(SPV_ERROR_INVALID_DATA, &inst)
-                       << _.VkErrorID(vuid) << "According to the "
-                       << spvLogStringForEnv(_.context()->target_env)
-                       << " spec BuiltIn "
-                       << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN,
-                              (uint32_t)decoration.builtin())
-                       << " variable needs to be a 3-component 32-bit int "
-                          "array."
-                       << message;
-              })) {
-        return error;
+      switch (builtin) {
+        case spv::BuiltIn::PrimitivePointIndicesEXT:
+          if (!modes || !modes->count(spv::ExecutionMode::OutputPoints)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7042)
+                   << "The PrimitivePointIndicesEXT decoration must be used "
+                      "with "
+                      "the OutputPoints Execution Mode. ";
+          }
+          if (primitiveArrayDim && primitiveArrayDim != maxOutputPrimitives) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7046)
+                   << "The size of the array decorated with "
+                      "PrimitivePointIndicesEXT must match the value specified "
+                      "by OutputPrimitivesEXT. ";
+          }
+          break;
+        case spv::BuiltIn::PrimitiveLineIndicesEXT:
+          if (!modes || !modes->count(spv::ExecutionMode::OutputLinesEXT)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7048)
+                   << "The PrimitiveLineIndicesEXT decoration must be used "
+                      "with "
+                      "the OutputLinesEXT Execution Mode. ";
+          }
+          if (primitiveArrayDim && primitiveArrayDim != maxOutputPrimitives) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7052)
+                   << "The size of the array decorated with "
+                      "PrimitiveLineIndicesEXT must match the value specified "
+                      "by OutputPrimitivesEXT. ";
+          }
+          break;
+        case spv::BuiltIn::PrimitiveTriangleIndicesEXT:
+          if (!modes || !modes->count(spv::ExecutionMode::OutputTrianglesEXT)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7054)
+                   << "The PrimitiveTriangleIndicesEXT decoration must be used "
+                      "with "
+                      "the OutputTrianglesEXT Execution Mode. ";
+          }
+          if (primitiveArrayDim && primitiveArrayDim != maxOutputPrimitives) {
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(7058)
+                   << "The size of the array decorated with "
+                      "PrimitiveTriangleIndicesEXT must match the value "
+                      "specified "
+                      "by OutputPrimitivesEXT. ";
+          }
+          break;
+        default:
+          break;  // no validation rules
       }
     }
   }
@@ -4293,7 +4461,6 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtReference(
                                  referenced_from_inst)
              << " " << GetStorageClassDesc(referenced_from_inst);
     }
-
     for (const spv::ExecutionModel execution_model : execution_models_) {
       if (execution_model != spv::ExecutionModel::MeshEXT) {
         uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorExecutionModel);
@@ -4495,6 +4662,7 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinitionVulkan(
     case spv::BuiltIn::CullMaskKHR: {
       return ValidateRayTracingBuiltinsAtDefinition(decoration, inst);
     }
+    case spv::BuiltIn::CullPrimitiveEXT:
     case spv::BuiltIn::PrimitivePointIndicesEXT:
     case spv::BuiltIn::PrimitiveLineIndicesEXT:
     case spv::BuiltIn::PrimitiveTriangleIndicesEXT: {

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -481,6 +481,10 @@ spv_result_t InstructionPass(ValidationState_t& _, const Instruction* inst) {
             spv::ExecutionMode::LocalSizeId) {
       _.RegisterEntryPointLocalSize(entry_point, inst);
     }
+    if (inst->GetOperandAs<spv::ExecutionMode>(1) ==
+        spv::ExecutionMode::OutputPrimitivesEXT) {
+      _.RegisterEntryPointOutputPrimitivesEXT(entry_point, inst);
+    }
   } else if (opcode == spv::Op::OpVariable) {
     const auto storage_class = inst->GetOperandAs<spv::StorageClass>(2);
     if (auto error = LimitCheckNumVars(_, inst->id(), storage_class)) {

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -579,6 +579,15 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                     "tessellation execution model.";
         }
       }
+      if (spvIsVulkanEnv(_.context()->target_env)) {
+        if (_.HasCapability(spv::Capability::MeshShadingEXT) &&
+            inst->GetOperandAs<uint32_t>(2) == 0) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(7330)
+                 << "In mesh shaders using the MeshEXT Execution Model the "
+                    "OutputVertices Execution Mode must be greater than 0";
+        }
+      }
       break;
     case spv::ExecutionMode::OutputLinesEXT:
     case spv::ExecutionMode::OutputTrianglesEXT:
@@ -592,6 +601,16 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                << "Execution mode can only be used with the MeshEXT or MeshNV "
                   "execution "
                   "model.";
+      }
+      if (mode == spv::ExecutionMode::OutputPrimitivesEXT &&
+          spvIsVulkanEnv(_.context()->target_env)) {
+        if (_.HasCapability(spv::Capability::MeshShadingEXT) &&
+            inst->GetOperandAs<uint32_t>(2) == 0) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(7331)
+                 << "In mesh shaders using the MeshEXT Execution Model the "
+                    "OutputPrimitivesEXT Execution Mode must be greater than 0";
+        }
       }
       break;
     case spv::ExecutionMode::QuadDerivativesKHR:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2054,6 +2054,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04330);
     case 4334:
       return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04334);
+    case 4336:
+      return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04336);
     case 4337:
       return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04337);
     case 4345:
@@ -2382,30 +2384,62 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-06924);
     case 6925:
       return VUID_WRAP(VUID-StandaloneSpirv-Uniform-06925);
+    case 7034:
+      return VUID_WRAP(VUID-CullPrimitiveEXT-CullPrimitiveEXT-07034);
+    case 7035:
+      return VUID_WRAP(VUID-CullPrimitiveEXT-CullPrimitiveEXT-07035);
+    case 7036:
+      return VUID_WRAP(VUID-CullPrimitiveEXT-CullPrimitiveEXT-07036);
+    case 7038:
+      return VUID_WRAP(VUID-CullPrimitiveEXT-CullPrimitiveEXT-07038);
+    case 7039:
+        return VUID_WRAP(VUID-Layer-Layer-07039);
+    case 7040:
+      return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-07040);
     case 7041:
       return VUID_WRAP(VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07041);
+    case 7042:
+      return VUID_WRAP(VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07042);
     case 7043:
       return VUID_WRAP(VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07043);
     case 7044:
       return VUID_WRAP(VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07044);
+    case 7046:
+      return VUID_WRAP(VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07046);
     case 7047:
       return VUID_WRAP(VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07047);
+    case 7048:
+      return VUID_WRAP(VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07048);
     case 7049:
       return VUID_WRAP(VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07049);
     case 7050:
       return VUID_WRAP(VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07050);
+    case 7052:
+      return VUID_WRAP(VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07052);
     case 7053:
       return VUID_WRAP(VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07053);
+    case 7054:
+      return VUID_WRAP(VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07054);
     case 7055:
       return VUID_WRAP(VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07055);
     case 7056:
       return VUID_WRAP(VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07056);
+    case 7058:
+      return VUID_WRAP(VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07058);
+    case 7059:
+      return VUID_WRAP(VUID-PrimitiveShadingRateKHR-PrimitiveShadingRateKHR-07059);
+    case 7060:
+      return VUID_WRAP(VUID-ViewportIndex-ViewportIndex-07060);
     case 7102:
       return VUID_WRAP(VUID-StandaloneSpirv-MeshEXT-07102);
-    case 7320:
-      return VUID_WRAP(VUID-StandaloneSpirv-ExecutionModel-07320);
     case 7290:
       return VUID_WRAP(VUID-StandaloneSpirv-Input-07290);
+    case 7320:
+      return VUID_WRAP(VUID-StandaloneSpirv-ExecutionModel-07320);
+    case 7330:
+      return VUID_WRAP(VUID-StandaloneSpirv-ExecutionModel-07330);
+    case 7331:
+      return VUID_WRAP(VUID-StandaloneSpirv-ExecutionModel-07331);
     case 7650:
       return VUID_WRAP(VUID-StandaloneSpirv-Base-07650);
     case 7651:

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -245,6 +245,24 @@ class ValidationState_t {
                                    const Instruction* inst) {
     entry_point_to_local_size_or_id_[entry_point] = inst;
   }
+
+  /// Registers that the entry point maximum number of primitives
+  /// mesh shader will ever emit
+  void RegisterEntryPointOutputPrimitivesEXT(uint32_t entry_point,
+                                             const Instruction* inst) {
+    entry_point_to_output_primitives_[entry_point] = inst;
+  }
+
+  /// Returns the maximum number of primitives mesh shader can emit
+  uint32_t GetOutputPrimitivesEXT(uint32_t entry_point) {
+    auto entry = entry_point_to_output_primitives_.find(entry_point);
+    if (entry != entry_point_to_output_primitives_.end()) {
+      auto inst = entry->second;
+      return inst->GetOperandAs<uint32_t>(2);
+    }
+    return 0;
+  }
+
   /// Returns whether the entry point declares its local size
   bool EntryPointHasLocalSizeOrId(uint32_t entry_point) const {
     return entry_point_to_local_size_or_id_.find(entry_point) !=
@@ -970,6 +988,10 @@ class ValidationState_t {
   // Mapping entry point -> local size execution mode instruction
   std::unordered_map<uint32_t, const Instruction*>
       entry_point_to_local_size_or_id_;
+
+  // Mapping entry point -> OutputPrimitivesEXT execution mode instruction
+  std::unordered_map<uint32_t, const Instruction*>
+      entry_point_to_output_primitives_;
 
   /// Mapping function -> array of entry points inside this
   /// module which can (indirectly) call the function.

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -3947,7 +3947,8 @@ INSTANTIATE_TEST_SUITE_P(
         Values(TestResult(
             SPV_ERROR_INVALID_DATA,
             "Vulkan spec allows BuiltIn PrimitiveShadingRateKHR to be used "
-            "only with Vertex, Geometry, or MeshNV execution models."))));
+            "only with Vertex, Geometry, MeshNV or MeshEXT execution "
+            "models."))));
 
 INSTANTIATE_TEST_SUITE_P(
     PrimitiveShadingRateInvalidStorageClass,
@@ -4325,6 +4326,29 @@ TEST_F(ValidateBuiltIns, VulkanPrimitiveTriangleIndicesEXTSuccess) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 
+TEST_F(ValidateBuiltIns,
+       VulkanPrimitiveTriangleIndicesEXTInvalidExecutionMode) {
+  const std::string declarations = R"(
+%array = OpTypeArray %v3uint %uint_16
+%array_ptr = OpTypePointer Output %array
+%var = OpVariable %array_ptr Output
+%ptr = OpTypePointer Output %v3uint
+)";
+  const std::string body = R"(
+%access = OpAccessChain %ptr %var %int_0
+)";
+
+  CompileSuccessfully(
+      GenerateMeshShadingCode("PrimitiveTriangleIndicesEXT", "OutputPoints",
+                              body, declarations)
+          .c_str(),
+      SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-PrimitiveTriangleIndicesEXT-"
+                      "PrimitiveTriangleIndicesEXT-07054"));
+}
+
 TEST_F(ValidateBuiltIns, VulkanPrimitiveTriangleIndicesEXTStorageClass) {
   const std::string declarations = R"(
 %array = OpTypeArray %v3uint %uint_16
@@ -4408,6 +4432,28 @@ TEST_F(ValidateBuiltIns, VulkanPrimitiveLineIndicesEXTSuccess) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 
+TEST_F(ValidateBuiltIns, VulkanPrimitiveLineIndicesEXTInvalidExecutionMode) {
+  const std::string declarations = R"(
+  %array = OpTypeArray %v2uint %uint_16
+  %array_ptr = OpTypePointer Output %array
+  %var = OpVariable %array_ptr Output
+  %ptr = OpTypePointer Output %v2uint
+  )";
+  const std::string body = R"(
+  %access = OpAccessChain %ptr %var %int_0
+  )";
+
+  CompileSuccessfully(
+      GenerateMeshShadingCode("PrimitiveLineIndicesEXT", "OutputPoints", body,
+                              declarations)
+          .c_str(),
+      SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07048"));
+}
+
 TEST_F(ValidateBuiltIns, VulkanPrimitiveLineIndicesEXTStorageClass) {
   const std::string declarations = R"(
 %array = OpTypeArray %v2uint %uint_16
@@ -4471,6 +4517,28 @@ TEST_F(ValidateBuiltIns, VulkanPrimitivePointIndicesEXTSuccess) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 
+TEST_F(ValidateBuiltIns, VulkanPrimitivePointIndicesEXTInvalidExecutionMode) {
+  const std::string declarations = R"(
+    %array = OpTypeArray %uint %uint_16
+    %array_ptr = OpTypePointer Output %array
+    %var = OpVariable %array_ptr Output
+    %ptr = OpTypePointer Output %uint
+    )";
+  const std::string body = R"(
+    %access = OpAccessChain %ptr %var %int_0
+    )";
+
+  CompileSuccessfully(
+      GenerateMeshShadingCode("PrimitivePointIndicesEXT", "OutputTrianglesNV",
+                              body, declarations)
+          .c_str(),
+      SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07042"));
+}
+
 TEST_F(ValidateBuiltIns, VulkanPrimitivePointIndicesEXTStorageClass) {
   const std::string declarations = R"(
 %array = OpTypeArray %uint %uint_16
@@ -4513,6 +4581,906 @@ TEST_F(ValidateBuiltIns, VulkanPrimitivePointIndicesEXTType) {
   EXPECT_THAT(
       getDiagnosticString(),
       AnyVUID("VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07044"));
+}
+
+TEST_F(ValidateBuiltIns, VulkanBuiltinPrimtiveIDWithPerPrimitiveEXT) {
+  const std::string text = R"(
+               OpCapability MeshShadingEXT
+               OpCapability Shader
+               OpExtension "SPV_EXT_mesh_shader"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint MeshEXT %MainMesh "MainMesh" %gl_PrimitiveID
+               OpExecutionMode %MainMesh OutputPrimitivesNV 1
+               OpExecutionMode %MainMesh OutputVertices 3
+               OpExecutionMode %MainMesh OutputTrianglesNV
+               OpExecutionMode %MainMesh LocalSize 1 1 1
+               OpSource Slang 1
+               OpName %MainMesh "MainMesh"
+               OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
+               OpDecorate %gl_PrimitiveID PerPrimitiveNV
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %uint_3 = OpConstant %uint 3
+     %uint_1 = OpConstant %uint 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_3 = OpConstant %int 3
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+     %uint_0 = OpConstant %uint 0
+    %v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%_ptr_Output_int = OpTypePointer Output %int
+%_arr_int_int_1 = OpTypeArray %int %int_1
+%_ptr_Output__arr_int_int_1 = OpTypePointer Output %_arr_int_int_1
+%gl_PrimitiveID = OpVariable %_ptr_Output__arr_int_int_1 Output
+   %MainMesh = OpFunction %void None %9
+         %25 = OpLabel
+               OpSetMeshOutputsEXT %uint_3 %uint_1
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinPrimtiveIDWithPerPrimitiveEXT) {
+  const std::string text = R"(
+       OpCapability MeshShadingEXT
+       OpCapability Shader
+       OpExtension "SPV_EXT_mesh_shader"
+       OpMemoryModel Logical GLSL450
+       OpEntryPoint MeshEXT %MainMesh "MainMesh" %gl_PrimitiveID
+       OpExecutionMode %MainMesh OutputPrimitivesNV 1
+       OpExecutionMode %MainMesh OutputVertices 3
+       OpExecutionMode %MainMesh OutputTrianglesNV
+       OpExecutionMode %MainMesh LocalSize 1 1 1
+       OpSource Slang 1
+       OpName %MainMesh "MainMesh"
+       OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
+%void = OpTypeVoid
+  %9 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%float = OpTypeFloat 32
+%v4float = OpTypeVector %float 4
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%int_3 = OpConstant %int 3
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+%uint_0 = OpConstant %uint 0
+%v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%v3uint = OpTypeVector %uint 3
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%_ptr_Output_int = OpTypePointer Output %int
+%_arr_int_int_1 = OpTypeArray %int %int_1
+%_ptr_Output__arr_int_int_1 = OpTypePointer Output %_arr_int_int_1
+%gl_PrimitiveID = OpVariable %_ptr_Output__arr_int_int_1 Output
+%MainMesh = OpFunction %void None %9
+ %25 = OpLabel
+       OpSetMeshOutputsEXT %uint_3 %uint_1
+       OpReturn
+       OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-PrimitiveId-PrimitiveId-07040"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinLayerWithPerPrimitiveEXT) {
+  const std::string text = R"(
+          OpCapability MeshShadingEXT
+          OpCapability Shader
+          OpExtension "SPV_EXT_mesh_shader"
+          OpMemoryModel Logical GLSL450
+          OpEntryPoint MeshEXT %MainMesh "MainMesh" %gl_Layer
+          OpExecutionMode %MainMesh OutputPrimitivesNV 1
+          OpExecutionMode %MainMesh OutputVertices 3
+          OpExecutionMode %MainMesh OutputTrianglesNV
+          OpExecutionMode %MainMesh LocalSize 1 1 1
+          OpSource Slang 1
+          OpName %MainMesh "MainMesh"
+          OpDecorate %gl_Layer BuiltIn Layer
+  %void = OpTypeVoid
+     %9 = OpTypeFunction %void
+  %uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+ %float = OpTypeFloat 32
+   %int = OpTypeInt 32 1
+ %int_1 = OpConstant %int 1
+ %int_3 = OpConstant %int 3
+%uint_0 = OpConstant %uint 0
+%v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%v3uint = OpTypeVector %uint 3
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%_ptr_Output_int = OpTypePointer Output %int
+%_arr_int_int_1 = OpTypeArray %int %int_1
+%_ptr_Output__arr_int_int_1 = OpTypePointer Output %_arr_int_int_1
+%gl_Layer = OpVariable %_ptr_Output__arr_int_int_1 Output
+%MainMesh = OpFunction %void None %9
+    %25 = OpLabel
+          OpSetMeshOutputsEXT %uint_3 %uint_1
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-Layer-Layer-07039"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinViewportIndexWithPerPrimitiveEXT) {
+  const std::string text = R"(
+     OpCapability MeshShadingEXT
+     OpCapability Shader
+     OpExtension "SPV_EXT_mesh_shader"
+     OpMemoryModel Logical GLSL450
+     OpEntryPoint MeshEXT %MainMesh "MainMesh" %gl_ViewportIndex
+     OpExecutionMode %MainMesh OutputPrimitivesNV 1
+     OpExecutionMode %MainMesh OutputVertices 3
+     OpExecutionMode %MainMesh OutputTrianglesNV
+     OpExecutionMode %MainMesh LocalSize 1 1 1
+     OpSource Slang 1
+     OpName %MainMesh "MainMesh"
+     OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
+%void = OpTypeVoid
+%9 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%float = OpTypeFloat 32
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%int_3 = OpConstant %int 3
+%uint_0 = OpConstant %uint 0
+%v3float = OpTypeVector %float 3
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%v3uint = OpTypeVector %uint 3
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%_ptr_Output_int = OpTypePointer Output %int
+%_arr_int_int_1 = OpTypeArray %int %int_1
+%_ptr_Output__arr_int_int_1 = OpTypePointer Output %_arr_int_int_1
+%gl_ViewportIndex = OpVariable %_ptr_Output__arr_int_int_1 Output
+%MainMesh = OpFunction %void None %9
+%25 = OpLabel
+     OpSetMeshOutputsEXT %uint_3 %uint_1
+     OpReturn
+     OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-ViewportIndex-ViewportIndex-07060"));
+}
+
+TEST_F(ValidateBuiltIns, VulkanBuiltinPrimitivePointIndicesEXT) {
+  const std::string text = R"(
+       OpCapability MeshShadingEXT
+       OpExtension "SPV_EXT_mesh_shader"
+  %1 = OpExtInstImport "GLSL.std.450"
+       OpMemoryModel Logical GLSL450
+       OpEntryPoint MeshEXT %main "main" %gl_PrimitivePointIndicesEXT
+       OpExecutionMode %main LocalSize 32 1 1
+       OpExecutionMode %main OutputVertices 81
+       OpExecutionMode %main OutputPrimitivesEXT 32
+       OpExecutionMode %main OutputPoints
+       OpSource GLSL 460
+       OpSourceExtension "GL_EXT_mesh_shader"
+       OpName %main "main"
+       OpName %gl_PrimitivePointIndicesEXT "gl_PrimitivePointIndicesEXT"
+       OpDecorate %gl_PrimitivePointIndicesEXT BuiltIn PrimitivePointIndicesEXT
+       OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+  %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
+%_ptr_Output__arr_uint_uint_32 = OpTypePointer Output %_arr_uint_uint_32
+%gl_PrimitivePointIndicesEXT = OpVariable %_ptr_Output__arr_uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_uint = OpTypePointer Output %uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+  %5 = OpLabel
+ %15 = OpAccessChain %_ptr_Output_uint %gl_PrimitivePointIndicesEXT %int_0
+       OpStore %15 %uint_0
+       OpReturn
+       OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, VulkanBuiltinPrimitiveLineIndicesEXT) {
+  const std::string text = R"(
+          OpCapability MeshShadingEXT
+          OpExtension "SPV_EXT_mesh_shader"
+     %1 = OpExtInstImport "GLSL.std.450"
+          OpMemoryModel Logical GLSL450
+          OpEntryPoint MeshEXT %main "main" %gl_PrimitiveLineIndicesEXT
+          OpExecutionMode %main LocalSize 32 1 1
+          OpExecutionMode %main OutputVertices 81
+          OpExecutionMode %main OutputPrimitivesEXT 32
+          OpExecutionMode %main OutputLinesEXT
+          OpSource GLSL 460
+          OpSourceExtension "GL_EXT_mesh_shader"
+          OpName %main "main"
+          OpName %gl_PrimitiveLineIndicesEXT "gl_PrimitiveLineIndicesEXT"
+          OpDecorate %gl_PrimitiveLineIndicesEXT BuiltIn PrimitiveLineIndicesEXT
+          OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+  %void = OpTypeVoid
+     %3 = OpTypeFunction %void
+  %uint = OpTypeInt 32 0
+%v2uint = OpTypeVector %uint 2
+%uint_32 = OpConstant %uint 32
+%_arr_v2uint_uint_32 = OpTypeArray %v2uint %uint_32
+%_ptr_Output__arr_v2uint_uint_32 = OpTypePointer Output %_arr_v2uint_uint_32
+%gl_PrimitiveLineIndicesEXT = OpVariable %_ptr_Output__arr_v2uint_uint_32 Output
+   %int = OpTypeInt 32 1
+ %int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+    %15 = OpConstantComposite %v2uint %uint_0 %uint_0
+%_ptr_Output_v2uint = OpTypePointer Output %v2uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+  %main = OpFunction %void None %3
+     %5 = OpLabel
+    %17 = OpAccessChain %_ptr_Output_v2uint %gl_PrimitiveLineIndicesEXT %int_0
+          OpStore %17 %15
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinPrimitiveLineIndicesEXT) {
+  const std::string text = R"(
+          OpCapability MeshShadingEXT
+          OpExtension "SPV_EXT_mesh_shader"
+     %1 = OpExtInstImport "GLSL.std.450"
+          OpMemoryModel Logical GLSL450
+          OpEntryPoint MeshEXT %main "main" %gl_PrimitiveLineIndicesEXT
+          OpExecutionMode %main LocalSize 32 1 1
+          OpExecutionMode %main OutputVertices 81
+          OpExecutionMode %main OutputPrimitivesEXT 32
+          OpExecutionMode %main OutputPoints
+          OpSource GLSL 460
+          OpSourceExtension "GL_EXT_mesh_shader"
+          OpName %main "main"
+          OpName %gl_PrimitiveLineIndicesEXT "gl_PrimitiveLineIndicesEXT"
+          OpDecorate %gl_PrimitiveLineIndicesEXT BuiltIn PrimitiveLineIndicesEXT
+          OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+  %void = OpTypeVoid
+     %3 = OpTypeFunction %void
+  %uint = OpTypeInt 32 0
+%v2uint = OpTypeVector %uint 2
+%uint_32 = OpConstant %uint 32
+%_arr_v2uint_uint_32 = OpTypeArray %v2uint %uint_32
+%_ptr_Output__arr_v2uint_uint_32 = OpTypePointer Output %_arr_v2uint_uint_32
+%gl_PrimitiveLineIndicesEXT = OpVariable %_ptr_Output__arr_v2uint_uint_32 Output
+   %int = OpTypeInt 32 1
+ %int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+    %15 = OpConstantComposite %v2uint %uint_0 %uint_0
+%_ptr_Output_v2uint = OpTypePointer Output %v2uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+  %main = OpFunction %void None %3
+     %5 = OpLabel
+    %17 = OpAccessChain %_ptr_Output_v2uint %gl_PrimitiveLineIndicesEXT %int_0
+          OpStore %17 %15
+          OpReturn
+          OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07048"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinPrimitivePointIndicesEXT) {
+  const std::string text = R"(
+       OpCapability MeshShadingEXT
+       OpExtension "SPV_EXT_mesh_shader"
+  %1 = OpExtInstImport "GLSL.std.450"
+       OpMemoryModel Logical GLSL450
+       OpEntryPoint MeshEXT %main "main" %gl_PrimitivePointIndicesEXT
+       OpExecutionMode %main LocalSize 32 1 1
+       OpExecutionMode %main OutputVertices 81
+       OpExecutionMode %main OutputPrimitivesEXT 32
+       OpExecutionMode %main OutputTrianglesEXT
+       OpSource GLSL 460
+       OpSourceExtension "GL_EXT_mesh_shader"
+       OpName %main "main"
+       OpName %gl_PrimitivePointIndicesEXT "gl_PrimitivePointIndicesEXT"
+       OpDecorate %gl_PrimitivePointIndicesEXT BuiltIn PrimitivePointIndicesEXT
+       OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+  %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
+%_ptr_Output__arr_uint_uint_32 = OpTypePointer Output %_arr_uint_uint_32
+%gl_PrimitivePointIndicesEXT = OpVariable %_ptr_Output__arr_uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_uint = OpTypePointer Output %uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+  %5 = OpLabel
+ %15 = OpAccessChain %_ptr_Output_uint %gl_PrimitivePointIndicesEXT %int_0
+       OpStore %15 %uint_0
+       OpReturn
+       OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07042"));
+}
+
+TEST_F(ValidateBuiltIns, VulkanBuiltinPrimitiveTriangleIndicesEXT) {
+  const std::string text = R"(
+    OpCapability MeshShadingEXT
+    OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint MeshEXT %main "main" %gl_PrimitiveTriangleIndicesEXT
+    OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+    OpExecutionMode %main OutputVertices 81
+    OpExecutionMode %main OutputPrimitivesEXT 32
+    OpExecutionMode %main OutputTrianglesEXT
+    OpSource GLSL 460
+    OpSourceExtension "GL_EXT_mesh_shader"
+    OpName %main "main"
+    OpName %gl_PrimitiveTriangleIndicesEXT "gl_PrimitiveTriangleIndicesEXT"
+    OpDecorate %gl_PrimitiveTriangleIndicesEXT BuiltIn PrimitiveTriangleIndicesEXT
+%void = OpTypeVoid
+%7 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%_arr_v3uint_uint_32 = OpTypeArray %v3uint %uint_32
+%_ptr_Output__arr_v3uint_uint_32 = OpTypePointer Output %_arr_v3uint_uint_32
+%gl_PrimitiveTriangleIndicesEXT = OpVariable %_ptr_Output__arr_v3uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%15 = OpConstantComposite %v3uint %uint_0 %uint_0 %uint_0
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%17 = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %7
+%18 = OpLabel
+%19 = OpAccessChain %_ptr_Output_v3uint %gl_PrimitiveTriangleIndicesEXT %int_0
+    OpStore %19 %15
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinPrimitiveTriangleIndicesEXT) {
+  const std::string text = R"(
+    OpCapability MeshShadingEXT
+    OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint MeshEXT %main "main" %gl_PrimitiveTriangleIndicesEXT
+    OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+    OpExecutionMode %main OutputVertices 81
+    OpExecutionMode %main OutputPrimitivesEXT 32
+    OpExecutionMode %main OutputPoints
+    OpSource GLSL 460
+    OpSourceExtension "GL_EXT_mesh_shader"
+    OpName %main "main"
+    OpName %gl_PrimitiveTriangleIndicesEXT "gl_PrimitiveTriangleIndicesEXT"
+    OpDecorate %gl_PrimitiveTriangleIndicesEXT BuiltIn PrimitiveTriangleIndicesEXT
+%void = OpTypeVoid
+%7 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%_arr_v3uint_uint_32 = OpTypeArray %v3uint %uint_32
+%_ptr_Output__arr_v3uint_uint_32 = OpTypePointer Output %_arr_v3uint_uint_32
+%gl_PrimitiveTriangleIndicesEXT = OpVariable %_ptr_Output__arr_v3uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%15 = OpConstantComposite %v3uint %uint_0 %uint_0 %uint_0
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%17 = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %7
+%18 = OpLabel
+%19 = OpAccessChain %_ptr_Output_v3uint %gl_PrimitiveTriangleIndicesEXT %int_0
+    OpStore %19 %15
+    OpReturn
+    OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-PrimitiveTriangleIndicesEXT-"
+                      "PrimitiveTriangleIndicesEXT-07054"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanPrimitivePointIndicesArraySizeMeshEXT) {
+  const std::string text = R"(
+   OpCapability MeshShadingEXT
+   OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+   OpMemoryModel Logical GLSL450
+   OpEntryPoint MeshEXT %main "main" %gl_PrimitivePointIndicesEXT
+   OpExecutionMode %main LocalSize 32 1 1
+   OpExecutionMode %main OutputVertices 81
+   OpExecutionMode %main OutputPrimitivesEXT 16
+   OpExecutionMode %main OutputPoints
+   OpSource GLSL 460
+   OpSourceExtension "GL_EXT_mesh_shader"
+   OpName %main "main"
+   OpName %gl_PrimitivePointIndicesEXT "gl_PrimitivePointIndicesEXT"
+   OpDecorate %gl_PrimitivePointIndicesEXT BuiltIn PrimitivePointIndicesEXT
+   OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
+%_ptr_Output__arr_uint_uint_32 = OpTypePointer Output %_arr_uint_uint_32
+%gl_PrimitivePointIndicesEXT = OpVariable %_ptr_Output__arr_uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_uint = OpTypePointer Output %uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+%5 = OpLabel
+%15 = OpAccessChain %_ptr_Output_uint %gl_PrimitivePointIndicesEXT %int_0
+   OpStore %15 %uint_0
+   OpReturn
+   OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07046"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanPrimitiveLineIndicesArraySizeMeshEXT) {
+  const std::string text = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_PrimitiveLineIndicesEXT
+      OpExecutionMode %main LocalSize 32 1 1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 16
+      OpExecutionMode %main OutputLinesEXT
+      OpSource GLSL 460
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_PrimitiveLineIndicesEXT "gl_PrimitiveLineIndicesEXT"
+      OpDecorate %gl_PrimitiveLineIndicesEXT BuiltIn PrimitiveLineIndicesEXT
+      OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%v2uint = OpTypeVector %uint 2
+%uint_32 = OpConstant %uint 32
+%_arr_v2uint_uint_32 = OpTypeArray %v2uint %uint_32
+%_ptr_Output__arr_v2uint_uint_32 = OpTypePointer Output %_arr_v2uint_uint_32
+%gl_PrimitiveLineIndicesEXT = OpVariable %_ptr_Output__arr_v2uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%15 = OpConstantComposite %v2uint %uint_0 %uint_0
+%_ptr_Output_v2uint = OpTypePointer Output %v2uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+ %5 = OpLabel
+%17 = OpAccessChain %_ptr_Output_v2uint %gl_PrimitiveLineIndicesEXT %int_0
+      OpStore %17 %15
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07052"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanPrimitiveTriangleIndicesArraySizeMeshEXT) {
+  const std::string text = R"(
+  OpCapability MeshShadingEXT
+  OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+  OpMemoryModel Logical GLSL450
+  OpEntryPoint MeshEXT %main "main" %gl_PrimitiveTriangleIndicesEXT
+  OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+  OpExecutionMode %main OutputVertices 81
+  OpExecutionMode %main OutputPrimitivesEXT 16
+  OpExecutionMode %main OutputTrianglesEXT
+  OpSource GLSL 460
+  OpSourceExtension "GL_EXT_mesh_shader"
+  OpName %main "main"
+  OpName %gl_PrimitiveTriangleIndicesEXT "gl_PrimitiveTriangleIndicesEXT"
+  OpDecorate %gl_PrimitiveTriangleIndicesEXT BuiltIn PrimitiveTriangleIndicesEXT
+%void = OpTypeVoid
+%7 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%_arr_v3uint_uint_32 = OpTypeArray %v3uint %uint_32
+%_ptr_Output__arr_v3uint_uint_32 = OpTypePointer Output %_arr_v3uint_uint_32
+%gl_PrimitiveTriangleIndicesEXT = OpVariable %_ptr_Output__arr_v3uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%15 = OpConstantComposite %v3uint %uint_0 %uint_0 %uint_0
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%17 = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %7
+%18 = OpLabel
+%19 = OpAccessChain %_ptr_Output_v3uint %gl_PrimitiveTriangleIndicesEXT %int_0
+  OpStore %19 %15
+  OpReturn
+  OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-PrimitiveTriangleIndicesEXT-"
+                      "PrimitiveTriangleIndicesEXT-07058"));
+}
+
+TEST_F(ValidateBuiltIns, BadExecModelVulkanPrimitivePointIndicesEXT) {
+  const std::string text = R"(
+  OpCapability MeshShadingNV
+  OpCapability MeshShadingEXT
+  OpExtension "SPV_NV_mesh_shader"
+  OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+  OpMemoryModel Logical GLSL450
+  OpEntryPoint MeshNV %main "main" %gl_PrimitivePointIndicesEXT
+  OpExecutionMode %main LocalSize 32 1 1
+  OpExecutionMode %main OutputVertices 81
+  OpExecutionMode %main OutputPrimitivesEXT 32
+  OpExecutionMode %main OutputPoints
+  OpSource GLSL 460
+  OpSourceExtension "GL_EXT_mesh_shader"
+  OpName %main "main"
+  OpName %gl_PrimitivePointIndicesEXT "gl_PrimitivePointIndicesEXT"
+  OpDecorate %gl_PrimitivePointIndicesEXT BuiltIn PrimitivePointIndicesEXT
+  OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%_arr_uint_uint_32 = OpTypeArray %uint %uint_32
+%_ptr_Output__arr_uint_uint_32 = OpTypePointer Output %_arr_uint_uint_32
+%gl_PrimitivePointIndicesEXT = OpVariable %_ptr_Output__arr_uint_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%_ptr_Output_uint = OpTypePointer Output %uint
+%v3uint = OpTypeVector %uint 3
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+%5 = OpLabel
+%15 = OpAccessChain %_ptr_Output_uint %gl_PrimitivePointIndicesEXT %int_0
+  OpStore %15 %uint_0
+  OpReturn
+  OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07041"));
+}
+
+TEST_F(ValidateBuiltIns, VulkanBuiltinCullPrimitiveEXT) {
+  const std::string text = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_MeshPrimitivesEXT
+      OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 32
+      OpExecutionMode %main OutputTrianglesEXT
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_MeshPerPrimitiveEXT "gl_MeshPerPrimitiveEXT"
+      OpMemberName %gl_MeshPerPrimitiveEXT 0 "gl_CullPrimitiveEXT"
+      OpName %gl_MeshPrimitivesEXT "gl_MeshPrimitivesEXT"
+      OpDecorate %gl_MeshPerPrimitiveEXT Block
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn CullPrimitiveEXT
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 PerPrimitiveEXT
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%int = OpTypeInt 32 1
+%bool = OpTypeBool
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %bool
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Output %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Output
+%main = OpFunction %void None %3
+ %5 = OpLabel
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinCullPrimitiveEXTType) {
+  const std::string text = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_MeshPrimitivesEXT
+      OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 32
+      OpExecutionMode %main OutputTrianglesEXT
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_MeshPerPrimitiveEXT "gl_MeshPerPrimitiveEXT"
+      OpMemberName %gl_MeshPerPrimitiveEXT 0 "gl_CullPrimitiveEXT"
+      OpName %gl_MeshPrimitivesEXT "gl_MeshPrimitivesEXT"
+      OpDecorate %gl_MeshPerPrimitiveEXT Block
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn CullPrimitiveEXT
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 PerPrimitiveEXT
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%int = OpTypeInt 32 1
+%bool = OpTypeBool
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %int
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Output %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Output
+%main = OpFunction %void None %3
+ %5 = OpLabel
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-CullPrimitiveEXT-CullPrimitiveEXT-07036"));
+}
+
+TEST_F(ValidateBuiltIns, BadVulkanBuiltinCullPrimitiveEXTStorageClass) {
+  const std::string text = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_MeshPrimitivesEXT
+      OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 32
+      OpExecutionMode %main OutputTrianglesEXT
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_MeshPerPrimitiveEXT "gl_MeshPerPrimitiveEXT"
+      OpMemberName %gl_MeshPerPrimitiveEXT 0 "gl_CullPrimitiveEXT"
+      OpName %gl_MeshPrimitivesEXT "gl_MeshPrimitivesEXT"
+      OpDecorate %gl_MeshPerPrimitiveEXT Block
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn CullPrimitiveEXT
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 PerPrimitiveEXT
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%int = OpTypeInt 32 1
+%bool = OpTypeBool
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %bool
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Input %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Input
+%main = OpFunction %void None %3
+ %5 = OpLabel
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-CullPrimitiveEXT-CullPrimitiveEXT-07035"));
+}
+
+TEST_F(ValidateBuiltIns, BadBuiltinCullPrimitiveEXTWithPerPrimitiveEXT) {
+  const std::string text = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_MeshPrimitivesEXT
+      OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 32
+      OpExecutionMode %main OutputTrianglesEXT
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_MeshPerPrimitiveEXT "gl_MeshPerPrimitiveEXT"
+      OpMemberName %gl_MeshPerPrimitiveEXT 0 "gl_CullPrimitiveEXT"
+      OpName %gl_MeshPrimitivesEXT "gl_MeshPrimitivesEXT"
+      OpDecorate %gl_MeshPerPrimitiveEXT Block
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn CullPrimitiveEXT
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%int = OpTypeInt 32 1
+%bool = OpTypeBool
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %bool
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Output %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Output
+%main = OpFunction %void None %3
+ %5 = OpLabel
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-CullPrimitiveEXT-CullPrimitiveEXT-07038"));
+}
+
+TEST_F(ValidateBuiltIns, BadBuiltinPrimitiveShadingRateWithPerPrimitiveEXT) {
+  const std::string text = R"(
+      OpCapability FragmentShadingRateKHR
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+      OpExtension "SPV_KHR_fragment_shading_rate"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_MeshPrimitivesEXT
+      OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesEXT 32
+      OpExecutionMode %main OutputTrianglesEXT
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %gl_MeshPerPrimitiveEXT "gl_MeshPerPrimitiveEXT"
+      OpMemberName %gl_MeshPerPrimitiveEXT 0 "gl_PrimitiveShadingRateKHR"
+      OpName %gl_MeshPrimitivesEXT "gl_MeshPrimitivesEXT"
+      OpDecorate %gl_MeshPerPrimitiveEXT Block
+      OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn PrimitiveShadingRateKHR
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%int = OpTypeInt 32 1
+%bool = OpTypeBool
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %int
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Output %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Output
+%main = OpFunction %void None %3
+ %5 = OpLabel
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      AnyVUID("VUID-PrimitiveShadingRateKHR-PrimitiveShadingRateKHR-07059"));
+}
+
+TEST_F(ValidateBuiltIns, BadExecModelVulkanCullPrimitiveEXT) {
+  const std::string text = R"(
+         OpCapability MeshShadingNV
+         OpCapability MeshShadingEXT
+         OpExtension "SPV_NV_mesh_shader"
+         OpExtension "SPV_EXT_mesh_shader"
+    %1 = OpExtInstImport "GLSL.std.450"
+         OpMemoryModel Logical GLSL450
+         OpEntryPoint MeshNV %main "main" %gl_MeshPrimitivesEXT
+         OpExecutionModeId %main LocalSizeId %uint_32 %uint_1 %uint_1
+         OpExecutionMode %main OutputVertices 81
+         OpExecutionMode %main OutputPrimitivesNV 32
+         OpExecutionMode %main OutputTrianglesNV
+         OpSource GLSL 450
+         OpSourceExtension "GL_EXT_mesh_shader"
+         OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 PerPrimitiveEXT
+         OpMemberDecorate %gl_MeshPerPrimitiveEXT 0 BuiltIn CullPrimitiveEXT
+         OpDecorate %gl_MeshPerPrimitiveEXT Block
+ %void = OpTypeVoid
+    %3 = OpTypeFunction %void
+ %uint = OpTypeInt 32 0
+%uint_32 = OpConstant %uint 32
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+ %bool = OpTypeBool
+  %int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%gl_MeshPerPrimitiveEXT = OpTypeStruct %bool
+%_ptr_Output_bool = OpTypePointer Output %bool
+%_arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypeArray %gl_MeshPerPrimitiveEXT %uint_32
+%_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 = OpTypePointer Output %_arr_gl_MeshPerPrimitiveEXT_uint_32
+%gl_MeshPrimitivesEXT = OpVariable %_ptr_Output__arr_gl_MeshPerPrimitiveEXT_uint_32 Output
+ %main = OpFunction %void None %3
+    %5 = OpLabel
+   %18 = OpAccessChain %_ptr_Output_bool %gl_MeshPrimitivesEXT %int_0 %int_0
+         OpReturn
+         OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-CullPrimitiveEXT-CullPrimitiveEXT-07034"));
 }
 
 }  // namespace

--- a/test/val/val_mesh_shading_test.cpp
+++ b/test/val/val_mesh_shading_test.cpp
@@ -467,6 +467,79 @@ TEST_F(ValidateMeshShading, TaskPayloadWorkgroupBadExecutionModel) {
                         "TaskEXT and MeshKHR execution model"));
 }
 
+TEST_F(ValidateMeshShading, BadMultipleTaskPayloadWorkgroupEXT) {
+  const std::string body = R"(
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint TaskEXT %main "main" %payload %payload1
+       %void = OpTypeVoid
+       %func = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_TaskPayloadWorkgroupEXT = OpTypePointer TaskPayloadWorkgroupEXT %uint
+    %payload = OpVariable %_ptr_TaskPayloadWorkgroupEXT TaskPayloadWorkgroupEXT
+    %payload1 = OpVariable %_ptr_TaskPayloadWorkgroupEXT TaskPayloadWorkgroupEXT
+       %main = OpFunction %void None %func
+      %label = OpLabel
+       %load = OpLoad %uint %payload
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("There can be at most one OpVariable with storage "
+                        "class TaskPayloadWorkgroupEXT associated with "
+                        "an OpEntryPoint"));
+}
+
+TEST_F(ValidateMeshShading, TaskPayloadWorkgroupTaskExtExecutionModel) {
+  const std::string body = R"(
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint TaskEXT %main "main" %payload
+       %void = OpTypeVoid
+       %func = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_TaskPayloadWorkgroupEXT = OpTypePointer TaskPayloadWorkgroupEXT %uint
+    %payload = OpVariable %_ptr_TaskPayloadWorkgroupEXT TaskPayloadWorkgroupEXT
+       %main = OpFunction %void None %func
+      %label = OpLabel
+       %load = OpLoad %uint %payload
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+}
+
+TEST_F(ValidateMeshShading, TaskPayloadWorkgroupMeshExtExecutionModel) {
+  const std::string body = R"(
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint MeshEXT %main "main" %payload
+               OpExecutionMode %main OutputVertices 1
+               OpExecutionMode %main OutputPrimitivesEXT 1
+               OpExecutionMode %main OutputTrianglesEXT
+       %void = OpTypeVoid
+       %func = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_TaskPayloadWorkgroupEXT = OpTypePointer TaskPayloadWorkgroupEXT %uint
+    %payload = OpVariable %_ptr_TaskPayloadWorkgroupEXT TaskPayloadWorkgroupEXT
+       %main = OpFunction %void None %func
+      %label = OpLabel
+       %load = OpLoad %uint %payload
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+}
+
 TEST_F(ValidateMeshShading, OpSetMeshOutputsBadVertexCount) {
   const std::string body = R"(
                OpCapability MeshShadingEXT
@@ -591,6 +664,317 @@ TEST_F(ValidateMeshShading, OpEmitMeshTasksZeroSuccess) {
        %main = OpFunction %void None %func
       %label = OpLabel
                OpEmitMeshTasksEXT %uint_0 %uint_0 %uint_0
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+}
+
+TEST_F(ValidateMeshShading, BadPerPrimitiveEXTStorageClassInMeshEXT) {
+  const std::string body = R"(
+              OpCapability MeshShadingEXT
+              OpExtension "SPV_EXT_mesh_shader"
+         %1 = OpExtInstImport "GLSL.std.450"
+              OpMemoryModel Logical GLSL450
+              OpEntryPoint MeshEXT %main "main" %gl_LocalInvocationID %blk %triangleNormal
+              OpExecutionMode %main LocalSize 32 1 1
+              OpExecutionMode %main OutputVertices 81
+              OpExecutionMode %main OutputPrimitivesNV 32
+              OpExecutionMode %main OutputTrianglesNV
+              OpSource GLSL 450
+              OpSourceExtension "GL_EXT_mesh_shader"
+              OpName %main "main"
+              OpName %iid "iid"
+              OpName %gl_LocalInvocationID "gl_LocalInvocationID"
+              OpName %myblock "myblock"
+              OpMemberName %myblock 0 "f"
+              OpName %blk "blk"
+              OpName %triangleNormal "triangleNormal"
+              OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
+              OpMemberDecorate %myblock 0 PerPrimitiveEXT
+              OpDecorate %myblock Block
+              OpDecorate %blk Location 0
+              OpDecorate %triangleNormal PerPrimitiveEXT
+              OpDecorate %triangleNormal Location 0
+              OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+      %void = OpTypeVoid
+         %3 = OpTypeFunction %void
+      %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+    %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
+    %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+     %float = OpTypeFloat 32
+   %myblock = OpTypeStruct %float
+   %uint_32 = OpConstant %uint 32
+%_arr_myblock_uint_32 = OpTypeArray %myblock %uint_32
+%_ptr_Output__arr_myblock_uint_32 = OpTypePointer Output %_arr_myblock_uint_32
+       %blk = OpVariable %_ptr_Output__arr_myblock_uint_32 Output
+       %int = OpTypeInt 32 1
+     %int_0 = OpConstant %int 0
+  %float_11 = OpConstant %float 11
+%_ptr_Output_float = OpTypePointer Output %float
+   %v3float = OpTypeVector %float 3
+%_arr_v3float_uint_32 = OpTypeArray %v3float %uint_32
+%_ptr_Output__arr_v3float_uint_32 = OpTypePointer Input %_arr_v3float_uint_32
+%triangleNormal = OpVariable %_ptr_Output__arr_v3float_uint_32 Input
+        %33 = OpConstantComposite %v3float %float_11 %float_11 %float_11
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+    %uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+      %main = OpFunction %void None %3
+         %5 = OpLabel
+       %iid = OpVariable %_ptr_Function_uint Function
+        %14 = OpAccessChain %_ptr_Input_uint %gl_LocalInvocationID %uint_0
+        %15 = OpLoad %uint %14
+              OpStore %iid %15
+        %22 = OpLoad %uint %iid
+        %27 = OpAccessChain %_ptr_Output_float %blk %22 %int_0
+              OpStore %27 %float_11
+              OpReturn
+              OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("PerPrimitiveEXT decoration must be applied only to "
+                        "variables in the Output Storage Class in the Storage "
+                        "Class in the MeshEXT Execution Model."));
+}
+
+TEST_F(ValidateMeshShading, VulkanPerPrimitiveEXTStorageClassInMeshEXT) {
+  const std::string body = R"(
+      OpCapability MeshShadingEXT
+      OpExtension "SPV_EXT_mesh_shader"
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint MeshEXT %main "main" %gl_LocalInvocationID %blk %triangleNormal
+      OpExecutionMode %main LocalSize 32 1 1
+      OpExecutionMode %main OutputVertices 81
+      OpExecutionMode %main OutputPrimitivesNV 32
+      OpExecutionMode %main OutputTrianglesNV
+      OpSource GLSL 450
+      OpSourceExtension "GL_EXT_mesh_shader"
+      OpName %main "main"
+      OpName %iid "iid"
+      OpName %gl_LocalInvocationID "gl_LocalInvocationID"
+      OpName %myblock "myblock"
+      OpMemberName %myblock 0 "f"
+      OpName %blk "blk"
+      OpName %triangleNormal "triangleNormal"
+      OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
+      OpMemberDecorate %myblock 0 PerPrimitiveEXT
+      OpDecorate %myblock Block
+      OpDecorate %blk Location 0
+      OpDecorate %triangleNormal PerPrimitiveEXT
+      OpDecorate %triangleNormal Location 0
+      OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+ %3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+%v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
+%uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+%float = OpTypeFloat 32
+%myblock = OpTypeStruct %float
+%uint_32 = OpConstant %uint 32
+%_arr_myblock_uint_32 = OpTypeArray %myblock %uint_32
+%_ptr_Output__arr_myblock_uint_32 = OpTypePointer Output %_arr_myblock_uint_32
+%blk = OpVariable %_ptr_Output__arr_myblock_uint_32 Output
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%float_11 = OpConstant %float 11
+%_ptr_Output_float = OpTypePointer Output %float
+%v3float = OpTypeVector %float 3
+%_arr_v3float_uint_32 = OpTypeArray %v3float %uint_32
+%_ptr_Output__arr_v3float_uint_32 = OpTypePointer Input %_arr_v3float_uint_32
+%triangleNormal = OpVariable %_ptr_Output__arr_v3float_uint_32 Input
+%33 = OpConstantComposite %v3float %float_11 %float_11 %float_11
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+%uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+%main = OpFunction %void None %3
+ %5 = OpLabel
+%iid = OpVariable %_ptr_Function_uint Function
+%14 = OpAccessChain %_ptr_Input_uint %gl_LocalInvocationID %uint_0
+%15 = OpLoad %uint %14
+      OpStore %iid %15
+%22 = OpLoad %uint %iid
+%27 = OpAccessChain %_ptr_Output_float %blk %22 %int_0
+      OpStore %27 %float_11
+      OpReturn
+      OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-PrimitiveId-PrimitiveId-04336"));
+}
+
+TEST_F(ValidateMeshShading, BadPerPrimitiveEXTStorageClassInFrag) {
+  const std::string body = R"(
+             OpCapability Shader
+             OpCapability MeshShadingEXT
+             OpExtension "SPV_EXT_mesh_shader"
+        %1 = OpExtInstImport "GLSL.std.450"
+             OpMemoryModel Logical GLSL450
+             OpEntryPoint Fragment %main "main" %triangleNormal
+             OpExecutionMode %main OriginUpperLeft
+             OpSource GLSL 450
+             OpSourceExtension "GL_EXT_mesh_shader"
+             OpName %main "main"
+             OpName %triangleNormal "triangleNormal"
+             OpDecorate %triangleNormal PerPrimitiveNV
+             OpDecorate %triangleNormal Location 0
+     %void = OpTypeVoid
+        %3 = OpTypeFunction %void
+    %float = OpTypeFloat 32
+  %v3float = OpTypeVector %float 3
+     %uint = OpTypeInt 32 0
+   %uint_3 = OpConstant %uint 3
+%_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
+%_ptr_Input__arr_v3float_uint_3 = OpTypePointer Output %_arr_v3float_uint_3
+%triangleNormal = OpVariable %_ptr_Input__arr_v3float_uint_3 Output
+      %int = OpTypeInt 32 1
+    %int_0 = OpConstant %int 0
+%_ptr_Input_v3float = OpTypePointer Input %v3float
+     %main = OpFunction %void None %3
+        %5 = OpLabel
+       %18 = OpAccessChain %_ptr_Input_v3float %triangleNormal %int_0
+       %19 = OpLoad %v3float %18
+             OpReturn
+             OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("PerPrimitiveEXT decoration must be applied only to "
+                        "variables in the Input Storage Class in the Fragment "
+                        "Execution Model."));
+}
+
+TEST_F(ValidateMeshShading, PerPrimitiveEXTStorageClassInFrag) {
+  const std::string body = R"(
+                OpCapability Shader
+                OpCapability MeshShadingEXT
+                OpExtension "SPV_EXT_mesh_shader"
+           %1 = OpExtInstImport "GLSL.std.450"
+                OpMemoryModel Logical GLSL450
+                OpEntryPoint Fragment %main "main" %res3 %triangleNormal
+                OpExecutionMode %main OriginUpperLeft
+                OpSource GLSL 450
+                OpSourceExtension "GL_EXT_mesh_shader"
+                OpName %main "main"
+                OpName %res3 "res3"
+                OpName %triangleNormal "triangleNormal"
+                OpDecorate %res3 Location 0
+                OpDecorate %triangleNormal PerPrimitiveNV
+                OpDecorate %triangleNormal Location 0
+        %void = OpTypeVoid
+           %3 = OpTypeFunction %void
+       %float = OpTypeFloat 32
+     %v3float = OpTypeVector %float 3
+ %_ptr_Output_v3float = OpTypePointer Output %v3float
+        %res3 = OpVariable %_ptr_Output_v3float Output
+        %uint = OpTypeInt 32 0
+      %uint_3 = OpConstant %uint 3
+ %_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
+ %_ptr_Input__arr_v3float_uint_3 = OpTypePointer Input %_arr_v3float_uint_3
+ %triangleNormal = OpVariable %_ptr_Input__arr_v3float_uint_3 Input
+         %int = OpTypeInt 32 1
+       %int_0 = OpConstant %int 0
+ %_ptr_Input_v3float = OpTypePointer Input %v3float
+        %main = OpFunction %void None %3
+           %5 = OpLabel
+          %18 = OpAccessChain %_ptr_Input_v3float %triangleNormal %int_0
+          %19 = OpLoad %v3float %18
+                OpStore %res3 %19
+                OpReturn
+                OpFunctionEnd
+)";
+
+  CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
+}
+
+TEST_F(ValidateMeshShading, PerPrimitiveEXTStorageClassInMeshEXT) {
+  const std::string body = R"(
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint MeshEXT %main "main" %gl_LocalInvocationID %blk %triangleNormal
+               OpExecutionMode %main LocalSize 32 1 1
+               OpExecutionMode %main OutputVertices 81
+               OpExecutionMode %main OutputPrimitivesNV 32
+               OpExecutionMode %main OutputTrianglesNV
+               OpSource GLSL 450
+               OpSourceExtension "GL_EXT_mesh_shader"
+               OpName %main "main"
+               OpName %iid "iid"
+               OpName %gl_LocalInvocationID "gl_LocalInvocationID"
+               OpName %myblock "myblock"
+               OpMemberName %myblock 0 "f"
+               OpName %blk "blk"
+               OpName %triangleNormal "triangleNormal"
+               OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
+               OpMemberDecorate %myblock 0 PerPrimitiveNV
+               OpDecorate %myblock Block
+               OpDecorate %blk Location 0
+               OpDecorate %triangleNormal PerPrimitiveNV
+               OpDecorate %triangleNormal Location 0
+               OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_LocalInvocationID = OpVariable %_ptr_Input_v3uint Input
+     %uint_0 = OpConstant %uint 0
+%_ptr_Input_uint = OpTypePointer Input %uint
+      %float = OpTypeFloat 32
+    %myblock = OpTypeStruct %float
+    %uint_32 = OpConstant %uint 32
+%_arr_myblock_uint_32 = OpTypeArray %myblock %uint_32
+%_ptr_Output__arr_myblock_uint_32 = OpTypePointer Output %_arr_myblock_uint_32
+        %blk = OpVariable %_ptr_Output__arr_myblock_uint_32 Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+   %float_11 = OpConstant %float 11
+%_ptr_Output_float = OpTypePointer Output %float
+    %v3float = OpTypeVector %float 3
+%_arr_v3float_uint_32 = OpTypeArray %v3float %uint_32
+%_ptr_Output__arr_v3float_uint_32 = OpTypePointer Output %_arr_v3float_uint_32
+%triangleNormal = OpVariable %_ptr_Output__arr_v3float_uint_32 Output
+         %33 = OpConstantComposite %v3float %float_11 %float_11 %float_11
+%_ptr_Output_v3float = OpTypePointer Output %v3float
+     %uint_1 = OpConstant %uint 1
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_32 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+        %iid = OpVariable %_ptr_Function_uint Function
+         %14 = OpAccessChain %_ptr_Input_uint %gl_LocalInvocationID %uint_0
+         %15 = OpLoad %uint %14
+               OpStore %iid %15
+         %22 = OpLoad %uint %iid
+         %27 = OpAccessChain %_ptr_Output_float %blk %22 %int_0
+               OpStore %27 %float_11
+         %32 = OpLoad %uint %iid
+         %35 = OpAccessChain %_ptr_Output_v3float %triangleNormal %32
+               OpStore %35 %33
+               OpReturn
                OpFunctionEnd
 )";
 

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -997,6 +997,109 @@ OpExecutionMode %main OutputPoints
   EXPECT_THAT(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateModeExecution, MeshEXTOutputVertices) {
+  const std::string spirv = R"(
+OpCapability MeshShadingEXT
+OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint MeshEXT %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpExecutionMode %main OutputVertices 3
+OpExecutionMode %main OutputPrimitivesNV 1
+OpExecutionMode %main OutputTrianglesNV
+OpSource GLSL 460
+OpSourceExtension "GL_EXT_mesh_shader"
+OpName %main "main"
+OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+%main = OpFunction %void None %3
+%5 = OpLabel
+OpSetMeshOutputsEXT %uint_3 %uint_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
+  EXPECT_THAT(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+}
+
+TEST_F(ValidateModeExecution, VulkanBadMeshEXTOutputVertices) {
+  const std::string spirv = R"(
+OpCapability MeshShadingEXT
+OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint MeshEXT %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpExecutionMode %main OutputVertices 0
+OpExecutionMode %main OutputPrimitivesNV 1
+OpExecutionMode %main OutputTrianglesNV
+OpSource GLSL 460
+OpSourceExtension "GL_EXT_mesh_shader"
+OpName %main "main"
+OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+%main = OpFunction %void None %3
+%5 = OpLabel
+OpSetMeshOutputsEXT %uint_3 %uint_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-ExecutionModel-07330"));
+}
+
+TEST_F(ValidateModeExecution, VulkanBadMeshEXTOutputOutputPrimitivesEXT) {
+  const std::string spirv = R"(
+OpCapability MeshShadingEXT
+OpExtension "SPV_EXT_mesh_shader"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint MeshEXT %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpExecutionMode %main OutputVertices 1
+OpExecutionMode %main OutputPrimitivesNV 0
+OpExecutionMode %main OutputTrianglesNV
+OpSource GLSL 460
+OpSourceExtension "GL_EXT_mesh_shader"
+OpName %main "main"
+OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%v3uint = OpTypeVector %uint 3
+%gl_WorkGroupSize = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+%main = OpFunction %void None %3
+%5 = OpLabel
+OpSetMeshOutputsEXT %uint_3 %uint_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-ExecutionModel-07331"));
+}
+
 TEST_F(ValidateModeExecution, MeshNVOutputVertices) {
   const std::string spirv = R"(
 OpCapability Shader


### PR DESCRIPTION
1. Each OpEntryPoint with the MeshEXT Execution Model can have at most one global OpVariable of storage class TaskPayloadWorkgroupEXT.
2. PerPrimitiveEXT only be used on a memory object declaration or a member of a structure type
3. PerPrimitiveEXT only Input in Fragment and Output in MeshEXT
4. Added Mesh vulkan validation support for following rules: VUID-Layer-Layer-07039 VUID-PrimitiveId-PrimitiveId-07040,VUID-PrimitivePointIndicesEXT-PrimitivePointIndicesEXT-07042, VUID-PrimitiveLineIndicesEXT-PrimitiveLineIndicesEXT-07048, VUID-PrimitiveTriangleIndicesEXT-PrimitiveTriangleIndicesEXT-07054, VUID-ViewportIndex-ViewportIndex-07060 VUID-StandaloneSpirv-ExecutionModel-07330 VUID-StandaloneSpirv-ExecutionModel-07331

For bug #4919 