### PR TITLE
A fix to support of SPV_QCOM_image_processing2

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -2169,7 +2169,8 @@ spv_result_t ValidateImageProcessingQCOMDecoration(ValidationState_t& _, int id,
                                                    spv::Decoration decor) {
   const Instruction* si_inst = nullptr;
   const Instruction* ld_inst = _.FindDef(id);
-  if (ld_inst->opcode() == spv::Op::OpSampledImage) {
+  bool is_intf_obj = (ld_inst->opcode() == spv::Op::OpSampledImage);
+  if (is_intf_obj == true) {
     si_inst = ld_inst;
     int t_idx = si_inst->GetOperandAs<int>(2);  // texture
     ld_inst = _.FindDef(t_idx);
@@ -2181,6 +2182,56 @@ spv_result_t ValidateImageProcessingQCOMDecoration(ValidationState_t& _, int id,
   if (!_.HasDecoration(texture_id, decor)) {
     return _.diag(SPV_ERROR_INVALID_DATA, ld_inst)
            << "Missing decoration " << _.SpvDecorationString(decor);
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateImageProcessing2QCOMWindowDecoration(ValidationState_t& _,
+                                                          int id) {
+  const Instruction* ld_inst = _.FindDef(id);
+  bool is_intf_obj = (ld_inst->opcode() != spv::Op::OpSampledImage);
+  if (is_intf_obj == true) {
+    if (ld_inst->opcode() != spv::Op::OpLoad) {
+      return _.diag(SPV_ERROR_INVALID_DATA, ld_inst) << "Expect to see OpLoad";
+    }
+    int texture_id = ld_inst->GetOperandAs<int>(2);  // variable to load
+    spv::Decoration decor = spv::Decoration::BlockMatchTextureQCOM;
+    if (!_.HasDecoration(texture_id, decor)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, ld_inst)
+             << "Missing decoration " << _.SpvDecorationString(decor);
+    }
+    decor = spv::Decoration::BlockMatchSamplerQCOM;
+    if (!_.HasDecoration(texture_id, decor)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, ld_inst)
+             << "Missing decoration " << _.SpvDecorationString(decor);
+    }
+  } else {
+    const Instruction* si_inst = ld_inst;
+    int t_idx = si_inst->GetOperandAs<int>(2);  // texture
+    const Instruction* t_ld_inst = _.FindDef(t_idx);
+    if (t_ld_inst->opcode() != spv::Op::OpLoad) {
+      return _.diag(SPV_ERROR_INVALID_DATA, t_ld_inst)
+             << "Expect to see OpLoad";
+    }
+    int texture_id = t_ld_inst->GetOperandAs<int>(2);  // variable to load
+    spv::Decoration decor = spv::Decoration::BlockMatchTextureQCOM;
+    if (!_.HasDecoration(texture_id, decor)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, ld_inst)
+             << "Missing decoration " << _.SpvDecorationString(decor);
+    }
+    int s_idx = si_inst->GetOperandAs<int>(3);  // sampler
+    const Instruction* s_ld_inst = _.FindDef(s_idx);
+    if (s_ld_inst->opcode() != spv::Op::OpLoad) {
+      return _.diag(SPV_ERROR_INVALID_DATA, s_ld_inst)
+             << "Expect to see OpLoad";
+    }
+    int sampler_id = s_ld_inst->GetOperandAs<int>(2);  // variable to load
+    decor = spv::Decoration::BlockMatchSamplerQCOM;
+    if (!_.HasDecoration(sampler_id, decor)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, ld_inst)
+             << "Missing decoration " << _.SpvDecorationString(decor);
+    }
   }
 
   return SPV_SUCCESS;
@@ -2211,18 +2262,10 @@ spv_result_t ValidateImageProcessingQCOM(ValidationState_t& _,
     case spv::Op::OpImageBlockMatchWindowSSDQCOM:
     case spv::Op::OpImageBlockMatchWindowSADQCOM: {
       int tgt_idx = inst->GetOperandAs<int>(2);  // target
-      res = ValidateImageProcessingQCOMDecoration(
-          _, tgt_idx, spv::Decoration::BlockMatchTextureQCOM);
-      if (res != SPV_SUCCESS) break;
-      res = ValidateImageProcessingQCOMDecoration(
-          _, tgt_idx, spv::Decoration::BlockMatchSamplerQCOM);
+      res = ValidateImageProcessing2QCOMWindowDecoration(_, tgt_idx);
       if (res != SPV_SUCCESS) break;
       int ref_idx = inst->GetOperandAs<int>(4);  // reference
-      res = ValidateImageProcessingQCOMDecoration(
-          _, ref_idx, spv::Decoration::BlockMatchTextureQCOM);
-      if (res != SPV_SUCCESS) break;
-      res = ValidateImageProcessingQCOMDecoration(
-          _, ref_idx, spv::Decoration::BlockMatchSamplerQCOM);
+      res = ValidateImageProcessing2QCOMWindowDecoration(_, ref_idx);
       break;
     }
     case spv::Op::OpImageBlockMatchGatherSSDQCOM:

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -8332,9 +8332,9 @@ TEST_F(ValidateImage, QCOMImageProcessing2BlockMatchWindowSADNoDecorRefNIT) {
            OpDecorate %4 DescriptorSet 0
            OpDecorate %4 Binding 1
            OpDecorate %4 BlockMatchTextureQCOM
-           OpDecorate %4 BlockMatchSamplerQCOM
            OpDecorate %5 DescriptorSet 0
            OpDecorate %5 Binding 3
+           OpDecorate %5 BlockMatchSamplerQCOM
            OpDecorate %6 DescriptorSet 0
            OpDecorate %6 Binding 2
            OpDecorate %6 BlockMatchSamplerQCOM
@@ -8816,9 +8816,9 @@ TEST_F(ValidateImage, QCOMImageProcessing2BlockMatchWindowSSDNoDecorRefNIT) {
            OpDecorate %4 DescriptorSet 0
            OpDecorate %4 Binding 1
            OpDecorate %4 BlockMatchTextureQCOM
-           OpDecorate %4 BlockMatchSamplerQCOM
            OpDecorate %5 DescriptorSet 0
            OpDecorate %5 Binding 3
+           OpDecorate %5 BlockMatchSamplerQCOM
            OpDecorate %6 DescriptorSet 0
            OpDecorate %6 Binding 2
            OpDecorate %6 BlockMatchSamplerQCOM
@@ -9557,9 +9557,8 @@ TEST_F(ValidateImage,
                OpDecorate %104 DescriptorSet 0
                OpDecorate %104 Binding 2
                OpDecorate %102 BlockMatchTextureQCOM
-               OpDecorate %102 BlockMatchSamplerQCOM
+               OpDecorate %103 BlockMatchSamplerQCOM
                OpDecorate %104 BlockMatchTextureQCOM
-               OpDecorate %104 BlockMatchSamplerQCOM
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
        %uint = OpTypeInt 32 0
@@ -9632,9 +9631,8 @@ TEST_F(ValidateImage, QCOMImageProcessing2BlockMatchWindowSADInvalidUseRefNI) {
                OpDecorate %104 DescriptorSet 0
                OpDecorate %104 Binding 2
                OpDecorate %102 BlockMatchTextureQCOM
-               OpDecorate %102 BlockMatchSamplerQCOM
+               OpDecorate %103 BlockMatchSamplerQCOM
                OpDecorate %104 BlockMatchTextureQCOM
-               OpDecorate %104 BlockMatchSamplerQCOM
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
        %uint = OpTypeInt 32 0
@@ -9847,9 +9845,8 @@ TEST_F(ValidateImage,
                OpDecorate %104 DescriptorSet 0
                OpDecorate %104 Binding 2
                OpDecorate %102 BlockMatchTextureQCOM
-               OpDecorate %102 BlockMatchSamplerQCOM
+               OpDecorate %103 BlockMatchSamplerQCOM
                OpDecorate %104 BlockMatchTextureQCOM
-               OpDecorate %104 BlockMatchSamplerQCOM
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
        %uint = OpTypeInt 32 0
@@ -9922,9 +9919,8 @@ TEST_F(ValidateImage, QCOMImageProcessing2BlockMatchWindowSSDInvalidUseRefNI) {
                OpDecorate %104 DescriptorSet 0
                OpDecorate %104 Binding 2
                OpDecorate %102 BlockMatchTextureQCOM
-               OpDecorate %102 BlockMatchSamplerQCOM
+               OpDecorate %103 BlockMatchSamplerQCOM
                OpDecorate %104 BlockMatchTextureQCOM
-               OpDecorate %104 BlockMatchSamplerQCOM
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
        %uint = OpTypeInt 32 0


### PR DESCRIPTION
This patch set fixes validation of decorations attached to
texture/sampler operands of OpImageBlockMatchWindowSSDQCOM and OpImageBlockMatchWindowSADQCOM