### PR TITLE
properly handle the load and store cache control operand types

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -673,6 +673,8 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     case SPV_OPERAND_TYPE_OPTIONAL_PACKED_VECTOR_FORMAT:
     case SPV_OPERAND_TYPE_FPENCODING:
     case SPV_OPERAND_TYPE_OPTIONAL_FPENCODING:
+    case SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL:
+    case SPV_OPERAND_TYPE_STORE_CACHE_CONTROL:
     case SPV_OPERAND_TYPE_NAMED_MAXIMUM_NUMBER_OF_REGISTERS: {
       // A single word that is a plain enum value.
 

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -402,6 +402,22 @@ INSTANTIATE_TEST_SUITE_P(
                 "OpDecorateId %1 MaxByteOffsetId %2\n",
             })));
 
+INSTANTIATE_TEST_SUITE_P(
+    CacheControlsINTEL, RoundTripInstructionsTest,
+    Combine(
+        ::testing::Values(SPV_ENV_UNIVERSAL_1_0),
+        ::testing::ValuesIn(std::vector<std::string>{
+            "OpDecorate %1 CacheControlLoadINTEL 0 UncachedINTEL\n",
+            "OpDecorate %1 CacheControlLoadINTEL 1 CachedINTEL\n",
+            "OpDecorate %1 CacheControlLoadINTEL 2 StreamingINTEL\n",
+            "OpDecorate %1 CacheControlLoadINTEL 3 InvalidateAfterReadINTEL\n",
+            "OpDecorate %1 CacheControlLoadINTEL 4 ConstCachedINTEL\n",
+            "OpDecorate %1 CacheControlStoreINTEL 0 UncachedINTEL\n",
+            "OpDecorate %1 CacheControlStoreINTEL 1 WriteThroughINTEL\n",
+            "OpDecorate %1 CacheControlStoreINTEL 2 WriteBackINTEL\n",
+            "OpDecorate %1 CacheControlStoreINTEL 3 StreamingINTEL\n",
+        })));
+
 using MaskSorting = TextToBinaryTest;
 
 TEST_F(MaskSorting, MasksAreSortedFromLSBToMSB) {


### PR DESCRIPTION
Without handling these operand types, disassembling a SPIR-V module that uses the cache control extension produces an invalid operand type error: "error: 33: Internal error: Unhandled operand type: 81".