### PR TITLE
Validate calls to printf

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -255,6 +255,12 @@ std::string ValidationState_t::getIdName(uint32_t id) const {
   return out.str();
 }
 
+const std::string ValidationState_t::getName(uint32_t id) const {
+  const std::string id_name = name_mapper_(id);
+
+  return id_name;
+}
+
 size_t ValidationState_t::unresolved_forward_id_count() const {
   return unresolved_forward_ids_.size();
 }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -151,6 +151,9 @@ class ValidationState_t {
   /// the OpName instruction
   std::string getIdName(uint32_t id) const;
 
+  /// Returns the string assigned to id by the OpName instruction
+  const std::string getName(uint32_t id) const;
+
   /// Accessor function for ID bound.
   uint32_t getIdBound() const;
 


### PR DESCRIPTION
Kernels with calls to __builtin_printf can produce calls to printf in SPIRV.  Add support in spirv-val to validate parameters to vararg functions.