### PR TITLE
Use raw string to avoid unintended escapes in regex

### DIFF
--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -78,7 +78,7 @@ def git_executable():
       minor=None
       try:
         version_info = subprocess.check_output([git, '--version']).decode('utf-8')
-        match = re.search("^git version (\d+)\.(\d+)",version_info)
+        match = re.search(r"^git version (\d+)\.(\d+)",version_info)
         print("Using {}".format(version_info))
         if match:
           major = int(match.group(1))


### PR DESCRIPTION
The original code seems to forget to use the raw string mark, so Python is treating `\d` as an invalid escaped char (but still can parse the version correctly, idk why):
```
git-sync-deps:81: SyntaxWarning: invalid escape sequence '\d'
  match = re.search("^git version (\d+)\.(\d+)",version_info)
```

This simple PR fixes this.