### PR TITLE
spirv-dis: Add --nested-indent and --reorder-blocks

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -382,6 +382,11 @@ typedef enum spv_binary_to_text_options_t {
   SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES = SPV_BIT(6),
   // Add some comments to the generated assembly
   SPV_BINARY_TO_TEXT_OPTION_COMMENT = SPV_BIT(7),
+  // Use nested indentation for more readable SPIR-V
+  SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT = SPV_BIT(8),
+  // Reorder blocks to match the structured control flow of SPIR-V to increase
+  // readability.
+  SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS = SPV_BIT(9),
   SPV_FORCE_32_BIT_ENUM(spv_binary_to_text_options_t)
 } spv_binary_to_text_options_t;
 

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -24,6 +24,8 @@
 #include <cstring>
 #include <iomanip>
 #include <memory>
+#include <set>
+#include <stack>
 #include <unordered_map>
 #include <utility>
 
@@ -43,6 +45,70 @@
 namespace spvtools {
 namespace {
 
+// Indices to ControlFlowGraph's list of blocks from one block to its successors
+struct BlockSuccessors {
+  // Merge block in OpLoopMerge and OpSelectionMerge
+  uint32_t merge_block_id = 0;
+  // The continue block in OpLoopMerge
+  uint32_t continue_block_id = 0;
+  // The true and false blocks in OpBranchConditional
+  uint32_t true_block_id = 0;
+  uint32_t false_block_id = 0;
+  // The body block of a loop, as specified by OpBranch after a merge
+  // instruction
+  uint32_t body_block_id = 0;
+  // The same-nesting-level block that follows this one, indicated by an
+  // OpBranch with no merge instruction.
+  uint32_t next_block_id = 0;
+  // The cases (including default) of an OpSwitch
+  std::vector<uint32_t> case_block_ids;
+};
+
+class ParsedInstruction {
+ public:
+  ParsedInstruction(const spv_parsed_instruction_t* instruction) {
+    // Make a copy of the parsed instruction, including stable memory for its
+    // operands.
+    instruction_ = *instruction;
+    operands_ =
+        std::make_unique<spv_parsed_operand_t[]>(instruction->num_operands);
+    memcpy(operands_.get(), instruction->operands,
+           instruction->num_operands * sizeof(*instruction->operands));
+    instruction_.operands = operands_.get();
+  }
+
+  const spv_parsed_instruction_t* get() const { return &instruction_; }
+
+ private:
+  spv_parsed_instruction_t instruction_;
+  std::unique_ptr<spv_parsed_operand_t[]> operands_;
+};
+
+// One block in the CFG
+struct SingleBlock {
+  // The byte offset in the SPIR-V where the block starts.  Used for printing in
+  // a comment.
+  size_t byte_offset;
+
+  // Block instructions
+  std::vector<ParsedInstruction> instructions;
+
+  // Successors of this block
+  BlockSuccessors successors;
+
+  // The nesting level for this block.
+  uint32_t nest_level = 0;
+  bool nest_level_assigned = false;
+
+  // Whether the block was reachable
+  bool reachable = false;
+};
+
+// CFG for one function
+struct ControlFlowGraph {
+  std::vector<SingleBlock> blocks;
+};
+
 // A Disassembler instance converts a SPIR-V binary to its assembly
 // representation.
 class Disassembler {
@@ -50,6 +116,10 @@ class Disassembler {
   Disassembler(const AssemblyGrammar& grammar, uint32_t options,
                NameMapper name_mapper)
       : print_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_PRINT, options)),
+        nested_indent_(
+            spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT, options)),
+        reorder_blocks_(
+            spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS, options)),
         text_(),
         out_(print_ ? out_stream() : out_stream(text_)),
         instruction_disassembler_(grammar, out_.get(), options, name_mapper),
@@ -70,7 +140,13 @@ class Disassembler {
   spv_result_t SaveTextResult(spv_text* text_result) const;
 
  private:
+  void EmitCFG();
+
   const bool print_;  // Should we also print to the standard output stream?
+  const bool nested_indent_;  // Should the blocks be indented according to the
+                              // control flow structure?
+  const bool
+      reorder_blocks_;       // Should the blocks be reordered for readability?
   spv_endianness_t endian_;  // The detected endianness of the binary.
   std::stringstream text_;   // Captures the text, if not printing.
   out_stream out_;  // The Output stream.  Either to text_ or standard output.
@@ -80,6 +156,9 @@ class Disassembler {
   bool inserted_decoration_space_ = false;
   bool inserted_debug_space_ = false;
   bool inserted_type_space_ = false;
+
+  // The CFG for the current function
+  ControlFlowGraph current_function_cfg_;
 };
 
 spv_result_t Disassembler::HandleHeader(spv_endianness_t endian,
@@ -106,11 +185,334 @@ spv_result_t Disassembler::HandleInstruction(
                                                inserted_debug_space_,
                                                inserted_type_space_);
 
-  instruction_disassembler_.EmitInstruction(inst, byte_offset_);
+  // When nesting needs to be calculated or when the blocks are reordered, we
+  // have to have the full picture of the CFG first.  Defer processing of the
+  // instructions until the entire function is visited.  This is not done
+  // without those options (even if simpler) to improve debuggability; for
+  // example to be able to see whatever is parsed so far even if there is a
+  // parse error.
+  if (nested_indent_ || reorder_blocks_) {
+    switch (static_cast<spv::Op>(inst.opcode)) {
+      case spv::Op::OpLabel: {
+        // Add a new block to the CFG
+        SingleBlock new_block;
+        new_block.byte_offset = byte_offset_;
+        new_block.instructions.emplace_back(&inst);
+        current_function_cfg_.blocks.push_back(std::move(new_block));
+        break;
+      }
+      case spv::Op::OpFunctionEnd:
+        // Process the CFG and output the instructions
+        EmitCFG();
+        // Output OpFunctionEnd itself too
+        [[fallthrough]];
+      default:
+        if (!current_function_cfg_.blocks.empty()) {
+          // If in a function, stash the instruction for later.
+          current_function_cfg_.blocks.back().instructions.emplace_back(&inst);
+        } else {
+          // Otherwise emit the instruction right away.
+          instruction_disassembler_.EmitInstruction(inst, byte_offset_);
+        }
+        break;
+    }
+  } else {
+    instruction_disassembler_.EmitInstruction(inst, byte_offset_);
+  }
 
   byte_offset_ += inst.num_words * sizeof(uint32_t);
 
   return SPV_SUCCESS;
+}
+
+// Helper to get the operand of an instruction as an id.
+uint32_t GetOperand(const spv_parsed_instruction_t* instruction,
+                    uint32_t operand) {
+  return instruction->words[instruction->operands[operand].offset];
+}
+
+std::unordered_map<uint32_t, uint32_t> BuildControlFlowGraph(
+    ControlFlowGraph& cfg) {
+  std::unordered_map<uint32_t, uint32_t> id_to_index;
+
+  for (size_t index = 0; index < cfg.blocks.size(); ++index) {
+    SingleBlock& block = cfg.blocks[index];
+
+    // For future use, build the ID->index map
+    assert(static_cast<spv::Op>(block.instructions[0].get()->opcode) ==
+           spv::Op::OpLabel);
+    const uint32_t id = block.instructions[0].get()->result_id;
+
+    id_to_index[id] = static_cast<uint32_t>(index);
+
+    // Look for a merge instruction first.  The function of OpBranch depends on
+    // that.
+    if (block.instructions.size() >= 3) {
+      const spv_parsed_instruction_t* maybe_merge =
+          block.instructions[block.instructions.size() - 2].get();
+
+      switch (static_cast<spv::Op>(maybe_merge->opcode)) {
+        case spv::Op::OpLoopMerge:
+          block.successors.merge_block_id = GetOperand(maybe_merge, 0);
+          block.successors.continue_block_id = GetOperand(maybe_merge, 1);
+          break;
+
+        case spv::Op::OpSelectionMerge:
+          block.successors.merge_block_id = GetOperand(maybe_merge, 0);
+          break;
+
+        default:
+          break;
+      }
+    }
+
+    // Then look at the last instruction; it must be a branch
+    assert(block.instructions.size() >= 2);
+
+    const spv_parsed_instruction_t* branch = block.instructions.back().get();
+    switch (static_cast<spv::Op>(branch->opcode)) {
+      case spv::Op::OpBranch:
+        if (block.successors.merge_block_id != 0) {
+          block.successors.body_block_id = GetOperand(branch, 0);
+        } else {
+          block.successors.next_block_id = GetOperand(branch, 0);
+        }
+        break;
+
+      case spv::Op::OpBranchConditional:
+        block.successors.true_block_id = GetOperand(branch, 1);
+        block.successors.false_block_id = GetOperand(branch, 2);
+        break;
+
+      case spv::Op::OpSwitch:
+        for (uint32_t case_index = 1; case_index < branch->num_operands;
+             case_index += 2) {
+          block.successors.case_block_ids.push_back(
+              GetOperand(branch, case_index));
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return id_to_index;
+}
+
+// Helper to deal with nesting and non-existing ids / previously-assigned
+// levels.  It assigns a given nesting level `level` to the block identified by
+// `id` (unless that block already has a nesting level assigned).
+void Nest(ControlFlowGraph& cfg,
+          const std::unordered_map<uint32_t, uint32_t>& id_to_index,
+          uint32_t id, uint32_t level) {
+  if (id == 0) {
+    return;
+  }
+
+  const uint32_t block_index = id_to_index.at(id);
+  SingleBlock& block = cfg.blocks[block_index];
+
+  if (!block.nest_level_assigned) {
+    block.nest_level = level;
+    block.nest_level_assigned = true;
+  }
+}
+
+// For a given block, assign nesting level to its successors.
+void NestSuccessors(ControlFlowGraph& cfg, const SingleBlock& block,
+                    const std::unordered_map<uint32_t, uint32_t>& id_to_index) {
+  assert(block.nest_level_assigned);
+
+  // Nest loops as such:
+  //
+  //     %loop = OpLabel
+  //               OpLoopMerge %merge %cont ...
+  //               OpBranch %body
+  //     %body =     OpLabel
+  //                   Op...
+  //     %cont =   OpLabel
+  //                 Op...
+  //    %merge = OpLabel
+  //               Op...
+  //
+  // Nest conditional branches as such:
+  //
+  //   %header = OpLabel
+  //               OpSelectionMerge %merge ...
+  //               OpBranchConditional ... %true %false
+  //     %true =     OpLabel
+  //                   Op...
+  //    %false =     OpLabel
+  //                   Op...
+  //    %merge = OpLabel
+  //               Op...
+  //
+  // Nest switch/case as such:
+  //
+  //   %header = OpLabel
+  //               OpSelectionMerge %merge ...
+  //               OpSwitch ... %default ... %case0 ... %case1 ...
+  //  %default =     OpLabel
+  //                   Op...
+  //    %case0 =     OpLabel
+  //                   Op...
+  //    %case1 =     OpLabel
+  //                   Op...
+  //             ...
+  //    %merge = OpLabel
+  //               Op...
+  //
+  // The following can be observed:
+  //
+  // - In all cases, the merge block has the same nesting as this block
+  // - The continue block of loops is nested 1 level deeper
+  // - The body/branches/cases are nested 2 levels deeper
+  //
+  // Back branches to the header block, branches to the merge block, etc
+  // are correctly handled by processing the header block first (that is
+  // _this_ block, already processed), then following the above rules
+  // (in the same order) for any block that is not already processed.
+  Nest(cfg, id_to_index, block.successors.merge_block_id, block.nest_level);
+  Nest(cfg, id_to_index, block.successors.continue_block_id,
+       block.nest_level + 1);
+  Nest(cfg, id_to_index, block.successors.true_block_id, block.nest_level + 2);
+  Nest(cfg, id_to_index, block.successors.false_block_id, block.nest_level + 2);
+  Nest(cfg, id_to_index, block.successors.body_block_id, block.nest_level + 2);
+  Nest(cfg, id_to_index, block.successors.next_block_id, block.nest_level);
+  for (uint32_t case_block_id : block.successors.case_block_ids) {
+    Nest(cfg, id_to_index, case_block_id, block.nest_level + 2);
+  }
+}
+
+struct StackEntry {
+  // The index of the block (in ControlFlowGraph::blocks) to process.
+  uint32_t block_index;
+  // Whether this is the pre or post visit of the block.  Because a post-visit
+  // traversal is needed, the same block is pushed back on the stack on
+  // pre-visit so it can be visited again on post-visit.
+  bool post_visit = false;
+};
+
+// Helper to deal with DFS traversal and non-existing ids
+void VisitSuccesor(std::stack<StackEntry>* dfs_stack,
+                   const std::unordered_map<uint32_t, uint32_t>& id_to_index,
+                   uint32_t id) {
+  if (id != 0) {
+    dfs_stack->push({id_to_index.at(id), false});
+  }
+}
+
+// Given the control flow graph, calculates and returns the reverse post-order
+// ordering of the blocks.  The blocks are then disassembled in that order for
+// readability.
+std::vector<uint32_t> OrderBlocks(
+    ControlFlowGraph& cfg,
+    const std::unordered_map<uint32_t, uint32_t>& id_to_index) {
+  std::vector<uint32_t> post_order;
+
+  // Nest level of a function's first block is 0.
+  cfg.blocks[0].nest_level = 0;
+  cfg.blocks[0].nest_level_assigned = true;
+
+  // Stack of block indices as they are visited.
+  std::stack<StackEntry> dfs_stack;
+  dfs_stack.push({0, false});
+
+  std::set<uint32_t> visited;
+
+  while (!dfs_stack.empty()) {
+    const uint32_t block_index = dfs_stack.top().block_index;
+    const bool post_visit = dfs_stack.top().post_visit;
+    dfs_stack.pop();
+
+    // If this is the second time the block is visited, that's the post-order
+    // visit.
+    if (post_visit) {
+      post_order.push_back(block_index);
+      continue;
+    }
+
+    // If already visited, another path got to it first (like a case
+    // fallthrough), avoid reprocessing it.
+    if (visited.count(block_index) > 0) {
+      continue;
+    }
+    visited.insert(block_index);
+
+    // Push it back in the stack for post-order visit
+    dfs_stack.push({block_index, true});
+
+    SingleBlock& block = cfg.blocks[block_index];
+
+    // Assign nest levels of successors right away.  The successors are either
+    // nested under this block, or are back or forward edges to blocks outside
+    // this nesting level (no farther than the merge block), whose nesting
+    // levels are already assigned before this block is visited.
+    NestSuccessors(cfg, block, id_to_index);
+    block.reachable = true;
+
+    // The post-order visit yields the order in which the blocks are naturally
+    // ordered _backwards_. So blocks to be ordered last should be visited
+    // first.  In other words, they should be pushed to the DFS stack last.
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.true_block_id);
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.false_block_id);
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.body_block_id);
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.next_block_id);
+    for (uint32_t case_block_id : block.successors.case_block_ids) {
+      VisitSuccesor(&dfs_stack, id_to_index, case_block_id);
+    }
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.continue_block_id);
+    VisitSuccesor(&dfs_stack, id_to_index, block.successors.merge_block_id);
+  }
+
+  std::vector<uint32_t> order(post_order.rbegin(), post_order.rend());
+
+  // Finally, dump all unreachable blocks at the end
+  for (size_t index = 0; index < cfg.blocks.size(); ++index) {
+    SingleBlock& block = cfg.blocks[index];
+
+    if (!block.reachable) {
+      order.push_back(static_cast<uint32_t>(index));
+      block.nest_level = 0;
+      block.nest_level_assigned = true;
+    }
+  }
+
+  return order;
+}
+
+void Disassembler::EmitCFG() {
+  // Build the CFG edges.  At the same time, build an ID->block index map to
+  // simplify building the CFG edges.
+  const std::unordered_map<uint32_t, uint32_t> id_to_index =
+      BuildControlFlowGraph(current_function_cfg_);
+
+  // Walk the CFG in reverse post-order to find the best ordering of blocks for
+  // presentation
+  std::vector<uint32_t> block_order =
+      OrderBlocks(current_function_cfg_, id_to_index);
+  assert(block_order.size() == current_function_cfg_.blocks.size());
+
+  // Walk the CFG either in block order or input order based on whether the
+  // reorder_blocks_ option is given.
+  for (uint32_t index = 0; index < current_function_cfg_.blocks.size();
+       ++index) {
+    const uint32_t block_index = reorder_blocks_ ? block_order[index] : index;
+    const SingleBlock& block = current_function_cfg_.blocks[block_index];
+
+    // Emit instructions for this block
+    size_t byte_offset = block.byte_offset;
+    assert(block.nest_level_assigned);
+
+    for (const ParsedInstruction& inst : block.instructions) {
+      instruction_disassembler_.EmitInstructionInBlock(*inst.get(), byte_offset,
+                                                       block.nest_level);
+      byte_offset += inst.get()->num_words * sizeof(uint32_t);
+    }
+  }
+
+  current_function_cfg_.blocks.clear();
 }
 
 spv_result_t Disassembler::SaveTextResult(spv_text* text_result) const {
@@ -214,6 +616,8 @@ uint32_t GetLineLengthWithoutColor(const std::string line) {
 }
 
 constexpr int kStandardIndent = 15;
+constexpr int kBlockNestIndent = 2;
+constexpr int kBlockBodyIndentOffset = 2;
 constexpr uint32_t kCommentColumn = 50;
 }  // namespace
 
