### PR TITLE
Allow fmt arg to printf to be an array of i8 in non-constant space

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2968,7 +2968,9 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
 
         if (format_storage_class != spv::StorageClass::UniformConstant &&
             // Extension SPV_EXT_relaxed_printf_string_address_space allows
-            // format strings in Global, Local, Private and Generic address spaces
+            // format strings in Global, Local, Private and Generic address
+            // spaces
+
             // Global
             format_storage_class != spv::StorageClass::CrossWorkgroup &&
             // Local
@@ -2979,7 +2981,8 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
             format_storage_class != spv::StorageClass::Generic) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
-                 << "expected Format storage class to be UniformConstant, Crossworkgroup, Workgroup, Function, or Generic";
+                 << "expected Format storage class to be UniformConstant, "
+                    "Crossworkgroup, Workgroup, Function, or Generic";
         }
 
         if (!_.IsIntScalarType(format_data_type) ||

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2962,7 +2962,14 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                  << "expected operand Format to be a pointer";
         }
 
-        if (format_storage_class != spv::StorageClass::UniformConstant) {
+        // If pointer points to an array, get the type of an element
+        if (_.IsIntArrayType(format_data_type))
+          format_data_type = _.GetComponentType(format_data_type);
+
+        if (format_storage_class != spv::StorageClass::UniformConstant &&
+            // Extension SPV_EXT_relaxed_printf_string_address_space allows
+            // format strings in Generic space
+            format_storage_class != spv::StorageClass::Generic) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected Format storage class to be UniformConstant";

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2968,11 +2968,18 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
 
         if (format_storage_class != spv::StorageClass::UniformConstant &&
             // Extension SPV_EXT_relaxed_printf_string_address_space allows
-            // format strings in Generic space
+            // format strings in Global, Local, Private and Generic address spaces
+            // Global
+            format_storage_class != spv::StorageClass::CrossWorkgroup &&
+            // Local
+            format_storage_class != spv::StorageClass::Workgroup &&
+            // Private
+            format_storage_class != spv::StorageClass::Function &&
+            // Generic
             format_storage_class != spv::StorageClass::Generic) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
-                 << "expected Format storage class to be UniformConstant";
+                 << "expected Format storage class to be UniformConstant, Crossworkgroup, Workgroup, Function, or Generic";
         }
 
         if (!_.IsIntScalarType(format_data_type) ||

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2962,10 +2962,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                  << "expected operand Format to be a pointer";
         }
 
-        // If pointer points to an array, get the type of an element
-        if (_.IsIntArrayType(format_data_type))
-          format_data_type = _.GetComponentType(format_data_type);
-
         if (format_storage_class != spv::StorageClass::UniformConstant &&
             // Extension SPV_EXT_relaxed_printf_string_address_space allows
             // format strings in Global, Local, Private and Generic address
@@ -2984,6 +2980,10 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                  << "expected Format storage class to be UniformConstant, "
                     "Crossworkgroup, Workgroup, Function, or Generic";
         }
+
+        // If pointer points to an array, get the type of an element
+        if (_.IsIntArrayType(format_data_type))
+          format_data_type = _.GetComponentType(format_data_type);
 
         if (!_.IsIntScalarType(format_data_type) ||
             _.GetBitWidth(format_data_type) != 8) {

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2962,23 +2962,32 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                  << "expected operand Format to be a pointer";
         }
 