@@ -229,6 +633,8 @@ InstructionDisassembler::InstructionDisassembler(const AssemblyGrammar& grammar,
       indent_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_INDENT, options)
                   ? kStandardIndent
                   : 0),
+      nested_indent_(
+          spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT, options)),
       comment_(spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_COMMENT, options)),
       show_byte_offset_(
           spvIsInBitfield(SPV_BINARY_TO_TEXT_OPTION_SHOW_BYTE_OFFSET, options)),
@@ -265,11 +671,28 @@ void InstructionDisassembler::EmitHeaderSchema(uint32_t schema) {
 
 void InstructionDisassembler::EmitInstruction(
     const spv_parsed_instruction_t& inst, size_t inst_byte_offset) {
+  EmitInstructionImpl(inst, inst_byte_offset, 0, false);
+}
+
+void InstructionDisassembler::EmitInstructionInBlock(
+    const spv_parsed_instruction_t& inst, size_t inst_byte_offset,
+    uint32_t block_indent) {
+  EmitInstructionImpl(inst, inst_byte_offset, block_indent, true);
+}
+
+void InstructionDisassembler::EmitInstructionImpl(
+    const spv_parsed_instruction_t& inst, size_t inst_byte_offset,
+    uint32_t block_indent, bool is_in_block) {
   auto opcode = static_cast<spv::Op>(inst.opcode);
 
   // To better align the comments (if any), write the instruction to a line
   // first so its length can be readily available.
   std::ostringstream line;
+
+  if (nested_indent_ && opcode == spv::Op::OpLabel) {
+    // Separate the blocks by an empty line to make them easier to separate
+    stream_ << std::endl;
+  }
 
   if (inst.result_id) {
     SetBlue();
@@ -281,6 +704,17 @@ void InstructionDisassembler::EmitInstruction(
     line << " = ";
   } else {
     line << std::string(indent_, ' ');
+  }
+
+  if (nested_indent_ && is_in_block) {
+    // Output OpLabel at the specified nest level, and instructions inside
+    // blocks nested a little more.
+    uint32_t indent = block_indent;
+    bool body_indent = opcode != spv::Op::OpLabel;
+
+    line << std::string(
+        indent * kBlockNestIndent + (body_indent ? kBlockBodyIndentOffset : 0),
+        ' ');
   }
 
   line << "Op" << spvOpcodeString(opcode);
@@ -386,6 +820,11 @@ void InstructionDisassembler::EmitSectionComment(
   auto opcode = static_cast<spv::Op>(inst.opcode);
   if (comment_ && opcode == spv::Op::OpFunction) {
     stream_ << std::endl;
+    if (nested_indent_) {
+      // Double the empty lines between Function sections since nested_indent_
+      // also separates blocks by a blank.
+      stream_ << std::endl;
+    }
     stream_ << std::string(indent_, ' ');
     stream_ << "; Function " << name_mapper_(inst.result_id) << std::endl;
   }

--- a/source/disassemble.h
+++ b/source/disassemble.h
@@ -58,6 +58,11 @@ class InstructionDisassembler {
   // Emits the assembly text for the given instruction.
   void EmitInstruction(const spv_parsed_instruction_t& inst,
                        size_t inst_byte_offset);
+  // Same as EmitInstruction, but only for block instructions (including
+  // OpLabel) and useful for nested indentation.  If nested indentation is not
+  // desired, EmitInstruction can still be used for block instructions.
+  void EmitInstructionInBlock(const spv_parsed_instruction_t& inst,
+                              size_t inst_byte_offset, uint32_t block_indent);
 
   // Emits a comment between different sections of the module.
   void EmitSectionComment(const spv_parsed_instruction_t& inst,
@@ -82,6 +87,10 @@ class InstructionDisassembler {
   void SetRed(std::ostream& stream) const;
   void SetGreen(std::ostream& stream) const;
 
+  void EmitInstructionImpl(const spv_parsed_instruction_t& inst,
+                           size_t inst_byte_offset, uint32_t block_indent,
+                           bool is_in_block);
+
   // Emits an operand for the given instruction, where the instruction
   // is at offset words from the start of the binary.
   void EmitOperand(std::ostream& stream, const spv_parsed_instruction_t& inst,
@@ -97,10 +106,11 @@ class InstructionDisassembler {
 
   const spvtools::AssemblyGrammar& grammar_;
   std::ostream& stream_;
-  const bool print_;   // Should we also print to the standard output stream?
-  const bool color_;   // Should we print in colour?
-  const int indent_;   // How much to indent. 0 means don't indent
-  const int comment_;  // Should we comment the source
+  const bool print_;  // Should we also print to the standard output stream?
+  const bool color_;  // Should we print in colour?
+  const int indent_;  // How much to indent. 0 means don't indent
+  const bool nested_indent_;     // Whether indentation should indicate nesting
+  const int comment_;            // Should we comment the source
   const bool show_byte_offset_;  // Should we print byte offset, in hex?
   spvtools::NameMapper name_mapper_;
 

--- a/source/opt/build_module.h
+++ b/source/opt/build_module.h
@@ -24,7 +24,7 @@
 
 namespace spvtools {
 
-// Builds an Module returns the owning IRContext from the given SPIR-V
+// Builds a Module and returns the owning IRContext from the given SPIR-V
 // |binary|. |size| specifies number of words in |binary|. The |binary| will be
 // decoded according to the given target |env|. Returns nullptr if errors occur
 // and sends the errors to |consumer|.  When |extra_line_tracking| is true,
@@ -41,7 +41,7 @@ std::unique_ptr<opt::IRContext> BuildModule(spv_target_env env,
                                             const uint32_t* binary,
                                             size_t size);
 
-// Builds an Module and returns the owning IRContext from the given
+// Builds a Module and returns the owning IRContext from the given
 // SPIR-V assembly |text|.  The |text| will be encoded according to the given
 // target |env|. Returns nullptr if errors occur and sends the errors to
 // |consumer|.

--- a/test/binary_to_text.literal_test.cpp
+++ b/test/binary_to_text.literal_test.cpp
@@ -33,6 +33,7 @@ TEST_P(RoundTripLiteralsTest, Sample) {
   for (bool endian_swap : kSwapEndians) {
     EXPECT_THAT(
         EncodeAndDecodeSuccessfully(GetParam(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                                    SPV_TEXT_TO_BINARY_OPTION_NONE,
                                     SPV_ENV_UNIVERSAL_1_0, endian_swap),
         Eq(GetParam()));
   }
@@ -68,6 +69,7 @@ TEST_P(RoundTripSpecialCaseLiteralsTest, Sample) {
   for (bool endian_swap : kSwapEndians) {
     EXPECT_THAT(EncodeAndDecodeSuccessfully(std::get<0>(GetParam()),
                                             SPV_BINARY_TO_TEXT_OPTION_NONE,
+                                            SPV_TEXT_TO_BINARY_OPTION_NONE,
                                             SPV_ENV_UNIVERSAL_1_0, endian_swap),
                 Eq(std::get<1>(GetParam())));
   }

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -247,9 +247,9 @@ using RoundTripInstructionsTest = spvtest::TextToBinaryTestBase<
     ::testing::TestWithParam<std::tuple<spv_target_env, std::string>>>;
 
 TEST_P(RoundTripInstructionsTest, Sample) {
-  EXPECT_THAT(EncodeAndDecodeSuccessfully(std::get<1>(GetParam()),
-                                          SPV_BINARY_TO_TEXT_OPTION_NONE,
-                                          std::get<0>(GetParam())),
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  std::get<1>(GetParam()), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                  SPV_TEXT_TO_BINARY_OPTION_NONE, std::get<0>(GetParam())),
               Eq(std::get<1>(GetParam())));
 }
 
@@ -462,6 +462,1462 @@ OpStore %2 %3 Aligned|Volatile 4 ; bogus, but not indented
   EXPECT_THAT(
       EncodeAndDecodeSuccessfully(input, SPV_BINARY_TO_TEXT_OPTION_INDENT),
       expected);
+}
+
+TEST_F(IndentTest, NestedIf) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %100 "main"
+OpExecutionMode %100 OriginUpperLeft
+OpName %var "var"
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%bool = OpTypeBool
+%5 = OpConstantNull %bool
+%true = OpConstantTrue %bool
+%false = OpConstantFalse %bool
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%uint_42 = OpConstant %uint 42
+%int_42 = OpConstant %int 42
+%13 = OpTypeFunction %uint
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_7 = OpConstant %uint 7
+%uint_8 = OpConstant %uint 8
+%uint_10 = OpConstant %uint 10
+%uint_20 = OpConstant %uint 20
+%uint_30 = OpConstant %uint 30
+%uint_40 = OpConstant %uint 40
+%uint_50 = OpConstant %uint 50
+%uint_90 = OpConstant %uint 90
+%uint_99 = OpConstant %uint 99
+%_ptr_Private_uint = OpTypePointer Private %uint
+%var = OpVariable %_ptr_Private_uint Private
+%uint_999 = OpConstant %uint 999
+%100 = OpFunction %void None %3
+%10 = OpLabel
+OpStore %var %uint_0
+OpSelectionMerge %99 None
+OpBranchConditional %5 %30 %40
+%30 = OpLabel
+OpStore %var %uint_1
+OpBranch %99
+%40 = OpLabel
+OpStore %var %uint_2
+OpBranch %99
+%99 = OpLabel
+OpStore %var %uint_999
+OpReturn
+OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %20 = OpConstant %8 6
+         %21 = OpConstant %8 7
+         %22 = OpConstant %8 8
+         %23 = OpConstant %8 10
+         %24 = OpConstant %8 20
+         %25 = OpConstant %8 30
+         %26 = OpConstant %8 40
+         %27 = OpConstant %8 50
+         %28 = OpConstant %8 90
+         %29 = OpConstant %8 99
+         %31 = OpTypePointer Private %8
+          %1 = OpVariable %31 Private
+         %32 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+
+         %10 = OpLabel
+                 OpStore %1 %14
+                 OpSelectionMerge %99 None
+                 OpBranchConditional %5 %30 %40
+
+         %30 =     OpLabel
+                     OpStore %1 %15
+                     OpBranch %99
+
+         %40 =     OpLabel
+                     OpStore %1 %16
+                     OpBranch %99
+
+         %99 = OpLabel
+                 OpStore %1 %32
+                 OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, NestedWhile) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %100 "main"
+OpExecutionMode %100 OriginUpperLeft
+OpName %var "var"
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%bool = OpTypeBool
+%5 = OpConstantNull %bool
+%true = OpConstantTrue %bool
+%false = OpConstantFalse %bool
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%uint_42 = OpConstant %uint 42
+%int_42 = OpConstant %int 42
+%13 = OpTypeFunction %uint
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_7 = OpConstant %uint 7
+%uint_8 = OpConstant %uint 8
+%uint_10 = OpConstant %uint 10
+%uint_20 = OpConstant %uint 20
+%uint_30 = OpConstant %uint 30
+%uint_40 = OpConstant %uint 40
+%uint_50 = OpConstant %uint 50
+%uint_90 = OpConstant %uint 90
+%uint_99 = OpConstant %uint 99
+%_ptr_Private_uint = OpTypePointer Private %uint
+%var = OpVariable %_ptr_Private_uint Private
+%uint_999 = OpConstant %uint 999
+%100 = OpFunction %void None %3
+%10 = OpLabel
+OpStore %var %uint_0
+OpBranch %20
+%20 = OpLabel
+OpStore %var %uint_1
+OpLoopMerge %99 %20 None
+OpBranch %80
+%80 = OpLabel
+OpStore %var %uint_2
+OpBranchConditional %5 %99 %20
+%99 = OpLabel
+OpStore %var %uint_3
+OpReturn
+OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %30 = OpConstant %8 99
+         %31 = OpTypePointer Private %8
+          %1 = OpVariable %31 Private
+         %32 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+
+         %10 = OpLabel
+                 OpStore %1 %14
+                 OpBranch %20
+
+         %20 = OpLabel
+                 OpStore %1 %15
+                 OpLoopMerge %99 %20 None
+                 OpBranch %80
+
+         %80 =     OpLabel
+                     OpStore %1 %16
+                     OpBranchConditional %5 %99 %20
+
+         %99 = OpLabel
+                 OpStore %1 %17
+                 OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, NestedLoopInLoop) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %100 "main"
+OpExecutionMode %100 OriginUpperLeft
+OpName %var "var"
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%bool = OpTypeBool
+%5 = OpConstantNull %bool
+%true = OpConstantTrue %bool
+%false = OpConstantFalse %bool
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%uint_42 = OpConstant %uint 42
+%int_42 = OpConstant %int 42
+%13 = OpTypeFunction %uint
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_7 = OpConstant %uint 7
+%uint_8 = OpConstant %uint 8
+%uint_10 = OpConstant %uint 10
+%uint_20 = OpConstant %uint 20
+%uint_30 = OpConstant %uint 30
+%uint_40 = OpConstant %uint 40
+%uint_50 = OpConstant %uint 50
+%uint_90 = OpConstant %uint 90
+%uint_99 = OpConstant %uint 99
+%_ptr_Private_uint = OpTypePointer Private %uint
+%var = OpVariable %_ptr_Private_uint Private
+%uint_999 = OpConstant %uint 999
+%100 = OpFunction %void None %3
+%10 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpLoopMerge %99 %50 None
+OpBranchConditional %5 %30 %99
+%30 = OpLabel
+OpLoopMerge %49 %40 None
+OpBranchConditional %true %35 %49
+%35 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %40
+%40 = OpLabel
+OpBranch %30
+%49 = OpLabel
+OpBranch %50
+%50 = OpLabel
+OpBranch %20
+%99 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+
+         %10 = OpLabel
+                 OpBranch %20
+
+         %20 = OpLabel
+                 OpLoopMerge %99 %50 None
+                 OpBranchConditional %5 %30 %99
+
+         %30 =     OpLabel
+                     OpLoopMerge %49 %40 None
+                     OpBranchConditional %6 %35 %49
+
+         %35 =         OpLabel
+                         OpBranch %37
+
+         %37 =         OpLabel
+                         OpBranch %40
+
+         %40 =       OpLabel
+                       OpBranch %30
+
+         %49 =     OpLabel
+                     OpBranch %50
+
+         %50 =   OpLabel
+                   OpBranch %20
+
+         %99 = OpLabel
+                 OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, NestedSwitch) {
+  const std::string input = R"(
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %100 "main"
+OpExecutionMode %100 OriginUpperLeft
+OpName %var "var"
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%bool = OpTypeBool
+%5 = OpConstantNull %bool
+%true = OpConstantTrue %bool
+%false = OpConstantFalse %bool
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%uint_42 = OpConstant %uint 42
+%int_42 = OpConstant %int 42
+%13 = OpTypeFunction %uint
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_7 = OpConstant %uint 7
+%uint_8 = OpConstant %uint 8
+%uint_10 = OpConstant %uint 10
+%uint_20 = OpConstant %uint 20
+%uint_30 = OpConstant %uint 30
+%uint_40 = OpConstant %uint 40
+%uint_50 = OpConstant %uint 50
+%uint_90 = OpConstant %uint 90
+%uint_99 = OpConstant %uint 99
+%_ptr_Private_uint = OpTypePointer Private %uint
+%var = OpVariable %_ptr_Private_uint Private
+%uint_999 = OpConstant %uint 999
+%100 = OpFunction %void None %3
+%10 = OpLabel
+OpSelectionMerge %99 None
+OpSwitch %uint_42 %80 20 %20 30 %30
+%20 = OpLabel
+OpBranch %80
+%80 = OpLabel
+OpBranch %30
+%30 = OpLabel
+OpBranch %99
+%99 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+
+         %10 = OpLabel
+                 OpSelectionMerge %99 None
+                 OpSwitch %11 %80 20 %20 30 %30
+
+         %20 =     OpLabel
+                     OpBranch %80
+
+         %80 =     OpLabel
+                     OpBranch %30
+
+         %30 =     OpLabel
+                     OpBranch %99
+
+         %99 = OpLabel
+                 OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, ReorderedIf) {
+  const std::string input = R"(
+               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+         %10 = OpLabel
+               OpSelectionMerge %99 None
+               OpBranchConditional %5 %20 %50
+         %99 = OpLabel
+               OpReturn
+         %20 = OpLabel
+               OpSelectionMerge %49 None
+               OpBranchConditional %5 %30 %40
+         %49 = OpLabel
+               OpBranch %99
+         %40 = OpLabel
+               OpBranch %49
+         %30 = OpLabel
+               OpBranch %49
+         %50 = OpLabel
+               OpSelectionMerge %79 None
+               OpBranchConditional %5 %60 %70
+         %79 = OpLabel
+               OpBranch %99
+         %60 = OpLabel
+               OpBranch %79
+         %70 = OpLabel
+               OpBranch %79
+               OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+         %10 = OpLabel
+               OpSelectionMerge %99 None
+               OpBranchConditional %5 %20 %50
+         %20 = OpLabel
+               OpSelectionMerge %49 None
+               OpBranchConditional %5 %30 %40
+         %30 = OpLabel
+               OpBranch %49
+         %40 = OpLabel
+               OpBranch %49
+         %49 = OpLabel
+               OpBranch %99
+         %50 = OpLabel
+               OpSelectionMerge %79 None
+               OpBranchConditional %5 %60 %70
+         %60 = OpLabel
+               OpBranch %79
+         %70 = OpLabel
+               OpBranch %79
+         %79 = OpLabel
+               OpBranch %99
+         %99 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, ReorderedFallThroughInSwitch) {
+  const std::string input = R"(
+               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+         %10 = OpLabel
+               OpSelectionMerge %99 None
+               OpSwitch %11 %50 20 %20 50 %50
+         %99 = OpLabel
+               OpReturn
+         %20 = OpLabel
+               OpSelectionMerge %49 None
+               OpBranchConditional %5 %30 %40
+         %49 = OpLabel
+               OpBranchConditional %5 %99 %50
+         %30 = OpLabel
+               OpBranch %49
+         %40 = OpLabel
+               OpBranch %49
+         %50 = OpLabel
+               OpSelectionMerge %79 None
+               OpBranchConditional %5 %60 %70
+         %79 = OpLabel
+               OpBranch %99
+         %60 = OpLabel
+               OpBranch %79
+         %70 = OpLabel
+               OpBranch %79
+               OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Fragment %100 "main"
+               OpExecutionMode %100 OriginUpperLeft
+               OpName %1 "var"
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %4 = OpTypeBool
+          %5 = OpConstantNull %4
+          %6 = OpConstantTrue %4
+          %7 = OpConstantFalse %4
+          %8 = OpTypeInt 32 0
+          %9 = OpTypeInt 32 1
+         %11 = OpConstant %8 42
+         %12 = OpConstant %9 42
+         %13 = OpTypeFunction %8
+         %14 = OpConstant %8 0
+         %15 = OpConstant %8 1
+         %16 = OpConstant %8 2
+         %17 = OpConstant %8 3
+         %18 = OpConstant %8 4
+         %19 = OpConstant %8 5
+         %21 = OpConstant %8 6
+         %22 = OpConstant %8 7
+         %23 = OpConstant %8 8
+         %24 = OpConstant %8 10
+         %25 = OpConstant %8 20
+         %26 = OpConstant %8 30
+         %27 = OpConstant %8 40
+         %28 = OpConstant %8 50
+         %29 = OpConstant %8 90
+         %31 = OpConstant %8 99
+         %32 = OpTypePointer Private %8
+          %1 = OpVariable %32 Private
+         %33 = OpConstant %8 999
+        %100 = OpFunction %2 None %3
+         %10 = OpLabel
+               OpSelectionMerge %99 None
+               OpSwitch %11 %50 20 %20 50 %50
+         %20 = OpLabel
+               OpSelectionMerge %49 None
+               OpBranchConditional %5 %30 %40
+         %30 = OpLabel
+               OpBranch %49
+         %40 = OpLabel
+               OpBranch %49
+         %49 = OpLabel
+               OpBranchConditional %5 %99 %50
+         %50 = OpLabel
+               OpSelectionMerge %79 None
+               OpBranchConditional %5 %60 %70
+         %60 = OpLabel
+               OpBranch %79
+         %70 = OpLabel
+               OpBranch %79
+         %79 = OpLabel
+               OpBranch %99
+         %99 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
+}
+
+TEST_F(IndentTest, ReorderedNested) {
+  const std::string input = R"(
+OpCapability Shader
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %4 "main" %204
+OpExecutionMode %4 OriginUpperLeft
+OpSource GLSL 450
+OpName %4 "main"
+OpName %16 "ff(vf2;f1;"
+OpName %14 "g"
+OpName %15 "f"
+OpName %19 "vg"
+OpName %20 "Block140"
+OpMemberName %20 0 "a"
+OpMemberName %20 1 "b"
+OpName %22 "b140"
+OpName %35 "sv"
+OpName %39 "s"
+OpName %46 "f"
+OpName %51 "g"
+OpName %57 "x"
+OpName %69 "param"
+OpName %75 "i"
+OpName %80 "vc"
+OpName %88 "j"
+OpName %95 "size"
+OpName %174 "v"
+OpName %187 "i"
+OpName %204 "o_color"
+OpMemberDecorate %20 0 Offset 0
+OpMemberDecorate %20 1 Offset 16
+OpDecorate %20 Block
+OpDecorate %22 DescriptorSet 1
+OpDecorate %22 Binding 0
+OpDecorate %39 DescriptorSet 0
+OpDecorate %39 Binding 1
+OpDecorate %95 SpecId 20
+OpDecorate %204 Location 2
+%2 = OpTypeVoid
+%3 = OpTypeFunction %2
+%6 = OpTypeFloat 32
+%7 = OpTypeVector %6 2
+%8 = OpTypePointer Function %7
+%9 = OpTypeVector %6 4
+%10 = OpTypeInt 32 0
+%11 = OpConstant %10 2
+%12 = OpTypeArray %9 %11
+%13 = OpTypeFunction %12 %8 %6
+%18 = OpTypePointer Private %9
+%19 = OpVariable %18 Private
+%20 = OpTypeStruct %6 %9
+%21 = OpTypePointer Uniform %20
+%22 = OpVariable %21 Uniform
+%23 = OpTypeInt 32 1
+%24 = OpConstant %23 1
+%25 = OpTypePointer Uniform %9
+%28 = OpConstant %6 0
+%29 = OpConstantComposite %9 %28 %28 %28 %28
+%34 = OpTypePointer Function %9
+%36 = OpTypeImage %6 2D 0 0 0 1 Unknown
+%37 = OpTypeSampledImage %36
+%38 = OpTypePointer UniformConstant %37
+%39 = OpVariable %38 UniformConstant
+%41 = OpConstantComposite %7 %28 %28
+%45 = OpTypePointer Function %6
+%47 = OpConstant %23 0
+%48 = OpTypePointer Uniform %6
+%53 = OpConstant %6 1
+%55 = OpTypeBool
+%56 = OpTypePointer Function %55
+%58 = OpConstant %10 0
+%59 = OpTypePointer Private %6
+%74 = OpTypePointer Function %23
+%87 = OpTypePointer Function %10
+%95 = OpSpecConstant %10 2
+%100 = OpConstant %10 1
+%109 = OpConstantComposite %9 %53 %53 %53 %53
+%127 = OpConstant %23 10
+%139 = OpConstant %6 2
+%143 = OpConstant %6 3
+%158 = OpConstant %6 4
+%177 = OpConstant %6 0.5
+%195 = OpConstant %23 100
+%202 = OpTypeVector %10 4
+%203 = OpTypePointer Output %202
+%204 = OpVariable %203 Output
+%4 = OpFunction %2 None %3
+%5 = OpLabel
+%35 = OpVariable %34 Function
+%46 = OpVariable %45 Function
+%51 = OpVariable %45 Function
+%57 = OpVariable %56 Function
+%69 = OpVariable %8 Function
+%75 = OpVariable %74 Function
+%80 = OpVariable %34 Function
+%88 = OpVariable %87 Function
+%174 = OpVariable %45 Function
+%187 = OpVariable %74 Function
+%26 = OpAccessChain %25 %22 %24
+%27 = OpLoad %9 %26
+OpStore %19 %27
+%40 = OpLoad %37 %39
+%42 = OpImageSampleImplicitLod %9 %40 %41
+%43 = OpLoad %9 %19
+%44 = OpFAdd %9 %42 %43
+OpStore %35 %44
+%49 = OpAccessChain %48 %22 %47
+%50 = OpLoad %6 %49
+OpStore %46 %50
+%52 = OpLoad %6 %46
+%54 = OpFAdd %6 %52 %53
+OpStore %51 %54
+%60 = OpAccessChain %59 %19 %58
+%61 = OpLoad %6 %60
+%62 = OpFOrdGreaterThan %55 %61 %28
+OpSelectionMerge %64 None
+OpBranchConditional %62 %63 %64
+%64 = OpLabel
+%73 = OpPhi %55 %62 %5 %72 %63
+OpStore %57 %73
+OpStore %75 %47
+OpBranch %76
+%197 = OpLabel
+OpBranch %190
+%63 = OpLabel
+%65 = OpLoad %6 %46
+%66 = OpLoad %6 %51
+%67 = OpCompositeConstruct %7 %65 %66
+%68 = OpLoad %6 %51
+OpStore %69 %67
+%70 = OpFunctionCall %12 %16 %69 %68
+%71 = OpCompositeExtract %6 %70 0 0
+%72 = OpFOrdGreaterThan %55 %71 %28
+OpBranch %64
+%77 = OpLabel
+%81 = OpLoad %9 %19
+OpStore %80 %81
+%82 = OpAccessChain %45 %80 %58
+%83 = OpLoad %6 %82
+%84 = OpFOrdGreaterThan %55 %83 %28
+OpSelectionMerge %86 None
+OpBranchConditional %84 %85 %113
+%85 = OpLabel
+OpStore %88 %58
+OpBranch %89
+%89 = OpLabel
+OpLoopMerge %91 %92 None
+OpBranch %93
+%93 = OpLabel
+%94 = OpLoad %10 %88
+%96 = OpULessThan %55 %94 %95
+OpBranchConditional %96 %90 %91
+%105 = OpLabel
+OpBranch %92
+%198 = OpLabel
+OpBranch %191
+%163 = OpLabel
+OpBranch %136
+%104 = OpLabel
+OpBranch %91
+%76 = OpLabel
+OpLoopMerge %78 %79 None
+OpBranch %77
+%92 = OpLabel
+%107 = OpLoad %10 %88
+%108 = OpIAdd %10 %107 %24
+OpStore %88 %108
+OpBranch %89
+%91 = OpLabel
+%110 = OpLoad %9 %80
+%111 = OpFAdd %9 %110 %109
+OpStore %80 %111
+OpBranch %79
+%113 = OpLabel
+%114 = OpLoad %9 %80
+%115 = OpFSub %9 %114 %109
+OpStore %80 %115
+OpBranch %86
+%132 = OpLabel
+%137 = OpLoad %6 %51
+%138 = OpFAdd %6 %137 %53
+OpStore %51 %138
+OpBranch %133
+%86 = OpLabel
+%116 = OpAccessChain %45 %80 %100
+%117 = OpLoad %6 %116
+%118 = OpFOrdGreaterThan %55 %117 %28
+OpSelectionMerge %120 None
+OpBranchConditional %118 %119 %120
+%119 = OpLabel
+OpBranch %78
+%120 = OpLabel
+%122 = OpAccessChain %45 %80 %11
+%123 = OpLoad %6 %122
+%124 = OpFAdd %6 %123 %53
+%125 = OpAccessChain %45 %80 %11
+OpStore %125 %124
+OpBranch %79
+%79 = OpLabel
+%126 = OpLoad %23 %75
+%128 = OpSLessThan %55 %126 %127
+OpBranchConditional %128 %76 %78
+%78 = OpLabel
+%129 = OpAccessChain %48 %22 %47
+%130 = OpLoad %6 %129
+%131 = OpConvertFToS %23 %130
+OpSelectionMerge %136 None
+OpSwitch %131 %135 0 %132 1 %132 2 %132 3 %133 4 %134
+%90 = OpLabel
+%97 = OpLoad %9 %19
+%98 = OpLoad %9 %80
+%99 = OpFAdd %9 %98 %97
+OpStore %80 %99
+%101 = OpAccessChain %45 %80 %100
+%102 = OpLoad %6 %101
+%103 = OpFOrdLessThan %55 %102 %28
+OpSelectionMerge %105 None
+OpBranchConditional %103 %104 %105
+%161 = OpLabel
+OpLoopMerge %163 %164 None
+OpBranch %165
+%165 = OpLabel
+%166 = OpLoad %6 %51
+%167 = OpFOrdLessThan %55 %166 %139
+OpBranchConditional %167 %162 %163
+%164 = OpLabel
+OpBranch %161
+%162 = OpLabel
+%168 = OpLoad %6 %46
+%169 = OpFOrdLessThan %55 %168 %53
+OpSelectionMerge %171 None
+OpBranchConditional %169 %170 %171
+%135 = OpLabel
+%159 = OpLoad %6 %51
+%160 = OpFAdd %6 %159 %158
+OpStore %51 %160
+OpBranch %161
+%133 = OpLabel
+%140 = OpLoad %6 %51
+%141 = OpFAdd %6 %140 %139
+OpStore %51 %141
+OpBranch %136
+%134 = OpLabel
+%144 = OpLoad %6 %51
+%145 = OpFAdd %6 %144 %143
+OpStore %51 %145
+OpBranch %146
+%146 = OpLabel
+OpLoopMerge %148 %149 None
+OpBranch %150
+%150 = OpLabel
+%151 = OpLoad %6 %51
+%152 = OpFOrdLessThan %55 %151 %139
+OpBranchConditional %152 %147 %148
+%147 = OpLabel
+%153 = OpLoad %6 %46
+%154 = OpFOrdLessThan %55 %153 %53
+OpSelectionMerge %156 None
+OpBranchConditional %154 %155 %156
+%155 = OpLabel
+OpBranch %148
+%156 = OpLabel
+OpBranch %149
+%149 = OpLabel
+OpBranch %146
+%148 = OpLabel
+OpBranch %135
+%136 = OpLabel
+OpStore %174 %53
+%175 = OpAccessChain %45 %35 %58
+%176 = OpLoad %6 %175
+%178 = OpFOrdLessThanEqual %55 %176 %177
+OpSelectionMerge %180 None
+OpBranchConditional %178 %179 %181
+%179 = OpLabel
+OpStore %174 %28
+OpBranch %180
+%185 = OpLabel
+OpStore %174 %139
+OpBranch %186
+%181 = OpLabel
+%182 = OpAccessChain %45 %35 %58
+%183 = OpLoad %6 %182
+%184 = OpFOrdGreaterThanEqual %55 %183 %177
+OpSelectionMerge %186 None
+OpBranchConditional %184 %185 %186
+%170 = OpLabel
+OpBranch %163
+%171 = OpLabel
+OpBranch %164
+%186 = OpLabel
+OpBranch %180
+%188 = OpLabel
+OpLoopMerge %190 %191 None
+OpBranch %189
+%189 = OpLabel
+%192 = OpLoad %9 %19
+%193 = OpFAdd %9 %192 %109
+OpStore %19 %193
+%194 = OpLoad %23 %187
+%196 = OpSGreaterThan %55 %194 %195
+OpSelectionMerge %198 None
+OpBranchConditional %196 %197 %198
+%180 = OpLabel
+OpStore %187 %47
+OpBranch %188
+%191 = OpLabel
+%200 = OpLoad %23 %187
+%201 = OpIAdd %23 %200 %24
+OpStore %187 %201
+OpBranch %188
+%190 = OpLabel
+OpReturn
+OpFunctionEnd
+%16 = OpFunction %12 None %13
+%14 = OpFunctionParameter %8
+%15 = OpFunctionParameter %6
+%17 = OpLabel
+%30 = OpCompositeConstruct %9 %15 %15 %15 %15
+%31 = OpCompositeConstruct %12 %29 %30
+OpReturnValue %31
+OpFunctionEnd
+)";
+  const std::string expected =
+      R"(               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %204
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource GLSL 450
+               OpName %4 "main"
+               OpName %16 "ff(vf2;f1;"
+               OpName %14 "g"
+               OpName %15 "f"
+               OpName %19 "vg"
+               OpName %20 "Block140"
+               OpMemberName %20 0 "a"
+               OpMemberName %20 1 "b"
+               OpName %22 "b140"
+               OpName %35 "sv"
+               OpName %39 "s"
+               OpName %46 "f"
+               OpName %51 "g"
+               OpName %57 "x"
+               OpName %69 "param"
+               OpName %75 "i"
+               OpName %80 "vc"
+               OpName %88 "j"
+               OpName %95 "size"
+               OpName %174 "v"
+               OpName %187 "i"
+               OpName %204 "o_color"
+               OpMemberDecorate %20 0 Offset 0
+               OpMemberDecorate %20 1 Offset 16
+               OpDecorate %20 Block
+               OpDecorate %22 DescriptorSet 1
+               OpDecorate %22 Binding 0
+               OpDecorate %39 DescriptorSet 0
+               OpDecorate %39 Binding 1
+               OpDecorate %95 SpecId 20
+               OpDecorate %204 Location 2
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypeVector %6 2
+          %8 = OpTypePointer Function %7
+          %9 = OpTypeVector %6 4
+         %10 = OpTypeInt 32 0
+         %11 = OpConstant %10 2
+         %12 = OpTypeArray %9 %11
+         %13 = OpTypeFunction %12 %8 %6
+         %18 = OpTypePointer Private %9
+         %19 = OpVariable %18 Private
+         %20 = OpTypeStruct %6 %9
+         %21 = OpTypePointer Uniform %20
+         %22 = OpVariable %21 Uniform
+         %23 = OpTypeInt 32 1
+         %24 = OpConstant %23 1
+         %25 = OpTypePointer Uniform %9
+         %28 = OpConstant %6 0
+         %29 = OpConstantComposite %9 %28 %28 %28 %28
+         %34 = OpTypePointer Function %9
+         %36 = OpTypeImage %6 2D 0 0 0 1 Unknown
+         %37 = OpTypeSampledImage %36
+         %38 = OpTypePointer UniformConstant %37
+         %39 = OpVariable %38 UniformConstant
+         %41 = OpConstantComposite %7 %28 %28
+         %45 = OpTypePointer Function %6
+         %47 = OpConstant %23 0
+         %48 = OpTypePointer Uniform %6
+         %53 = OpConstant %6 1
+         %55 = OpTypeBool
+         %56 = OpTypePointer Function %55
+         %58 = OpConstant %10 0
+         %59 = OpTypePointer Private %6
+         %74 = OpTypePointer Function %23
+         %87 = OpTypePointer Function %10
+         %95 = OpSpecConstant %10 2
+        %100 = OpConstant %10 1
+        %109 = OpConstantComposite %9 %53 %53 %53 %53
+        %127 = OpConstant %23 10
+        %139 = OpConstant %6 2
+        %143 = OpConstant %6 3
+        %158 = OpConstant %6 4
+        %177 = OpConstant %6 0.5
+        %195 = OpConstant %23 100
+        %202 = OpTypeVector %10 4
+        %203 = OpTypePointer Output %202
+        %204 = OpVariable %203 Output
+          %4 = OpFunction %2 None %3
+
+          %5 = OpLabel
+         %35 =   OpVariable %34 Function
+         %46 =   OpVariable %45 Function
+         %51 =   OpVariable %45 Function
+         %57 =   OpVariable %56 Function
+         %69 =   OpVariable %8 Function
+         %75 =   OpVariable %74 Function
+         %80 =   OpVariable %34 Function
+         %88 =   OpVariable %87 Function
+        %174 =   OpVariable %45 Function
+        %187 =   OpVariable %74 Function
+         %26 =   OpAccessChain %25 %22 %24
+         %27 =   OpLoad %9 %26
+                 OpStore %19 %27
+         %40 =   OpLoad %37 %39
+         %42 =   OpImageSampleImplicitLod %9 %40 %41
+         %43 =   OpLoad %9 %19
+         %44 =   OpFAdd %9 %42 %43
+                 OpStore %35 %44
+         %49 =   OpAccessChain %48 %22 %47
+         %50 =   OpLoad %6 %49
+                 OpStore %46 %50
+         %52 =   OpLoad %6 %46
+         %54 =   OpFAdd %6 %52 %53
+                 OpStore %51 %54
+         %60 =   OpAccessChain %59 %19 %58
+         %61 =   OpLoad %6 %60
+         %62 =   OpFOrdGreaterThan %55 %61 %28
+                 OpSelectionMerge %64 None
+                 OpBranchConditional %62 %63 %64
+
+         %63 =     OpLabel
+         %65 =       OpLoad %6 %46
+         %66 =       OpLoad %6 %51
+         %67 =       OpCompositeConstruct %7 %65 %66
+         %68 =       OpLoad %6 %51
+                     OpStore %69 %67
+         %70 =       OpFunctionCall %12 %16 %69 %68
+         %71 =       OpCompositeExtract %6 %70 0 0
+         %72 =       OpFOrdGreaterThan %55 %71 %28
+                     OpBranch %64
+
+         %64 = OpLabel
+         %73 =   OpPhi %55 %62 %5 %72 %63
+                 OpStore %57 %73
+                 OpStore %75 %47
+                 OpBranch %76
+
+         %76 = OpLabel
+                 OpLoopMerge %78 %79 None
+                 OpBranch %77
+
+         %77 =     OpLabel
+         %81 =       OpLoad %9 %19
+                     OpStore %80 %81
+         %82 =       OpAccessChain %45 %80 %58
+         %83 =       OpLoad %6 %82
+         %84 =       OpFOrdGreaterThan %55 %83 %28
+                     OpSelectionMerge %86 None
+                     OpBranchConditional %84 %85 %113
+
+         %85 =         OpLabel
+                         OpStore %88 %58
+                         OpBranch %89
+
+         %89 =         OpLabel
+                         OpLoopMerge %91 %92 None
+                         OpBranch %93
+
+         %93 =             OpLabel
+         %94 =               OpLoad %10 %88
+         %96 =               OpULessThan %55 %94 %95
+                             OpBranchConditional %96 %90 %91
+
+         %90 =                 OpLabel
+         %97 =                   OpLoad %9 %19
+         %98 =                   OpLoad %9 %80
+         %99 =                   OpFAdd %9 %98 %97
+                                 OpStore %80 %99
+        %101 =                   OpAccessChain %45 %80 %100
+        %102 =                   OpLoad %6 %101
+        %103 =                   OpFOrdLessThan %55 %102 %28
+                                 OpSelectionMerge %105 None
+                                 OpBranchConditional %103 %104 %105
+
+        %104 =                     OpLabel
+                                     OpBranch %91
+
+        %105 =                 OpLabel
+                                 OpBranch %92
+
+         %92 =           OpLabel
+        %107 =             OpLoad %10 %88
+        %108 =             OpIAdd %10 %107 %24
+                           OpStore %88 %108
+                           OpBranch %89
+
+         %91 =         OpLabel
+        %110 =           OpLoad %9 %80
+        %111 =           OpFAdd %9 %110 %109
+                         OpStore %80 %111
+                         OpBranch %79
+
+        %113 =         OpLabel
+        %114 =           OpLoad %9 %80
+        %115 =           OpFSub %9 %114 %109
+                         OpStore %80 %115
+                         OpBranch %86
+
+         %86 =     OpLabel
+        %116 =       OpAccessChain %45 %80 %100
+        %117 =       OpLoad %6 %116
+        %118 =       OpFOrdGreaterThan %55 %117 %28
+                     OpSelectionMerge %120 None
+                     OpBranchConditional %118 %119 %120
+
+        %119 =         OpLabel
+                         OpBranch %78
+
+        %120 =     OpLabel
+        %122 =       OpAccessChain %45 %80 %11
+        %123 =       OpLoad %6 %122
+        %124 =       OpFAdd %6 %123 %53
+        %125 =       OpAccessChain %45 %80 %11
+                     OpStore %125 %124
+                     OpBranch %79
+
+         %79 =   OpLabel
+        %126 =     OpLoad %23 %75
+        %128 =     OpSLessThan %55 %126 %127
+                   OpBranchConditional %128 %76 %78
+
+         %78 = OpLabel
+        %129 =   OpAccessChain %48 %22 %47
+        %130 =   OpLoad %6 %129
+        %131 =   OpConvertFToS %23 %130
+                 OpSelectionMerge %136 None
+                 OpSwitch %131 %135 0 %132 1 %132 2 %132 3 %133 4 %134
+
+        %132 =     OpLabel
+        %137 =       OpLoad %6 %51
+        %138 =       OpFAdd %6 %137 %53
+                     OpStore %51 %138
+                     OpBranch %133
+
+        %133 =     OpLabel
+        %140 =       OpLoad %6 %51
+        %141 =       OpFAdd %6 %140 %139
+                     OpStore %51 %141
+                     OpBranch %136
+
+        %134 =     OpLabel
+        %144 =       OpLoad %6 %51
+        %145 =       OpFAdd %6 %144 %143
+                     OpStore %51 %145
+                     OpBranch %146
+
+        %146 =     OpLabel
+                     OpLoopMerge %148 %149 None
+                     OpBranch %150
+
+        %150 =         OpLabel
+        %151 =           OpLoad %6 %51
+        %152 =           OpFOrdLessThan %55 %151 %139
+                         OpBranchConditional %152 %147 %148
+
+        %147 =             OpLabel
+        %153 =               OpLoad %6 %46
+        %154 =               OpFOrdLessThan %55 %153 %53
+                             OpSelectionMerge %156 None
+                             OpBranchConditional %154 %155 %156
+
+        %155 =                 OpLabel
+                                 OpBranch %148
+
+        %156 =             OpLabel
+                             OpBranch %149
+
+        %149 =       OpLabel
+                       OpBranch %146
+
+        %148 =     OpLabel
+                     OpBranch %135
+
+        %135 =     OpLabel
+        %159 =       OpLoad %6 %51
+        %160 =       OpFAdd %6 %159 %158
+                     OpStore %51 %160
+                     OpBranch %161
+
+        %161 =     OpLabel
+                     OpLoopMerge %163 %164 None
+                     OpBranch %165
+
+        %165 =         OpLabel
+        %166 =           OpLoad %6 %51
+        %167 =           OpFOrdLessThan %55 %166 %139
+                         OpBranchConditional %167 %162 %163
+
+        %162 =             OpLabel
+        %168 =               OpLoad %6 %46
+        %169 =               OpFOrdLessThan %55 %168 %53
+                             OpSelectionMerge %171 None
+                             OpBranchConditional %169 %170 %171
+
+        %170 =                 OpLabel
+                                 OpBranch %163
+
+        %171 =             OpLabel
+                             OpBranch %164
+
+        %164 =       OpLabel
+                       OpBranch %161
+
+        %163 =     OpLabel
+                     OpBranch %136
+
+        %136 = OpLabel
+                 OpStore %174 %53
+        %175 =   OpAccessChain %45 %35 %58
+        %176 =   OpLoad %6 %175
+        %178 =   OpFOrdLessThanEqual %55 %176 %177
+                 OpSelectionMerge %180 None
+                 OpBranchConditional %178 %179 %181
+
+        %179 =     OpLabel
+                     OpStore %174 %28
+                     OpBranch %180
+
+        %181 =     OpLabel
+        %182 =       OpAccessChain %45 %35 %58
+        %183 =       OpLoad %6 %182
+        %184 =       OpFOrdGreaterThanEqual %55 %183 %177
+                     OpSelectionMerge %186 None
+                     OpBranchConditional %184 %185 %186
+
+        %185 =         OpLabel
+                         OpStore %174 %139
+                         OpBranch %186
+
+        %186 =     OpLabel
+                     OpBranch %180
+
+        %180 = OpLabel
+                 OpStore %187 %47
+                 OpBranch %188
+
+        %188 = OpLabel
+                 OpLoopMerge %190 %191 None
+                 OpBranch %189
+
+        %189 =     OpLabel
+        %192 =       OpLoad %9 %19
+        %193 =       OpFAdd %9 %192 %109
+                     OpStore %19 %193
+        %194 =       OpLoad %23 %187
+        %196 =       OpSGreaterThan %55 %194 %195
+                     OpSelectionMerge %198 None
+                     OpBranchConditional %196 %197 %198
+
+        %197 =         OpLabel
+                         OpBranch %190
+
+        %198 =     OpLabel
+                     OpBranch %191
+
+        %191 =   OpLabel
+        %200 =     OpLoad %23 %187
+        %201 =     OpIAdd %23 %200 %24
+                   OpStore %187 %201
+                   OpBranch %188
+
+        %190 = OpLabel
+                 OpReturn
+               OpFunctionEnd
+         %16 = OpFunction %12 None %13
+         %14 = OpFunctionParameter %8
+         %15 = OpFunctionParameter %6
+
+         %17 = OpLabel
+         %30 =   OpCompositeConstruct %9 %15 %15 %15 %15
+         %31 =   OpCompositeConstruct %12 %29 %30
+                 OpReturnValue %31
+               OpFunctionEnd
+)";
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input,
+                  SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT |
+                      SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
+                  SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+              expected);
 }
 
 using FriendlyNameDisassemblyTest = spvtest::TextToBinaryTest;
@@ -703,216 +2159,416 @@ OpFunctionEnd
 )";
   const std::string expected = R"(               OpCapability Shader
                OpMemoryModel Logical GLSL450
-               OpEntryPoint Fragment %1 "main" %2 %3
-               OpExecutionMode %1 OriginUpperLeft
+               OpEntryPoint Fragment %63 "main" %4 %22
+               OpExecutionMode %63 OriginUpperLeft
 
                ; Debug Information
                OpSource GLSL 450
-               OpName %2 "_ue"                      ; id %2
-               OpName %4 "_uf"                      ; id %4
-               OpName %5 "_ug"                      ; id %5
-               OpName %6 "_uA"                      ; id %6
-               OpMemberName %6 0 "_ux"
-               OpName %7 "_uc"                      ; id %7
-               OpName %8 "_uB"                      ; id %8
-               OpMemberName %8 0 "_ux"
-               OpName %9 "_ud"                      ; id %9
-               OpName %3 "_ucol"                    ; id %3
-               OpName %10 "ANGLEDepthRangeParams"   ; id %10
-               OpMemberName %10 0 "near"
-               OpMemberName %10 1 "far"
-               OpMemberName %10 2 "diff"
-               OpMemberName %10 3 "reserved"
-               OpName %11 "ANGLEUniformBlock"       ; id %11
-               OpMemberName %11 0 "viewport"
-               OpMemberName %11 1 "clipDistancesEnabled"
-               OpMemberName %11 2 "xfbActiveUnpaused"
-               OpMemberName %11 3 "xfbVerticesPerInstance"
-               OpMemberName %11 4 "numSamples"
-               OpMemberName %11 5 "xfbBufferOffsets"
-               OpMemberName %11 6 "acbBufferOffsets"
-               OpMemberName %11 7 "depthRange"
-               OpName %12 "ANGLEUniforms"           ; id %12
-               OpName %13 "_uc"                     ; id %13
-               OpName %14 "_uh"                     ; id %14
-               OpName %15 "_ux"                     ; id %15
-               OpName %16 "_uy"                     ; id %16
-               OpName %17 "_ui"                     ; id %17
-               OpName %1 "main"                     ; id %1
-               OpName %18 "param"                   ; id %18
-               OpName %19 "param"                   ; id %19
-               OpName %20 "param"                   ; id %20
+               OpName %4 "_ue"                      ; id %4
+               OpName %8 "_uf"                      ; id %8
+               OpName %11 "_ug"                     ; id %11
+               OpName %12 "_uA"                     ; id %12
+               OpMemberName %12 0 "_ux"
+               OpName %14 "_uc"                     ; id %14
+               OpName %15 "_uB"                     ; id %15
+               OpMemberName %15 0 "_ux"
+               OpName %20 "_ud"                     ; id %20
+               OpName %22 "_ucol"                   ; id %22
+               OpName %26 "ANGLEDepthRangeParams"   ; id %26
+               OpMemberName %26 0 "near"
+               OpMemberName %26 1 "far"
+               OpMemberName %26 2 "diff"
+               OpMemberName %26 3 "reserved"
+               OpName %27 "ANGLEUniformBlock"       ; id %27
+               OpMemberName %27 0 "viewport"
+               OpMemberName %27 1 "clipDistancesEnabled"
+               OpMemberName %27 2 "xfbActiveUnpaused"
+               OpMemberName %27 3 "xfbVerticesPerInstance"
+               OpMemberName %27 4 "numSamples"
+               OpMemberName %27 5 "xfbBufferOffsets"
+               OpMemberName %27 6 "acbBufferOffsets"
+               OpMemberName %27 7 "depthRange"
+               OpName %29 "ANGLEUniforms"           ; id %29
+               OpName %33 "_uc"                     ; id %33
+               OpName %32 "_uh"                     ; id %32
+               OpName %49 "_ux"                     ; id %49
+               OpName %50 "_uy"                     ; id %50
+               OpName %48 "_ui"                     ; id %48
+               OpName %63 "main"                    ; id %63
+               OpName %65 "param"                   ; id %65
+               OpName %68 "param"                   ; id %68
+               OpName %73 "param"                   ; id %73
 
                ; Annotations
-               OpDecorate %2 Location 0
-               OpDecorate %4 RelaxedPrecision
-               OpDecorate %4 DescriptorSet 0
-               OpDecorate %4 Binding 0
-               OpDecorate %5 DescriptorSet 0
-               OpDecorate %5 Binding 1
-               OpMemberDecorate %6 0 Offset 0
-               OpMemberDecorate %6 0 RelaxedPrecision
-               OpDecorate %6 Block
-               OpDecorate %7 DescriptorSet 0
-               OpDecorate %7 Binding 2
-               OpMemberDecorate %8 0 Offset 0
-               OpMemberDecorate %8 0 RelaxedPrecision
-               OpDecorate %8 BufferBlock
-               OpDecorate %9 DescriptorSet 0
-               OpDecorate %9 Binding 3
-               OpDecorate %3 RelaxedPrecision
-               OpDecorate %3 Location 0
-               OpMemberDecorate %10 0 Offset 0
-               OpMemberDecorate %10 1 Offset 4
-               OpMemberDecorate %10 2 Offset 8
-               OpMemberDecorate %10 3 Offset 12
-               OpMemberDecorate %11 0 Offset 0
-               OpMemberDecorate %11 1 Offset 16
-               OpMemberDecorate %11 2 Offset 20
-               OpMemberDecorate %11 3 Offset 24
-               OpMemberDecorate %11 4 Offset 28
-               OpMemberDecorate %11 5 Offset 32
-               OpMemberDecorate %11 6 Offset 48
-               OpMemberDecorate %11 7 Offset 64
-               OpMemberDecorate %11 2 RelaxedPrecision
-               OpMemberDecorate %11 4 RelaxedPrecision
-               OpDecorate %11 Block
-               OpDecorate %12 DescriptorSet 0
-               OpDecorate %12 Binding 4
-               OpDecorate %14 RelaxedPrecision
-               OpDecorate %13 RelaxedPrecision
-               OpDecorate %21 RelaxedPrecision
+               OpDecorate %4 Location 0
+               OpDecorate %8 RelaxedPrecision
+               OpDecorate %8 DescriptorSet 0
+               OpDecorate %8 Binding 0
+               OpDecorate %11 DescriptorSet 0
+               OpDecorate %11 Binding 1
+               OpMemberDecorate %12 0 Offset 0
+               OpMemberDecorate %12 0 RelaxedPrecision
+               OpDecorate %12 Block
+               OpDecorate %14 DescriptorSet 0
+               OpDecorate %14 Binding 2
+               OpMemberDecorate %15 0 Offset 0
+               OpMemberDecorate %15 0 RelaxedPrecision
+               OpDecorate %15 BufferBlock
+               OpDecorate %20 DescriptorSet 0
+               OpDecorate %20 Binding 3
                OpDecorate %22 RelaxedPrecision
-               OpDecorate %23 RelaxedPrecision
-               OpDecorate %24 RelaxedPrecision
-               OpDecorate %25 RelaxedPrecision
-               OpDecorate %26 RelaxedPrecision
-               OpDecorate %27 RelaxedPrecision
-               OpDecorate %17 RelaxedPrecision
-               OpDecorate %15 RelaxedPrecision
-               OpDecorate %16 RelaxedPrecision
-               OpDecorate %28 RelaxedPrecision
-               OpDecorate %29 RelaxedPrecision
-               OpDecorate %30 RelaxedPrecision
-               OpDecorate %31 RelaxedPrecision
+               OpDecorate %22 Location 0
+               OpMemberDecorate %26 0 Offset 0
+               OpMemberDecorate %26 1 Offset 4
+               OpMemberDecorate %26 2 Offset 8
+               OpMemberDecorate %26 3 Offset 12
+               OpMemberDecorate %27 0 Offset 0
+               OpMemberDecorate %27 1 Offset 16
+               OpMemberDecorate %27 2 Offset 20
+               OpMemberDecorate %27 3 Offset 24
+               OpMemberDecorate %27 4 Offset 28
+               OpMemberDecorate %27 5 Offset 32
+               OpMemberDecorate %27 6 Offset 48
+               OpMemberDecorate %27 7 Offset 64
+               OpMemberDecorate %27 2 RelaxedPrecision
+               OpMemberDecorate %27 4 RelaxedPrecision
+               OpDecorate %27 Block
+               OpDecorate %29 DescriptorSet 0
+               OpDecorate %29 Binding 4
                OpDecorate %32 RelaxedPrecision
                OpDecorate %33 RelaxedPrecision
-               OpDecorate %34 RelaxedPrecision
-               OpDecorate %35 RelaxedPrecision
                OpDecorate %36 RelaxedPrecision
                OpDecorate %37 RelaxedPrecision
-               OpDecorate %19 RelaxedPrecision
                OpDecorate %38 RelaxedPrecision
-               OpDecorate %20 RelaxedPrecision
                OpDecorate %39 RelaxedPrecision
-               OpDecorate %40 RelaxedPrecision
                OpDecorate %41 RelaxedPrecision
                OpDecorate %42 RelaxedPrecision
                OpDecorate %43 RelaxedPrecision
+               OpDecorate %48 RelaxedPrecision
+               OpDecorate %49 RelaxedPrecision
+               OpDecorate %50 RelaxedPrecision
+               OpDecorate %52 RelaxedPrecision
+               OpDecorate %53 RelaxedPrecision
+               OpDecorate %54 RelaxedPrecision
+               OpDecorate %55 RelaxedPrecision
+               OpDecorate %56 RelaxedPrecision
+               OpDecorate %57 RelaxedPrecision
+               OpDecorate %58 RelaxedPrecision
+               OpDecorate %59 RelaxedPrecision
+               OpDecorate %60 RelaxedPrecision
+               OpDecorate %67 RelaxedPrecision
+               OpDecorate %68 RelaxedPrecision
+               OpDecorate %72 RelaxedPrecision
+               OpDecorate %73 RelaxedPrecision
+               OpDecorate %75 RelaxedPrecision
+               OpDecorate %76 RelaxedPrecision
+               OpDecorate %77 RelaxedPrecision
+               OpDecorate %80 RelaxedPrecision
+               OpDecorate %81 RelaxedPrecision
 
                ; Types, variables and constants
-         %44 = OpTypeFloat 32
-         %45 = OpTypeVector %44 4
-         %46 = OpTypeImage %44 2D 0 0 0 1 Unknown
-         %47 = OpTypeSampledImage %46
-         %48 = OpTypeImage %44 2D 0 0 0 2 Rgba8
-          %6 = OpTypeStruct %45                     ; Block
-          %8 = OpTypeStruct %45                     ; BufferBlock
-         %49 = OpTypeInt 32 0
-         %50 = OpConstant %49 2
-         %51 = OpTypeArray %8 %50
-         %52 = OpTypeInt 32 1
-         %53 = OpTypeVector %52 4
-         %54 = OpTypeVector %49 4
-         %10 = OpTypeStruct %44 %44 %44 %44
-         %11 = OpTypeStruct %45 %49 %49 %52 %52 %53 %54 %10     ; Block
-         %55 = OpTypeVector %44 2
-         %56 = OpTypeVector %52 2
-         %57 = OpTypeVoid
-         %58 = OpConstant %49 0
-         %59 = OpConstant %49 1
-         %60 = OpTypePointer Input %45
-         %61 = OpTypePointer UniformConstant %47
-         %62 = OpTypePointer UniformConstant %48
-         %63 = OpTypePointer Uniform %6
-         %64 = OpTypePointer Uniform %51
-         %65 = OpTypePointer Output %45
-         %66 = OpTypePointer Uniform %11
-         %67 = OpTypePointer Function %45
-         %68 = OpTypePointer Uniform %45
-         %69 = OpTypeFunction %45 %67
-         %70 = OpTypeFunction %45 %67 %67
-         %71 = OpTypeFunction %57
-          %2 = OpVariable %60 Input                 ; Location 0
-          %4 = OpVariable %61 UniformConstant       ; RelaxedPrecision, DescriptorSet 0, Binding 0
-          %5 = OpVariable %62 UniformConstant       ; DescriptorSet 0, Binding 1
-          %7 = OpVariable %63 Uniform               ; DescriptorSet 0, Binding 2
-          %9 = OpVariable %64 Uniform               ; DescriptorSet 0, Binding 3
-          %3 = OpVariable %65 Output                ; RelaxedPrecision, Location 0
-         %12 = OpVariable %66 Uniform               ; DescriptorSet 0, Binding 4
+          %1 = OpTypeFloat 32
+          %2 = OpTypeVector %1 4
+          %5 = OpTypeImage %1 2D 0 0 0 1 Unknown
+          %6 = OpTypeSampledImage %5
+          %9 = OpTypeImage %1 2D 0 0 0 2 Rgba8
+         %12 = OpTypeStruct %2                      ; Block
+         %15 = OpTypeStruct %2                      ; BufferBlock
+         %16 = OpTypeInt 32 0
+         %17 = OpConstant %16 2
+         %18 = OpTypeArray %15 %17
+         %23 = OpTypeInt 32 1
+         %24 = OpTypeVector %23 4
+         %25 = OpTypeVector %16 4
+         %26 = OpTypeStruct %1 %1 %1 %1
+         %27 = OpTypeStruct %2 %16 %16 %23 %23 %24 %25 %26  ; Block
+         %35 = OpTypeVector %1 2
+         %40 = OpTypeVector %23 2
+         %61 = OpTypeVoid
+         %69 = OpConstant %16 0
+         %78 = OpConstant %16 1
+          %3 = OpTypePointer Input %2
+          %7 = OpTypePointer UniformConstant %6
+         %10 = OpTypePointer UniformConstant %9
+         %13 = OpTypePointer Uniform %12
+         %19 = OpTypePointer Uniform %18
+         %21 = OpTypePointer Output %2
+         %28 = OpTypePointer Uniform %27
+         %30 = OpTypePointer Function %2
+         %70 = OpTypePointer Uniform %2
+         %31 = OpTypeFunction %2 %30
+         %47 = OpTypeFunction %2 %30 %30
+         %62 = OpTypeFunction %61
+          %4 = OpVariable %3 Input                  ; Location 0
+          %8 = OpVariable %7 UniformConstant        ; RelaxedPrecision, DescriptorSet 0, Binding 0
+         %11 = OpVariable %10 UniformConstant       ; DescriptorSet 0, Binding 1
+         %14 = OpVariable %13 Uniform               ; DescriptorSet 0, Binding 2
+         %20 = OpVariable %19 Uniform               ; DescriptorSet 0, Binding 3
+         %22 = OpVariable %21 Output                ; RelaxedPrecision, Location 0
+         %29 = OpVariable %28 Uniform               ; DescriptorSet 0, Binding 4
 
-               ; Function 14
-         %14 = OpFunction %45 None %69              ; RelaxedPrecision
-         %13 = OpFunctionParameter %67              ; RelaxedPrecision
-         %72 = OpLabel
-         %21 = OpLoad %47 %4                        ; RelaxedPrecision
-         %22 = OpLoad %45 %13                       ; RelaxedPrecision
-         %23 = OpVectorShuffle %55 %22 %22 0 1      ; RelaxedPrecision
-         %24 = OpImageSampleImplicitLod %45 %21 %23     ; RelaxedPrecision
-         %25 = OpLoad %45 %13                           ; RelaxedPrecision
-         %26 = OpVectorShuffle %55 %25 %25 2 3          ; RelaxedPrecision
-         %27 = OpConvertFToS %56 %26                    ; RelaxedPrecision
-         %73 = OpLoad %48 %5
-         %74 = OpImageRead %45 %73 %27
-         %75 = OpFAdd %45 %24 %74
-               OpReturnValue %75
+               ; Function 32
+         %32 = OpFunction %2 None %31               ; RelaxedPrecision
+         %33 = OpFunctionParameter %30              ; RelaxedPrecision
+         %34 = OpLabel
+         %36 = OpLoad %6 %8                         ; RelaxedPrecision
+         %37 = OpLoad %2 %33                        ; RelaxedPrecision
+         %38 = OpVectorShuffle %35 %37 %37 0 1      ; RelaxedPrecision
+         %39 = OpImageSampleImplicitLod %2 %36 %38  ; RelaxedPrecision
+         %41 = OpLoad %2 %33                        ; RelaxedPrecision
+         %42 = OpVectorShuffle %35 %41 %41 2 3      ; RelaxedPrecision
+         %43 = OpConvertFToS %40 %42                ; RelaxedPrecision
+         %44 = OpLoad %9 %11
+         %45 = OpImageRead %2 %44 %43
+         %46 = OpFAdd %2 %39 %45
+               OpReturnValue %46
                OpFunctionEnd
 
-               ; Function 17
-         %17 = OpFunction %45 None %70              ; RelaxedPrecision
-         %15 = OpFunctionParameter %67              ; RelaxedPrecision
-         %16 = OpFunctionParameter %67              ; RelaxedPrecision
-         %76 = OpLabel
-         %28 = OpLoad %45 %15                       ; RelaxedPrecision
-         %29 = OpVectorShuffle %55 %28 %28 0 1      ; RelaxedPrecision
-         %30 = OpLoad %45 %16                       ; RelaxedPrecision
-         %31 = OpVectorShuffle %55 %30 %30 2 3      ; RelaxedPrecision
-         %32 = OpCompositeExtract %44 %29 0         ; RelaxedPrecision
-         %33 = OpCompositeExtract %44 %29 1         ; RelaxedPrecision
-         %34 = OpCompositeExtract %44 %31 0         ; RelaxedPrecision
-         %35 = OpCompositeExtract %44 %31 1         ; RelaxedPrecision
-         %36 = OpCompositeConstruct %45 %32 %33 %34 %35     ; RelaxedPrecision
-               OpReturnValue %36
+               ; Function 48
+         %48 = OpFunction %2 None %47               ; RelaxedPrecision
+         %49 = OpFunctionParameter %30              ; RelaxedPrecision
+         %50 = OpFunctionParameter %30              ; RelaxedPrecision
+         %51 = OpLabel
+         %52 = OpLoad %2 %49                        ; RelaxedPrecision
+         %53 = OpVectorShuffle %35 %52 %52 0 1      ; RelaxedPrecision
+         %54 = OpLoad %2 %50                        ; RelaxedPrecision
+         %55 = OpVectorShuffle %35 %54 %54 2 3      ; RelaxedPrecision
+         %56 = OpCompositeExtract %1 %53 0          ; RelaxedPrecision
+         %57 = OpCompositeExtract %1 %53 1          ; RelaxedPrecision
+         %58 = OpCompositeExtract %1 %55 0          ; RelaxedPrecision
+         %59 = OpCompositeExtract %1 %55 1          ; RelaxedPrecision
+         %60 = OpCompositeConstruct %2 %56 %57 %58 %59  ; RelaxedPrecision
+               OpReturnValue %60
                OpFunctionEnd
 
-               ; Function 1
-          %1 = OpFunction %57 None %71
-         %77 = OpLabel
-         %18 = OpVariable %67 Function
-         %19 = OpVariable %67 Function              ; RelaxedPrecision
-         %20 = OpVariable %67 Function              ; RelaxedPrecision
-         %78 = OpLoad %45 %2
-               OpStore %18 %78
-         %37 = OpFunctionCall %45 %14 %18           ; RelaxedPrecision
-         %79 = OpAccessChain %68 %7 %58
-         %38 = OpLoad %45 %79                       ; RelaxedPrecision
-               OpStore %19 %38
-         %80 = OpAccessChain %68 %9 %58 %58
-         %39 = OpLoad %45 %80                       ; RelaxedPrecision
-               OpStore %20 %39
-         %40 = OpFunctionCall %45 %17 %19 %20       ; RelaxedPrecision
-         %41 = OpFAdd %45 %37 %40                   ; RelaxedPrecision
-         %81 = OpAccessChain %68 %9 %59 %58
-         %42 = OpLoad %45 %81                       ; RelaxedPrecision
-         %43 = OpFAdd %45 %41 %42                   ; RelaxedPrecision
-               OpStore %3 %43
+               ; Function 63
+         %63 = OpFunction %61 None %62
+         %64 = OpLabel
+         %65 = OpVariable %30 Function
+         %68 = OpVariable %30 Function              ; RelaxedPrecision
+         %73 = OpVariable %30 Function              ; RelaxedPrecision
+         %66 = OpLoad %2 %4
+               OpStore %65 %66
+         %67 = OpFunctionCall %2 %32 %65            ; RelaxedPrecision
+         %71 = OpAccessChain %70 %14 %69
+         %72 = OpLoad %2 %71                        ; RelaxedPrecision
+               OpStore %68 %72
+         %74 = OpAccessChain %70 %20 %69 %69
+         %75 = OpLoad %2 %74                        ; RelaxedPrecision
+               OpStore %73 %75
+         %76 = OpFunctionCall %2 %48 %68 %73        ; RelaxedPrecision
+         %77 = OpFAdd %2 %67 %76                    ; RelaxedPrecision
+         %79 = OpAccessChain %70 %20 %78 %69
+         %80 = OpLoad %2 %79                        ; RelaxedPrecision
+         %81 = OpFAdd %2 %77 %80                    ; RelaxedPrecision
+               OpStore %22 %81
                OpReturn
                OpFunctionEnd
 )";
 
   EXPECT_THAT(
-      EncodeAndDecodeSuccessfully(input, SPV_BINARY_TO_TEXT_OPTION_COMMENT |
-                                             SPV_BINARY_TO_TEXT_OPTION_INDENT),
+      EncodeAndDecodeSuccessfully(
+          input,
+          SPV_BINARY_TO_TEXT_OPTION_COMMENT | SPV_BINARY_TO_TEXT_OPTION_INDENT,
+          SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
+      expected);
+}
+
+TEST_F(TextToBinaryTest, NestedWithComments) {
+  const std::string input = R"(OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %8 %44
+               OpExecutionMode %4 OriginUpperLeft
+               OpSource ESSL 310
+               OpName %4 "main"
+               OpName %8 "v"
+               OpName %44 "color"
+               OpDecorate %8 RelaxedPrecision
+               OpDecorate %8 Location 0
+               OpDecorate %9 RelaxedPrecision
+               OpDecorate %18 RelaxedPrecision
+               OpDecorate %19 RelaxedPrecision
+               OpDecorate %20 RelaxedPrecision
+               OpDecorate %23 RelaxedPrecision
+               OpDecorate %24 RelaxedPrecision
+               OpDecorate %25 RelaxedPrecision
+               OpDecorate %26 RelaxedPrecision
+               OpDecorate %27 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %29 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %33 RelaxedPrecision
+               OpDecorate %34 RelaxedPrecision
+               OpDecorate %35 RelaxedPrecision
+               OpDecorate %36 RelaxedPrecision
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %39 RelaxedPrecision
+               OpDecorate %40 RelaxedPrecision
+               OpDecorate %41 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %44 RelaxedPrecision
+               OpDecorate %44 Location 0
+               OpDecorate %45 RelaxedPrecision
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Input %6
+          %8 = OpVariable %7 Input
+         %10 = OpConstant %6 0
+         %11 = OpTypeBool
+         %15 = OpTypeVector %6 4
+         %16 = OpTypePointer Function %15
+         %21 = OpConstant %6 -0.5
+         %22 = OpConstant %6 -0.300000012
+         %38 = OpConstant %6 0.5
+         %43 = OpTypePointer Output %15
+         %44 = OpVariable %43 Output
+          %4 = OpFunction %2 None %3
+          %5 = OpLabel
+          %9 = OpLoad %6 %8
+         %12 = OpFOrdLessThanEqual %11 %9 %10
+               OpSelectionMerge %14 None
+               OpBranchConditional %12 %13 %32
+         %13 = OpLabel
+         %18 = OpLoad %6 %8
+         %19 = OpExtInst %6 %1 Log %18
+         %20 = OpLoad %6 %8
+         %23 = OpExtInst %6 %1 FClamp %20 %21 %22
+         %24 = OpFMul %6 %19 %23
+         %25 = OpLoad %6 %8
+         %26 = OpExtInst %6 %1 Sin %25
+         %27 = OpLoad %6 %8
+         %28 = OpExtInst %6 %1 Cos %27
+         %29 = OpLoad %6 %8
+         %30 = OpExtInst %6 %1 Exp %29
+         %31 = OpCompositeConstruct %15 %24 %26 %28 %30
+               OpBranch %14
+         %32 = OpLabel
+         %33 = OpLoad %6 %8
+         %34 = OpExtInst %6 %1 Sqrt %33
+         %35 = OpLoad %6 %8
+         %36 = OpExtInst %6 %1 FSign %35
+         %37 = OpLoad %6 %8
+         %39 = OpExtInst %6 %1 FMax %37 %38
+         %40 = OpLoad %6 %8
+         %41 = OpExtInst %6 %1 Floor %40
+         %42 = OpCompositeConstruct %15 %34 %36 %39 %41
+               OpBranch %14
+         %14 = OpLabel
+         %45 = OpPhi %15 %31 %13 %42 %32
+               OpStore %44 %45
+               OpReturn
+               OpFunctionEnd
+)";
+  const std::string expected = R"(               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %4 "main" %8 %44
+               OpExecutionMode %4 OriginUpperLeft
+
+               ; Debug Information
+               OpSource ESSL 310
+               OpName %4 "main"                     ; id %4
+               OpName %8 "v"                        ; id %8
+               OpName %44 "color"                   ; id %44
+
+               ; Annotations
+               OpDecorate %8 RelaxedPrecision
+               OpDecorate %8 Location 0
+               OpDecorate %9 RelaxedPrecision
+               OpDecorate %18 RelaxedPrecision
+               OpDecorate %19 RelaxedPrecision
+               OpDecorate %20 RelaxedPrecision
+               OpDecorate %23 RelaxedPrecision
+               OpDecorate %24 RelaxedPrecision
+               OpDecorate %25 RelaxedPrecision
+               OpDecorate %26 RelaxedPrecision
+               OpDecorate %27 RelaxedPrecision
+               OpDecorate %28 RelaxedPrecision
+               OpDecorate %29 RelaxedPrecision
+               OpDecorate %30 RelaxedPrecision
+               OpDecorate %31 RelaxedPrecision
+               OpDecorate %33 RelaxedPrecision
+               OpDecorate %34 RelaxedPrecision
+               OpDecorate %35 RelaxedPrecision
+               OpDecorate %36 RelaxedPrecision
+               OpDecorate %37 RelaxedPrecision
+               OpDecorate %39 RelaxedPrecision
+               OpDecorate %40 RelaxedPrecision
+               OpDecorate %41 RelaxedPrecision
+               OpDecorate %42 RelaxedPrecision
+               OpDecorate %44 RelaxedPrecision
+               OpDecorate %44 Location 0
+               OpDecorate %45 RelaxedPrecision
+
+               ; Types, variables and constants
+          %2 = OpTypeVoid
+          %3 = OpTypeFunction %2
+          %6 = OpTypeFloat 32
+          %7 = OpTypePointer Input %6
+          %8 = OpVariable %7 Input                  ; RelaxedPrecision, Location 0
+         %10 = OpConstant %6 0
+         %11 = OpTypeBool
+         %15 = OpTypeVector %6 4
+         %16 = OpTypePointer Function %15
+         %21 = OpConstant %6 -0.5
+         %22 = OpConstant %6 -0.300000012
+         %38 = OpConstant %6 0.5
+         %43 = OpTypePointer Output %15
+         %44 = OpVariable %43 Output                ; RelaxedPrecision, Location 0
+
+
+               ; Function 4
+          %4 = OpFunction %2 None %3
+
+          %5 = OpLabel
+          %9 =   OpLoad %6 %8                       ; RelaxedPrecision
+         %12 =   OpFOrdLessThanEqual %11 %9 %10
+                 OpSelectionMerge %14 None
+                 OpBranchConditional %12 %13 %32
+
+         %13 =     OpLabel
+         %18 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %19 =       OpExtInst %6 %1 Log %18        ; RelaxedPrecision
+         %20 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %23 =       OpExtInst %6 %1 FClamp %20 %21 %22     ; RelaxedPrecision
+         %24 =       OpFMul %6 %19 %23                      ; RelaxedPrecision
+         %25 =       OpLoad %6 %8                           ; RelaxedPrecision
+         %26 =       OpExtInst %6 %1 Sin %25                ; RelaxedPrecision
+         %27 =       OpLoad %6 %8                           ; RelaxedPrecision
+         %28 =       OpExtInst %6 %1 Cos %27                ; RelaxedPrecision
+         %29 =       OpLoad %6 %8                           ; RelaxedPrecision
+         %30 =       OpExtInst %6 %1 Exp %29                ; RelaxedPrecision
+         %31 =       OpCompositeConstruct %15 %24 %26 %28 %30   ; RelaxedPrecision
+                     OpBranch %14
+
+         %32 =     OpLabel
+         %33 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %34 =       OpExtInst %6 %1 Sqrt %33       ; RelaxedPrecision
+         %35 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %36 =       OpExtInst %6 %1 FSign %35      ; RelaxedPrecision
+         %37 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %39 =       OpExtInst %6 %1 FMax %37 %38   ; RelaxedPrecision
+         %40 =       OpLoad %6 %8                   ; RelaxedPrecision
+         %41 =       OpExtInst %6 %1 Floor %40      ; RelaxedPrecision
+         %42 =       OpCompositeConstruct %15 %34 %36 %39 %41   ; RelaxedPrecision
+                     OpBranch %14
+
+         %14 = OpLabel
+         %45 =   OpPhi %15 %31 %13 %42 %32          ; RelaxedPrecision
+                 OpStore %44 %45
+                 OpReturn
+               OpFunctionEnd
+)";
+
+  EXPECT_THAT(
+      EncodeAndDecodeSuccessfully(
+          input,
+          SPV_BINARY_TO_TEXT_OPTION_COMMENT | SPV_BINARY_TO_TEXT_OPTION_INDENT |
+              SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT,
+          SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS),
       expected);
 }
 

--- a/test/ext_inst.non_semantic_test.cpp
+++ b/test/ext_inst.non_semantic_test.cpp
@@ -41,8 +41,7 @@ TEST_F(NonSemanticRoundTripTest, NonSemanticInsts) {
 %8 = OpExtInstImport "NonSemantic.Testing.AnotherUnknownExtInstSet"
 %9 = OpExtInst %4 %8 613874321 %7 %5 %6
 )";
-  std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_0);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 

--- a/test/test_fixture.h
+++ b/test/test_fixture.h
@@ -111,13 +111,15 @@ class TextToBinaryTestBase : public T {
   std::string EncodeAndDecodeSuccessfully(
       const std::string& txt,
       uint32_t disassemble_options = SPV_BINARY_TO_TEXT_OPTION_NONE,
+      uint32_t assemble_options = SPV_TEXT_TO_BINARY_OPTION_NONE,
       spv_target_env env = SPV_ENV_UNIVERSAL_1_0, bool flip_words = false) {
     DestroyBinary();
     DestroyDiagnostic();
     ScopedContext context(env);
     disassemble_options |= SPV_BINARY_TO_TEXT_OPTION_NO_HEADER;
-    spv_result_t error = spvTextToBinary(context.context, txt.c_str(),
-                                         txt.size(), &binary, &diagnostic);
+    spv_result_t error =
+        spvTextToBinaryWithOptions(context.context, txt.c_str(), txt.size(),
+                                   assemble_options, &binary, &diagnostic);
     if (error) {
       spvDiagnosticPrint(diagnostic);
       spvDiagnosticDestroy(diagnostic);

--- a/test/text_to_binary.annotation_test.cpp
+++ b/test/text_to_binary.annotation_test.cpp
@@ -55,10 +55,10 @@ TEST_P(OpDecorateSimpleTest, AnySimpleDecoration) {
                                  {1, uint32_t(std::get<1>(GetParam()).value())},
                                  std::get<1>(GetParam()).operands())));
   // Also check disassembly.
-  EXPECT_THAT(
-      EncodeAndDecodeSuccessfully(input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
-                                  std::get<0>(GetParam())),
-      Eq(input.str()));
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                  SPV_TEXT_TO_BINARY_OPTION_NONE, std::get<0>(GetParam())),
+              Eq(input.str()));
 }
 
 // Like above, but parameters to the decoration are IDs.