-        if (format_storage_class != spv::StorageClass::UniformConstant &&
-            // Extension SPV_EXT_relaxed_printf_string_address_space allows
-            // format strings in Global, Local, Private and Generic address
-            // spaces
+        if (_.HasExtension(
+                Extension::kSPV_EXT_relaxed_printf_string_address_space)) {
+          if (format_storage_class != spv::StorageClass::UniformConstant &&
+              // Extension SPV_EXT_relaxed_printf_string_address_space allows
+              // format strings in Global, Local, Private and Generic address
+              // spaces
 
-            // Global
-            format_storage_class != spv::StorageClass::CrossWorkgroup &&
-            // Local
-            format_storage_class != spv::StorageClass::Workgroup &&
-            // Private
-            format_storage_class != spv::StorageClass::Function &&
-            // Generic
-            format_storage_class != spv::StorageClass::Generic) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << ext_inst_name() << ": "
-                 << "expected Format storage class to be UniformConstant, "
-                    "Crossworkgroup, Workgroup, Function, or Generic";
+              // Global
+              format_storage_class != spv::StorageClass::CrossWorkgroup &&
+              // Local
+              format_storage_class != spv::StorageClass::Workgroup &&
+              // Private
+              format_storage_class != spv::StorageClass::Function &&
+              // Generic
+              format_storage_class != spv::StorageClass::Generic) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name() << ": "
+                   << "expected Format storage class to be UniformConstant, "
+                      "Crossworkgroup, Workgroup, Function, or Generic";
+          }
+        } else {
+          if (format_storage_class != spv::StorageClass::UniformConstant) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name() << ": "
+                   << "expected Format storage class to be UniformConstant";
+          }
         }
 
         // If pointer points to an array, get the type of an element

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -868,6 +868,9 @@ uint32_t ValidationState_t::GetComponentType(uint32_t id) const {
     case spv::Op::OpTypeBool:
       return id;
 
+    case spv::Op::OpTypeArray:
+      return inst->word(2);
+
     case spv::Op::OpTypeVector:
       return inst->word(2);
 
@@ -989,6 +992,19 @@ bool ValidationState_t::IsFloatScalarOrVectorType(uint32_t id) const {
 bool ValidationState_t::IsIntScalarType(uint32_t id) const {
   const Instruction* inst = FindDef(id);
   return inst && inst->opcode() == spv::Op::OpTypeInt;
+}
+
+bool ValidationState_t::IsIntArrayType(uint32_t id) const {
+  const Instruction* inst = FindDef(id);
+  if (!inst) {
+    return false;
+  }
+
+  if (inst->opcode() == spv::Op::OpTypeArray) {
+    return IsIntScalarType(GetComponentType(id));
+  }
+
+  return false;
 }
 
 bool ValidationState_t::IsIntVectorType(uint32_t id) const {

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -606,6 +606,7 @@ class ValidationState_t {
   bool IsFloatScalarOrVectorType(uint32_t id) const;
   bool IsFloatMatrixType(uint32_t id) const;
   bool IsIntScalarType(uint32_t id) const;
+  bool IsIntArrayType(uint32_t id) const;
   bool IsIntVectorType(uint32_t id) const;
   bool IsIntScalarOrVectorType(uint32_t id) const;
   bool IsUnsignedIntScalarType(uint32_t id) const;

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -5273,13 +5273,16 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
 TEST_F(ValidateExtInst,
        OpenCLStdPrintfFormatWithExtensionNotAllowedStorageClass) {
   const std::string body = R"(
-OpExtension "SPV_EXT_relaxed_printf_string_address_space"
 %format_const = OpAccessChain %u8_ptr_uniform_constant %u8arr_uniform_constant %u32_0
 %format = OpBitcast %u8_ptr_input %format_const
 %val1 = OpExtInst %u32 %extinst printf %format %u32_0 %u32_1
 )";
 
-  CompileSuccessfully(GenerateKernelCode(body));
+  const std::string extension = R"(
+OpExtension  "SPV_EXT_relaxed_printf_string_address_space"
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body, extension));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpenCL.std printf: expected Format storage class to "

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -5266,7 +5266,8 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotAllowedStorageClass) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpenCL.std printf: expected Format storage class to "
-                        "be UniformConstant, Crossworkgroup, Workgroup, Function, or Generic"));
+                        "be UniformConstant, Crossworkgroup, Workgroup, "
+                        "Function, or Generic"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotU8Pointer) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -446,7 +446,7 @@ OpCapability Matrix
 %u8arr_ptr_uniform_constant = OpTypePointer UniformConstant %u8arr
 %u8arr_uniform_constant = OpVariable %u8arr_ptr_uniform_constant UniformConstant
 %u8_ptr_uniform_constant = OpTypePointer UniformConstant %u8
-%u8_ptr_generic = OpTypePointer Generic %u8
+%u8_ptr_input = OpTypePointer Input %u8
 
 %main = OpFunction %void None %func
 %main_entry = OpLabel
@@ -5255,10 +5255,10 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
                 "type"));
 }
 
-TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
+TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotAllowedStorageClass) {
   const std::string body = R"(
 %format_const = OpAccessChain %u8_ptr_uniform_constant %u8arr_uniform_constant %u32_0
-%format = OpBitcast %u8_ptr_generic %format_const
+%format = OpBitcast %u8_ptr_input %format_const
 %val1 = OpExtInst %u32 %extinst printf %format %u32_0 %u32_1
 )";
 
@@ -5266,7 +5266,7 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpenCL.std printf: expected Format storage class to "
-                        "be UniformConstant"));
+                        "be UniformConstant, Crossworkgroup, Workgroup, Function, or Generic"));
 }
 
 TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotU8Pointer) {

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -446,6 +446,7 @@ OpCapability Matrix
 %u8arr_ptr_uniform_constant = OpTypePointer UniformConstant %u8arr
 %u8arr_uniform_constant = OpVariable %u8arr_ptr_uniform_constant UniformConstant
 %u8_ptr_uniform_constant = OpTypePointer UniformConstant %u8
+%u8_ptr_generic = OpTypePointer Generic %u8
 %u8_ptr_input = OpTypePointer Input %u8
 
 %main = OpFunction %void None %func
@@ -5255,8 +5256,24 @@ TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotPointer) {
                 "type"));
 }
 
-TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotAllowedStorageClass) {
+TEST_F(ValidateExtInst, OpenCLStdPrintfFormatNotUniformConstStorageClass) {
   const std::string body = R"(
+%format_const = OpAccessChain %u8_ptr_uniform_constant %u8arr_uniform_constant %u32_0
+%format = OpBitcast %u8_ptr_generic %format_const
+%val1 = OpExtInst %u32 %extinst printf %format %u32_0 %u32_1
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpenCL.std printf: expected Format storage class to "
+                        "be UniformConstant"));
+}
+
+TEST_F(ValidateExtInst,
+       OpenCLStdPrintfFormatWithExtensionNotAllowedStorageClass) {
+  const std::string body = R"(
+OpExtension "SPV_EXT_relaxed_printf_string_address_space"
 %format_const = OpAccessChain %u8_ptr_uniform_constant %u8arr_uniform_constant %u32_0
 %format = OpBitcast %u8_ptr_input %format_const
 %val1 = OpExtInst %u32 %extinst printf %format %u32_0 %u32_1

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -31,6 +31,7 @@ SPV_AMD_gpu_shader_half_float
 SPV_AMD_gpu_shader_int16
 SPV_AMD_shader_trinary_minmax
 SPV_KHR_non_semantic_info
+SPV_EXT_relaxed_printf_string_address_space
 """
 
 OUTPUT_LANGUAGE = 'c'


### PR DESCRIPTION
If SPV_EXT_relaxed_printf_string_address_space is enabled llvm-spirv allows the format argument to be in Generic space.  Also allow format argument to point to an array of i8 instead of only an i8.