@@ -78,10 +78,10 @@ TEST_P(OpDecorateSimpleIdTest, AnySimpleDecoration) {
                                  {1, uint32_t(std::get<1>(GetParam()).value())},
                                  std::get<1>(GetParam()).operands())));
   // Also check disassembly.
-  EXPECT_THAT(
-      EncodeAndDecodeSuccessfully(input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
-                                  std::get<0>(GetParam())),
-      Eq(input.str()));
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                  SPV_TEXT_TO_BINARY_OPTION_NONE, std::get<0>(GetParam())),
+              Eq(input.str()));
 }
 
 #define CASE(NAME) spv::Decoration::NAME, #NAME
@@ -460,10 +460,10 @@ TEST_P(OpMemberDecorateSimpleTest, AnySimpleDecoration) {
                          {1, 42, uint32_t(std::get<1>(GetParam()).value())},
                          std::get<1>(GetParam()).operands())));
   // Also check disassembly.
-  EXPECT_THAT(
-      EncodeAndDecodeSuccessfully(input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
-                                  std::get<0>(GetParam())),
-      Eq(input.str()));
+  EXPECT_THAT(EncodeAndDecodeSuccessfully(
+                  input.str(), SPV_BINARY_TO_TEXT_OPTION_NONE,
+                  SPV_TEXT_TO_BINARY_OPTION_NONE, std::get<0>(GetParam())),
+              Eq(input.str()));
 }
 
 #define CASE(NAME) spv::Decoration::NAME, #NAME

--- a/test/text_to_binary.composite_test.cpp
+++ b/test/text_to_binary.composite_test.cpp
@@ -35,7 +35,8 @@ using CompositeRoundTripTest = RoundTripTest;
 TEST_F(CompositeRoundTripTest, Good) {
   std::string spirv = "%2 = OpCopyLogical %1 %3\n";
   std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_4);
+      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_TEXT_TO_BINARY_OPTION_NONE,
+      SPV_ENV_UNIVERSAL_1_4);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -130,9 +130,10 @@ TEST_P(ExtensionRoundTripTest, Samples) {
   EXPECT_THAT(CompiledInstructions(ac.input, env), Eq(ac.expected));
 
   // Check round trip through the disassembler.
-  EXPECT_THAT(EncodeAndDecodeSuccessfully(ac.input,
-                                          SPV_BINARY_TO_TEXT_OPTION_NONE, env),
-              Eq(ac.input))
+  EXPECT_THAT(
+      EncodeAndDecodeSuccessfully(ac.input, SPV_BINARY_TO_TEXT_OPTION_NONE,
+                                  SPV_TEXT_TO_BINARY_OPTION_NONE, env),
+      Eq(ac.input))
       << "target env: " << spvTargetEnvDescription(env) << "\n";
 }
 

--- a/test/text_to_binary.memory_test.cpp
+++ b/test/text_to_binary.memory_test.cpp
@@ -107,7 +107,8 @@ TEST_F(MemoryRoundTripTest, OpPtrEqualGood) {
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_4),
               Eq(MakeInstruction(spv::Op::OpPtrEqual, {1, 2, 3, 4})));
   std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_4);
+      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_TEXT_TO_BINARY_OPTION_NONE,
+      SPV_ENV_UNIVERSAL_1_4);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -124,7 +125,8 @@ TEST_F(MemoryRoundTripTest, OpPtrNotEqualGood) {
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_4),
               Eq(MakeInstruction(spv::Op::OpPtrNotEqual, {1, 2, 3, 4})));
   std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_4);
+      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_TEXT_TO_BINARY_OPTION_NONE,
+      SPV_ENV_UNIVERSAL_1_4);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -141,7 +143,8 @@ TEST_F(MemoryRoundTripTest, OpPtrDiffGood) {
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_4),
               Eq(MakeInstruction(spv::Op::OpPtrDiff, {1, 2, 3, 4})));
   std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_4);
+      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_TEXT_TO_BINARY_OPTION_NONE,
+      SPV_ENV_UNIVERSAL_1_4);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -151,7 +154,8 @@ TEST_F(MemoryRoundTripTest, OpPtrDiffV13Good) {
   // write tests.
   std::string spirv = "%2 = OpPtrDiff %1 %3 %4\n";
   std::string disassembly = EncodeAndDecodeSuccessfully(
-      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_ENV_UNIVERSAL_1_4);
+      spirv, SPV_BINARY_TO_TEXT_OPTION_NONE, SPV_TEXT_TO_BINARY_OPTION_NONE,
+      SPV_ENV_UNIVERSAL_1_4);
 }
 
 // OpCopyMemory
@@ -160,8 +164,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryNoMemAccessGood) {
   std::string spirv = "OpCopyMemory %1 %2\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -182,8 +185,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessNoneGood) {
   std::string spirv = "OpCopyMemory %1 %2 None\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 0})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -191,8 +193,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessVolatileGood) {
   std::string spirv = "OpCopyMemory %1 %2 Volatile\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -200,8 +201,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessAligned8Good) {
   std::string spirv = "OpCopyMemory %1 %2 Aligned 8\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 2, 8})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -209,8 +209,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessNontemporalGood) {
   std::string spirv = "OpCopyMemory %1 %2 Nontemporal\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -218,8 +217,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessAvGood) {
   std::string spirv = "OpCopyMemory %1 %2 MakePointerAvailable %3\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 8, 3})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -227,8 +225,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessVisGood) {
   std::string spirv = "OpCopyMemory %1 %2 MakePointerVisible %3\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 16, 3})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -236,8 +233,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessNonPrivateGood) {
   std::string spirv = "OpCopyMemory %1 %2 NonPrivatePointer\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 32})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -248,8 +244,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryAccessMixedGood) {
       "MakePointerVisible|NonPrivatePointer 16 %3 %4\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 63, 16, 3, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -258,8 +253,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryTwoAccessV13Good) {
   // Note: This will assemble but should not validate for SPIR-V 1.3
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_3),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 1, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -267,8 +261,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryTwoAccessV14Good) {
   std::string spirv = "OpCopyMemory %1 %2 Volatile Volatile\n";
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_4),
               Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 1, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -280,8 +273,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemoryTwoAccessMixedV14Good) {
   EXPECT_THAT(
       CompiledInstructions(spirv),
       Eq(MakeInstruction(spv::Op::OpCopyMemory, {1, 2, 21, 3, 42, 16, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -291,8 +283,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedNoMemAccessGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -313,8 +304,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessNoneGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 None\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 0})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -322,8 +312,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessVolatileGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 Volatile\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -331,8 +320,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessAligned8Good) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 Aligned 8\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 2, 8})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -340,8 +328,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessNontemporalGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 Nontemporal\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -349,8 +336,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessAvGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 MakePointerAvailable %4\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 8, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -359,8 +345,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessVisGood) {
   EXPECT_THAT(
       CompiledInstructions(spirv),
       Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 16, 4})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -368,8 +353,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessNonPrivateGood) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 NonPrivatePointer\n";
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 32})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -381,8 +365,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedAccessMixedGood) {
   EXPECT_THAT(
       CompiledInstructions(spirv),
       Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 63, 16, 4, 5})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -391,8 +374,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedTwoAccessV13Good) {
   // Note: This will assemble but should not validate for SPIR-V 1.3
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_3),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 1, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -400,8 +382,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedTwoAccessV14Good) {
   std::string spirv = "OpCopyMemorySized %1 %2 %3 Volatile Volatile\n";
   EXPECT_THAT(CompiledInstructions(spirv, SPV_ENV_UNIVERSAL_1_4),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized, {1, 2, 3, 1, 1})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 
@@ -413,8 +394,7 @@ TEST_F(MemoryRoundTripTest, OpCopyMemorySizedTwoAccessMixedV14Good) {
   EXPECT_THAT(CompiledInstructions(spirv),
               Eq(MakeInstruction(spv::Op::OpCopyMemorySized,
                                  {1, 2, 3, 21, 4, 42, 16, 5})));
-  std::string disassembly =
-      EncodeAndDecodeSuccessfully(spirv, SPV_BINARY_TO_TEXT_OPTION_NONE);
+  std::string disassembly = EncodeAndDecodeSuccessfully(spirv);
   EXPECT_THAT(disassembly, Eq(spirv));
 }
 

--- a/tools/dis/dis.cpp
+++ b/tools/dis/dis.cpp
@@ -35,42 +35,51 @@ or if the filename is "-", then the binary is read from standard input.
 
 Options:
 
-  -h, --help      Print this help.
-  --version       Display disassembler version information.
+  -h, --help        Print this help.
+  --version         Display disassembler version information.
 
-  -o <filename>   Set the output filename.
-                  Output goes to standard output if this option is
-                  not specified, or if the filename is "-".
+  -o <filename>     Set the output filename.
+                    Output goes to standard output if this option is
+                    not specified, or if the filename is "-".
 
-  --color         Force color output.  The default when printing to a terminal.
-                  Overrides a previous --no-color option.
-  --no-color      Don't print in color.  Overrides a previous --color option.
-                  The default when output goes to something other than a
-                  terminal (e.g. a file, a pipe, or a shell redirection).
+  --color           Force color output.  The default when printing to a terminal.
+                    Overrides a previous --no-color option.
+  --no-color        Don't print in color.  Overrides a previous --color option.
+                    The default when output goes to something other than a
+                    terminal (e.g. a file, a pipe, or a shell redirection).
 
-  --no-indent     Don't indent instructions.
+  --no-indent       Don't indent instructions.
 
-  --no-header     Don't output the header as leading comments.
+  --no-header       Don't output the header as leading comments.
 
-  --raw-id        Show raw Id values instead of friendly names.
+  --raw-id          Show raw Id values instead of friendly names.
 
-  --offsets       Show byte offsets for each instruction.
+  --nested-indent   Indentation is adjusted to indicate nesting in structured
+                    control flow.
 
-  --comment       Add comments to make reading easier
+  --reorder-blocks  Reorder blocks to match the structured control flow of SPIR-V.
+                    With this option, the order of instructions will no longer
+                    match the input binary, but the result will be more readable.
+
+  --offsets         Show byte offsets for each instruction.
+
+  --comment         Add comments to make reading easier
 )";
 
 // clang-format off
-FLAG_SHORT_bool  (h,         /* default_value= */ false, /* required= */ false);
-FLAG_SHORT_string(o,         /* default_value= */ "-",   /* required= */ false);
-FLAG_LONG_bool   (help,      /* default_value= */ false, /* required= */false);
-FLAG_LONG_bool   (version,   /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (color,     /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (no_color,  /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (no_indent, /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (no_header, /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (raw_id,    /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (offsets,   /* default_value= */ false, /* required= */ false);
-FLAG_LONG_bool   (comment,   /* default_value= */ false, /* required= */ false);
+FLAG_SHORT_bool  (h,              /* default_value= */ false, /* required= */ false);
+FLAG_SHORT_string(o,              /* default_value= */ "-",   /* required= */ false);
+FLAG_LONG_bool   (help,           /* default_value= */ false, /* required= */false);
+FLAG_LONG_bool   (version,        /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (color,          /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (no_color,       /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (no_indent,      /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (no_header,      /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (raw_id,         /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (nested_indent,  /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (reorder_blocks, /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (offsets,        /* default_value= */ false, /* required= */ false);
+FLAG_LONG_bool   (comment,        /* default_value= */ false, /* required= */ false);
 // clang-format on
 
 static const auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_5;
@@ -119,6 +128,12 @@ int main(int, const char** argv) {
 
   if (!flags::raw_id.value())
     options |= SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES;
+
+  if (flags::nested_indent.value())
+    options |= SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT;
+
+  if (flags::reorder_blocks.value())
+    options |= SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS;
 
   if (flags::comment.value()) options |= SPV_BINARY_TO_TEXT_OPTION_COMMENT;
 


### PR DESCRIPTION
With --nested-indent, the SPIR-V blocks are nested according to the
structured control flow.  Each OpLabel is nested that much with the
contents of the block nested a little more.  The blocks are separated by
a blank line for better visualization.

With --reorder-blocks, the SPIR-V blocks are reordered according to the
structured control flow.  This is particularly useful with
--nested-indent.

Note that with --nested-indent, the disassembly does not exactly show
the binary as-is, and the instructions may be reordered.
