### PR TITLE
spirv-val: Add Duplicate EntryPoint Builtin check

### DIFF
--- a/source/val/decoration.h
+++ b/source/val/decoration.h
@@ -55,6 +55,12 @@ namespace val {
 //              params_ = vector { 2 }
 // struct_member_index_ = 2
 //
+// Example 4: Decoration for a Builtin:
+// OpDecorate %var BuiltIn FragDepth
+//            dec_type_ = spv::Decoration::BuiltIn
+//              params_ = vector { FragDepth }
+// struct_member_index_ = kInvalidMember
+//
 class Decoration {
  public:
   enum { kInvalidMember = -1 };
@@ -68,6 +74,10 @@ class Decoration {
   spv::Decoration dec_type() const { return dec_type_; }
   std::vector<uint32_t>& params() { return params_; }
   const std::vector<uint32_t>& params() const { return params_; }
+  spv::BuiltIn builtin() const {
+    assert(dec_type_ == spv::Decoration::BuiltIn);
+    return spv::BuiltIn(params_[0]);
+  }
 
   inline bool operator<(const Decoration& rhs) const {
     // Note: Sort by struct_member_index_ first, then type, so look up can be

--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -741,7 +741,7 @@ std::string BuiltInsValidator::GetReferenceDesc(
 
   ss << " which is decorated with BuiltIn ";
   ss << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                      decoration.params()[0]);
+                                      (uint32_t)decoration.builtin());
   if (function_id_) {
     ss << " in function <" << function_id_ << ">";
     if (execution_model != spv::ExecutionModel::Max) {
@@ -1170,7 +1170,7 @@ spv_result_t BuiltInsValidator::ValidateNotCalledWithExecutionModel(
       const char* execution_model_str = _.grammar().lookupOperandName(
           SPV_OPERAND_TYPE_EXECUTION_MODEL, uint32_t(execution_model));
       const char* built_in_str = _.grammar().lookupOperandName(
-          SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0]);
+          SPV_OPERAND_TYPE_BUILT_IN, (uint32_t)decoration.builtin());
       return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
              << (vuid < 0 ? std::string("") : _.VkErrorID(vuid)) << comment
              << " " << GetIdDesc(referenced_inst) << " depends on "
@@ -1201,13 +1201,14 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input &&
         storage_class != spv::StorageClass::Output) {
-      uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance) ? 4190 : 4199;
+      uint32_t vuid =
+          (decoration.builtin() == spv::BuiltIn::ClipDistance) ? 4190 : 4199;
       return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
              << _.VkErrorID(vuid) << "Vulkan spec allows BuiltIn "
              << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
@@ -1221,7 +1222,8 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
 
     if (storage_class == spv::StorageClass::Input) {
       assert(function_id_ == 0);
-      uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance) ? 4188 : 4197;
+      uint32_t vuid =
+          (decoration.builtin() == spv::BuiltIn::ClipDistance) ? 4188 : 4197;
       id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
           &BuiltInsValidator::ValidateNotCalledWithExecutionModel, this, vuid,
           "Vulkan spec doesn't allow BuiltIn ClipDistance/CullDistance to be "
@@ -1247,7 +1249,8 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
 
     if (storage_class == spv::StorageClass::Output) {
       assert(function_id_ == 0);
-      uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance) ? 4189 : 4198;
+      uint32_t vuid =
+          (decoration.builtin() == spv::BuiltIn::ClipDistance) ? 4189 : 4198;
       id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
           &BuiltInsValidator::ValidateNotCalledWithExecutionModel, this, vuid,
           "Vulkan spec doesn't allow BuiltIn ClipDistance/CullDistance to be "
@@ -1266,7 +1269,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                   [this, &decoration, &referenced_from_inst](
                       const std::string& message) -> spv_result_t {
                     uint32_t vuid =
-                        (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance)
+                        (decoration.builtin() == spv::BuiltIn::ClipDistance)
                             ? 4191
                             : 4200;
                     return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
@@ -1274,7 +1277,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                            << "According to the Vulkan spec BuiltIn "
                            << _.grammar().lookupOperandName(
                                   SPV_OPERAND_TYPE_BUILT_IN,
-                                  decoration.params()[0])
+                                  (uint32_t)decoration.builtin())
                            << " variable needs to be a 32-bit float array. "
                            << message;
                   })) {
@@ -1294,7 +1297,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                     [this, &decoration, &referenced_from_inst](
                         const std::string& message) -> spv_result_t {
                       uint32_t vuid =
-                          (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance)
+                          (decoration.builtin() == spv::BuiltIn::ClipDistance)
                               ? 4191
                               : 4200;
                       return _.diag(SPV_ERROR_INVALID_DATA,
@@ -1303,7 +1306,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                              << "According to the Vulkan spec BuiltIn "
                              << _.grammar().lookupOperandName(
                                     SPV_OPERAND_TYPE_BUILT_IN,
-                                    decoration.params()[0])
+                                    (uint32_t)decoration.builtin())
                              << " variable needs to be a 32-bit float array. "
                              << message;
                     })) {
@@ -1315,7 +1318,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                     [this, &decoration, &referenced_from_inst](
                         const std::string& message) -> spv_result_t {
                       uint32_t vuid =
-                          (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance)
+                          (decoration.builtin() == spv::BuiltIn::ClipDistance)
                               ? 4191
                               : 4200;
                       return _.diag(SPV_ERROR_INVALID_DATA,
@@ -1324,7 +1327,7 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
                              << "According to the Vulkan spec BuiltIn "
                              << _.grammar().lookupOperandName(
                                     SPV_OPERAND_TYPE_BUILT_IN,
-                                    decoration.params()[0])
+                                    (uint32_t)decoration.builtin())
                              << " variable needs to be a 32-bit float array. "
                              << message;
                     })) {
@@ -1335,8 +1338,9 @@ spv_result_t BuiltInsValidator::ValidateClipOrCullDistanceAtReference(
         }
 
         default: {
-          uint32_t vuid =
-              (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::ClipDistance) ? 4187 : 4196;
+          uint32_t vuid = (decoration.builtin() == spv::BuiltIn::ClipDistance)
+                              ? 4187
+                              : 4196;
           return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                  << _.VkErrorID(vuid) << "Vulkan spec allows BuiltIn "
                  << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
@@ -2542,7 +2546,7 @@ spv_result_t BuiltInsValidator::ValidateTessLevelAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -2561,7 +2565,8 @@ spv_result_t BuiltInsValidator::ValidateTessLevelAtReference(
 
     if (storage_class == spv::StorageClass::Input) {
       assert(function_id_ == 0);
-      uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::TessLevelOuter) ? 4391 : 4395;
+      uint32_t vuid =
+          (decoration.builtin() == spv::BuiltIn::TessLevelOuter) ? 4391 : 4395;
       id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
           &BuiltInsValidator::ValidateNotCalledWithExecutionModel, this, vuid,
           "Vulkan spec doesn't allow TessLevelOuter/TessLevelInner to be "
@@ -2574,7 +2579,8 @@ spv_result_t BuiltInsValidator::ValidateTessLevelAtReference(
 
     if (storage_class == spv::StorageClass::Output) {
       assert(function_id_ == 0);
-      uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::TessLevelOuter) ? 4392 : 4396;
+      uint32_t vuid =
+          (decoration.builtin() == spv::BuiltIn::TessLevelOuter) ? 4392 : 4396;
       id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
           &BuiltInsValidator::ValidateNotCalledWithExecutionModel, this, vuid,
           "Vulkan spec doesn't allow TessLevelOuter/TessLevelInner to be "
@@ -2724,12 +2730,13 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtDefinition(
               [this, &decoration,
                &inst](const std::string& message) -> spv_result_t {
                 uint32_t vuid =
-                    (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::Layer) ? 4276 : 4408;
+                    (decoration.builtin() == spv::BuiltIn::Layer) ? 4276 : 4408;
                 return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                        << _.VkErrorID(vuid)
                        << "According to the Vulkan spec BuiltIn "
                        << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0])
+                              SPV_OPERAND_TYPE_BUILT_IN,
+                              (uint32_t)decoration.builtin())
                        << "variable needs to be a 32-bit int scalar. "
                        << message;
               })) {
@@ -2741,12 +2748,13 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtDefinition(
               [this, &decoration,
                &inst](const std::string& message) -> spv_result_t {
                 uint32_t vuid =
-                    (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::Layer) ? 4276 : 4408;
+                    (decoration.builtin() == spv::BuiltIn::Layer) ? 4276 : 4408;
                 return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                        << _.VkErrorID(vuid)
                        << "According to the Vulkan spec BuiltIn "
                        << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0])
+                              SPV_OPERAND_TYPE_BUILT_IN,
+                              (uint32_t)decoration.builtin())
                        << "variable needs to be a 32-bit int scalar. "
                        << message;
               })) {
@@ -2763,7 +2771,7 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -2877,7 +2885,7 @@ spv_result_t BuiltInsValidator::ValidateLayerOrViewportIndexAtReference(
 spv_result_t BuiltInsValidator::ValidateFragmentShaderF32Vec3InputAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateF32Vec(
             decoration, inst, 3,
             [this, &inst, builtin](const std::string& message) -> spv_result_t {
@@ -2907,7 +2915,7 @@ spv_result_t BuiltInsValidator::ValidateFragmentShaderF32Vec3InputAtReference(
     const Instruction& referenced_from_inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -2951,7 +2959,7 @@ spv_result_t BuiltInsValidator::ValidateFragmentShaderF32Vec3InputAtReference(
 spv_result_t BuiltInsValidator::ValidateComputeShaderI32Vec3InputAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateI32Vec(
             decoration, inst, 3,
             [this, &inst, builtin](const std::string& message) -> spv_result_t {
@@ -2980,7 +2988,7 @@ spv_result_t BuiltInsValidator::ValidateComputeShaderI32Vec3InputAtReference(
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -3031,7 +3039,7 @@ spv_result_t BuiltInsValidator::ValidateComputeShaderI32Vec3InputAtReference(
 spv_result_t BuiltInsValidator::ValidateComputeI32InputAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (decoration.struct_member_index() != Decoration::kInvalidMember) {
       return _.diag(SPV_ERROR_INVALID_DATA, &inst)
              << "BuiltIn "
@@ -3065,7 +3073,7 @@ spv_result_t BuiltInsValidator::ValidateComputeI32InputAtReference(
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -3116,7 +3124,7 @@ spv_result_t BuiltInsValidator::ValidateComputeI32InputAtReference(
 spv_result_t BuiltInsValidator::ValidateI32InputAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (decoration.struct_member_index() != Decoration::kInvalidMember) {
       return _.diag(SPV_ERROR_INVALID_DATA, &inst)
              << "BuiltIn "
@@ -3159,7 +3167,7 @@ spv_result_t BuiltInsValidator::ValidateI32InputAtDefinition(
 spv_result_t BuiltInsValidator::ValidateI32Vec4InputAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (decoration.struct_member_index() != Decoration::kInvalidMember) {
       return _.diag(SPV_ERROR_INVALID_DATA, &inst)
              << "BuiltIn "
@@ -3247,7 +3255,7 @@ spv_result_t BuiltInsValidator::ValidateWorkgroupSizeAtReference(
                << spvLogStringForEnv(_.context()->target_env)
                << " spec allows BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                decoration.params()[0])
+                                                (uint32_t)decoration.builtin())
                << " to be used only with GLCompute, MeshNV, TaskNV, MeshEXT or "
                << "TaskEXT execution model. "
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
@@ -3273,14 +3281,15 @@ spv_result_t BuiltInsValidator::ValidateBaseInstanceOrVertexAtDefinition(
             decoration, inst,
             [this, &inst,
              &decoration](const std::string& message) -> spv_result_t {
-              uint32_t vuid = (spv::BuiltIn(decoration.params()[0]) == spv::BuiltIn::BaseInstance)
-                                  ? 4183
-                                  : 4186;
+              uint32_t vuid =
+                  (decoration.builtin() == spv::BuiltIn::BaseInstance) ? 4183
+                                                                       : 4186;
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(vuid)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3295,7 +3304,7 @@ spv_result_t BuiltInsValidator::ValidateBaseInstanceOrVertexAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -3346,8 +3355,9 @@ spv_result_t BuiltInsValidator::ValidateDrawIndexAtDefinition(
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(4209)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3362,7 +3372,7 @@ spv_result_t BuiltInsValidator::ValidateDrawIndexAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -3416,8 +3426,9 @@ spv_result_t BuiltInsValidator::ValidateViewIndexAtDefinition(
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(4403)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3432,7 +3443,7 @@ spv_result_t BuiltInsValidator::ValidateViewIndexAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -3480,8 +3491,9 @@ spv_result_t BuiltInsValidator::ValidateDeviceIndexAtDefinition(
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(4206)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3496,7 +3508,7 @@ spv_result_t BuiltInsValidator::ValidateDeviceIndexAtReference(
     const Decoration& decoration, const Instruction& built_in_inst,
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
-  uint32_t operand = decoration.params()[0];
+  uint32_t operand = (uint32_t)decoration.builtin();
   if (spvIsVulkanEnv(_.context()->target_env)) {
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -3526,7 +3538,7 @@ spv_result_t BuiltInsValidator::ValidateFragInvocationCountAtDefinition(const De
                                             const Instruction& inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateI32(
             decoration, inst,
             [this, &inst, &builtin](const std::string& message) -> spv_result_t {
@@ -3553,7 +3565,7 @@ spv_result_t BuiltInsValidator::ValidateFragInvocationCountAtReference(
     const Instruction& referenced_from_inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -3596,7 +3608,7 @@ spv_result_t BuiltInsValidator::ValidateFragInvocationCountAtReference(
 spv_result_t BuiltInsValidator::ValidateFragSizeAtDefinition(const Decoration& decoration,
                                             const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateI32Vec(
             decoration, inst, 2,
             [this, &inst, &builtin](const std::string& message) -> spv_result_t {
@@ -3623,7 +3635,7 @@ spv_result_t BuiltInsValidator::ValidateFragSizeAtReference(
     const Instruction& referenced_from_inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -3666,7 +3678,7 @@ spv_result_t BuiltInsValidator::ValidateFragSizeAtReference(
 spv_result_t BuiltInsValidator::ValidateFragStencilRefAtDefinition(const Decoration& decoration,
                                             const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateI(
             decoration, inst,
             [this, &inst, &builtin](const std::string& message) -> spv_result_t {
@@ -3693,7 +3705,7 @@ spv_result_t BuiltInsValidator::ValidateFragStencilRefAtReference(
     const Instruction& referenced_from_inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Output) {
@@ -3736,7 +3748,7 @@ spv_result_t BuiltInsValidator::ValidateFragStencilRefAtReference(
 spv_result_t BuiltInsValidator::ValidateFullyCoveredAtDefinition(const Decoration& decoration,
                                                const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     if (spv_result_t error = ValidateBool(
             decoration, inst,
             [this, &inst, &builtin](const std::string& message) -> spv_result_t {
@@ -3763,7 +3775,7 @@ spv_result_t BuiltInsValidator::ValidateFullyCoveredAtReference(
     const Instruction& referenced_from_inst) {
 
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -3814,8 +3826,9 @@ spv_result_t BuiltInsValidator::ValidateNVSMOrARMCoreBuiltinsAtDefinition(
                      << "According to the "
                      << spvLogStringForEnv(_.context()->target_env)
                      << " spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3839,7 +3852,7 @@ spv_result_t BuiltInsValidator::ValidateNVSMOrARMCoreBuiltinsAtReference(
              << spvLogStringForEnv(_.context()->target_env)
              << " spec allows BuiltIn "
              << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                              decoration.params()[0])
+                                              (uint32_t)decoration.builtin())
              << " to be only used for "
                 "variables with Input storage class. "
              << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
@@ -3868,8 +3881,9 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtDefinition(
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(4486)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3892,7 +3906,7 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtReference(
       return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
              << _.VkErrorID(4485) << "Vulkan spec allows BuiltIn "
              << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                              decoration.params()[0])
+                                              (uint32_t)decoration.builtin())
              << " to be only used for variables with Output storage class. "
              << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                  referenced_from_inst)
@@ -3909,8 +3923,9 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtReference(
         default: {
           return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                  << _.VkErrorID(4484) << "Vulkan spec allows BuiltIn "
-                 << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                  decoration.params()[0])
+                 << _.grammar().lookupOperandName(
+                        SPV_OPERAND_TYPE_BUILT_IN,
+                        (uint32_t)decoration.builtin())
                  << " to be used only with Vertex, Geometry, or MeshNV "
                     "execution models. "
                  << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
@@ -3941,8 +3956,9 @@ spv_result_t BuiltInsValidator::ValidateShadingRateAtDefinition(
               return _.diag(SPV_ERROR_INVALID_DATA, &inst)
                      << _.VkErrorID(4492)
                      << "According to the Vulkan spec BuiltIn "
-                     << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                      decoration.params()[0])
+                     << _.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN,
+                            (uint32_t)decoration.builtin())
                      << " variable needs to be a 32-bit int scalar. "
                      << message;
             })) {
@@ -3965,7 +3981,7 @@ spv_result_t BuiltInsValidator::ValidateShadingRateAtReference(
       return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
              << _.VkErrorID(4491) << "Vulkan spec allows BuiltIn "
              << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                              decoration.params()[0])
+                                              (uint32_t)decoration.builtin())
              << " to be only used for variables with Input storage class. "
              << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                  referenced_from_inst)
@@ -3977,7 +3993,7 @@ spv_result_t BuiltInsValidator::ValidateShadingRateAtReference(
         return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                << _.VkErrorID(4490) << "Vulkan spec allows BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                decoration.params()[0])
+                                                (uint32_t)decoration.builtin())
                << " to be used only with the Fragment execution model. "
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
@@ -3998,7 +4014,7 @@ spv_result_t BuiltInsValidator::ValidateShadingRateAtReference(
 spv_result_t BuiltInsValidator::ValidateRayTracingBuiltinsAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     switch (builtin) {
       case spv::BuiltIn::HitTNV:
       case spv::BuiltIn::RayTminKHR:
@@ -4121,7 +4137,7 @@ spv_result_t BuiltInsValidator::ValidateRayTracingBuiltinsAtReference(
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class = GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
         storage_class != spv::StorageClass::Input) {
@@ -4129,7 +4145,7 @@ spv_result_t BuiltInsValidator::ValidateRayTracingBuiltinsAtReference(
       return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
              << _.VkErrorID(vuid) << "Vulkan spec allows BuiltIn "
              << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                              decoration.params()[0])
+                                              (uint32_t)decoration.builtin())
              << " to be only used for variables with Input storage class. "
              << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                  referenced_from_inst)
@@ -4142,10 +4158,11 @@ spv_result_t BuiltInsValidator::ValidateRayTracingBuiltinsAtReference(
         return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
                << _.VkErrorID(vuid) << "Vulkan spec does not allow BuiltIn "
                << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
-                                                decoration.params()[0])
+                                                (uint32_t)decoration.builtin())
                << " to be used with the execution model "
                << _.grammar().lookupOperandName(
-                      SPV_OPERAND_TYPE_EXECUTION_MODEL, uint32_t(execution_model))
+                      SPV_OPERAND_TYPE_EXECUTION_MODEL,
+                      uint32_t(execution_model))
                << ".\n"
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
@@ -4167,7 +4184,7 @@ spv_result_t BuiltInsValidator::ValidateRayTracingBuiltinsAtReference(
 spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorType);
     if (builtin == spv::BuiltIn::PrimitivePointIndicesEXT) {
       if (spv_result_t error = ValidateI32Arr(
@@ -4179,7 +4196,8 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtDefinition(
                        << spvLogStringForEnv(_.context()->target_env)
                        << " spec BuiltIn "
                        << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0])
+                              SPV_OPERAND_TYPE_BUILT_IN,
+                              (uint32_t)decoration.builtin())
                        << " variable needs to be a 32-bit int array."
                        << message;
               })) {
@@ -4196,7 +4214,8 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtDefinition(
                        << spvLogStringForEnv(_.context()->target_env)
                        << " spec BuiltIn "
                        << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0])
+                              SPV_OPERAND_TYPE_BUILT_IN,
+                              (uint32_t)decoration.builtin())
                        << " variable needs to be a 2-component 32-bit int "
                           "array."
                        << message;
@@ -4214,7 +4233,8 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtDefinition(
                        << spvLogStringForEnv(_.context()->target_env)
                        << " spec BuiltIn "
                        << _.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, decoration.params()[0])
+                              SPV_OPERAND_TYPE_BUILT_IN,
+                              (uint32_t)decoration.builtin())
                        << " variable needs to be a 3-component 32-bit int "
                           "array."
                        << message;
@@ -4233,7 +4253,7 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtReference(
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    const spv::BuiltIn builtin = spv::BuiltIn(decoration.params()[0]);
+    const spv::BuiltIn builtin = decoration.builtin();
     const spv::StorageClass storage_class =
         GetStorageClass(referenced_from_inst);
     if (storage_class != spv::StorageClass::Max &&
@@ -4279,7 +4299,7 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtReference(
 
 spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
-  const spv::BuiltIn label = spv::BuiltIn(decoration.params()[0]);
+  const spv::BuiltIn label = decoration.builtin();
 
   if (!spvIsVulkanEnv(_.context()->target_env)) {
     // Early return. All currently implemented rules are based on Vulkan spec.

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -869,8 +869,6 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
               ++num_builtin_block_outputs;
             if (num_builtin_block_inputs > 1 || num_builtin_block_outputs > 1)
               break;
-            if (auto error = CheckBuiltInVariable(interface, vstate))
-              return error;
           }
         }
 

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -71,17 +71,6 @@ uint32_t GetArrayStride(uint32_t array_id, ValidationState_t& vstate) {
   return 0;
 }
 
-// Returns true if the given structure type has any members with BuiltIn
-// decoration.
-bool isBuiltInStruct(uint32_t struct_id, ValidationState_t& vstate) {
-  const auto& decorations = vstate.id_decorations(struct_id);
-  return std::any_of(
-      decorations.begin(), decorations.end(), [](const Decoration& d) {
-        return spv::Decoration::BuiltIn == d.dec_type() &&
-               Decoration::kInvalidMember != d.struct_member_index();
-      });
-}
-
 // Returns true if the given structure type has a Block decoration.
 bool isBlock(uint32_t struct_id, ValidationState_t& vstate) {
   const auto& decorations = vstate.id_decorations(struct_id);
@@ -822,67 +811,72 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
         // to.
         const uint32_t type_id = ptr_instr->word(3);
         Instruction* type_instr = vstate.FindDef(type_id);
-        if (type_instr && spv::Op::OpTypeStruct == type_instr->opcode() &&
-            isBuiltInStruct(type_id, vstate)) {
-          if (!isBlock(type_id, vstate)) {
-            return vstate.diag(SPV_ERROR_INVALID_DATA, vstate.FindDef(type_id))
-                   << vstate.VkErrorID(4919)
-                   << "Interface struct has no Block decoration but has "
-                      "BuiltIn members. "
-                      "Location decorations must be used on each member of "
-                      "OpVariable with a structure type that is a block not "
-                      "decorated with Location.";
+        const bool is_struct =
+            type_instr && spv::Op::OpTypeStruct == type_instr->opcode();
+
+        // Search all Built-in (on the variable or the struct)
+        bool has_built_in = false;
+        for (auto& dec :
+             vstate.id_decorations(is_struct ? type_id : interface)) {
+          if (dec.dec_type() != spv::Decoration::BuiltIn) continue;
+          has_built_in = true;
+
+          if (!spvIsVulkanEnv(vstate.context()->target_env)) continue;
+
+          const spv::BuiltIn builtin = dec.builtin();
+          if (storage_class == spv::StorageClass::Input) {
+            if (!input_var_builtin.insert(builtin).second) {
+              return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
+                     << vstate.VkErrorID(9658)
+                     << "OpEntryPoint contains duplicate input variables "
+                        "with "
+                     << vstate.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN, (uint32_t)builtin)
+                     << " builtin";
+            }
           }
-          if (storage_class == spv::StorageClass::Input)
-            ++num_builtin_block_inputs;
-          if (storage_class == spv::StorageClass::Output)
-            ++num_builtin_block_outputs;
-          if (num_builtin_block_inputs > 1 || num_builtin_block_outputs > 1)
-            break;
+          if (storage_class == spv::StorageClass::Output) {
+            if (!output_var_builtin.insert(builtin).second) {
+              return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
+                     << vstate.VkErrorID(9659)
+                     << "OpEntryPoint contains duplicate output variables "
+                        "with "
+                     << vstate.grammar().lookupOperandName(
+                            SPV_OPERAND_TYPE_BUILT_IN, (uint32_t)builtin)
+                     << " builtin";
+            }
+          }
+        }
+
+        if (has_built_in) {
           if (auto error = CheckBuiltInVariable(interface, vstate))
             return error;
-        } else {
-          // If there is not builtin block, check for builtin on the variable
-          for (auto& dec : vstate.id_decorations(interface)) {
-            if (dec.dec_type() != spv::Decoration::BuiltIn) continue;
 
+          if (is_struct) {
+            if (!isBlock(type_id, vstate)) {
+              return vstate.diag(SPV_ERROR_INVALID_DATA,
+                                 vstate.FindDef(type_id))
+                     << vstate.VkErrorID(4919)
+                     << "Interface struct has no Block decoration but has "
+                        "BuiltIn members. "
+                        "Location decorations must be used on each member of "
+                        "OpVariable with a structure type that is a block not "
+                        "decorated with Location.";
+            }
+            if (storage_class == spv::StorageClass::Input)
+              ++num_builtin_block_inputs;
+            if (storage_class == spv::StorageClass::Output)
+              ++num_builtin_block_outputs;
+            if (num_builtin_block_inputs > 1 || num_builtin_block_outputs > 1)
+              break;
             if (auto error = CheckBuiltInVariable(interface, vstate))
               return error;
-
-            if (!spvIsVulkanEnv(vstate.context()->target_env)) continue;
-
-            const spv::BuiltIn builtin = dec.builtin();
-            if (storage_class == spv::StorageClass::Input) {
-              // RayTmaxKHR can be duplicated
-              // (https://gitlab.khronos.org/vulkan/vulkan/-/issues/3885)
-              if (!input_var_builtin.insert(builtin).second &&
-                  builtin != spv::BuiltIn::RayTmaxKHR) {
-                return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                       << vstate.VkErrorID(9658)
-                       << "OpEntryPoint contains duplicate input variables "
-                          "with "
-                       << vstate.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, (uint32_t)builtin)
-                       << " builtin";
-              }
-            }
-            if (storage_class == spv::StorageClass::Output) {
-              if (!output_var_builtin.insert(builtin).second) {
-                return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                       << vstate.VkErrorID(9659)
-                       << "OpEntryPoint contains duplicate output variables "
-                          "with "
-                       << vstate.grammar().lookupOperandName(
-                              SPV_OPERAND_TYPE_BUILT_IN, (uint32_t)builtin)
-                       << " builtin";
-              }
-            }
           }
         }
 
         if (storage_class == spv::StorageClass::Workgroup) {
           ++num_workgroup_variables;
-          if (type_instr && spv::Op::OpTypeStruct == type_instr->opcode()) {
+          if (is_struct) {
             if (hasDecoration(type_id, spv::Decoration::Block, vstate))
               ++num_workgroup_variables_with_block;
             if (hasDecoration(var_instr->id(), spv::Decoration::Aliased,

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -853,7 +853,10 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
 
             const spv::BuiltIn builtin = dec.builtin();
             if (storage_class == spv::StorageClass::Input) {
-              if (!input_var_builtin.insert(builtin).second) {
+              // RayTmaxKHR can be duplicated
+              // (https://gitlab.khronos.org/vulkan/vulkan/-/issues/3885)
+              if (!input_var_builtin.insert(builtin).second &&
+                  builtin != spv::BuiltIn::RayTmaxKHR) {
                 return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
                        << vstate.VkErrorID(9658)
                        << "OpEntryPoint contains duplicate input variables "

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2353,6 +2353,10 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Pointer-08973);
     case 9638:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-09638);
+    case 9658:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpEntryPoint-09658);
+    case 9659:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpEntryPoint-09659);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -9670,6 +9670,177 @@ OpFunctionEnd
       HasSubstr("is a matrix with stride 8 not satisfying alignment to 16"));
 }
 
+TEST_F(ValidateDecorations, MultipleBuiltinsInputVertex) {
+  const std::string body = R"(
+               OpCapability Shader
+               OpCapability DrawParameters
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %_ %gl_BaseInstance1 %gl_BaseInstance2
+               OpMemberDecorate %gl_PerVertex 0 BuiltIn Position
+               OpMemberDecorate %gl_PerVertex 1 BuiltIn PointSize
+               OpMemberDecorate %gl_PerVertex 2 BuiltIn ClipDistance
+               OpMemberDecorate %gl_PerVertex 3 BuiltIn CullDistance
+               OpDecorate %gl_PerVertex Block
+               OpDecorate %gl_BaseInstance1 BuiltIn BaseInstance
+               OpDecorate %gl_BaseInstance2 BuiltIn BaseInstance
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+%_arr_float_uint_1 = OpTypeArray %float %uint_1
+%gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
+%_ptr_Output_gl_PerVertex = OpTypePointer Output %gl_PerVertex
+          %_ = OpVariable %_ptr_Output_gl_PerVertex Output
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+         %17 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_Input_int = OpTypePointer Input %int
+%gl_BaseInstance1 = OpVariable %_ptr_Input_int Input
+%gl_BaseInstance2 = OpVariable %_ptr_Input_int Input
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %20 = OpLoad %int %gl_BaseInstance1
+         %21 = OpConvertSToF %float %20
+         %22 = OpVectorTimesScalar %v4float %17 %21
+         %24 = OpAccessChain %_ptr_Output_v4float %_ %int_0
+               OpStore %24 %22
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint contains duplicate input variables with "
+                        "BaseInstance builtin"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-09658"));
+}
+
+TEST_F(ValidateDecorations, MultipleBuiltinsInputMesh) {
+  const std::string body = R"(
+               OpCapability DrawParameters
+               OpCapability MeshShadingEXT
+               OpExtension "SPV_EXT_mesh_shader"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint MeshEXT %main "main" %gl_DrawID_1 %gl_DrawID_2
+               OpExecutionMode %main LocalSize 1 1 1
+               OpExecutionMode %main OutputVertices 32
+               OpExecutionMode %main OutputPrimitivesEXT 32
+               OpExecutionMode %main OutputTrianglesEXT
+               OpDecorate %gl_DrawID_1 BuiltIn DrawIndex
+               OpDecorate %gl_DrawID_2 BuiltIn DrawIndex
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%_ptr_Input_int = OpTypePointer Input %int
+  %gl_DrawID_1 = OpVariable %_ptr_Input_int Input
+  %gl_DrawID_2 = OpVariable %_ptr_Input_int Input
+       %uint = OpTypeInt 32 0
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %9 = OpLoad %int %gl_DrawID_1
+         %11 = OpBitcast %uint %9
+         %12 = OpLoad %int %gl_DrawID_2
+         %13 = OpBitcast %uint %12
+               OpSetMeshOutputsEXT %11 %13
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint contains duplicate input variables with "
+                        "DrawIndex builtin"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-09658"));
+}
+
+TEST_F(ValidateDecorations, MultipleBuiltinsInputCompute) {
+  const std::string body = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %_ %gl_WorkGroupID_1 %gl_WorkGroupID_2
+               OpExecutionMode %main LocalSize 1 1 1
+               OpMemberDecorate %Buffers 0 Offset 0
+               OpDecorate %Buffers Block
+               OpDecorate %_ DescriptorSet 0
+               OpDecorate %_ Binding 0
+               OpDecorate %gl_WorkGroupID_1 BuiltIn WorkgroupId
+               OpDecorate %gl_WorkGroupID_2 BuiltIn WorkgroupId
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+    %Buffers = OpTypeStruct %v3uint
+%_ptr_StorageBuffer_Buffers = OpTypePointer StorageBuffer %Buffers
+          %_ = OpVariable %_ptr_StorageBuffer_Buffers StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_WorkGroupID_1 = OpVariable %_ptr_Input_v3uint Input
+%gl_WorkGroupID_2 = OpVariable %_ptr_Input_v3uint Input
+%_ptr_StorageBuffer_v3uint = OpTypePointer StorageBuffer %v3uint
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %15 = OpLoad %v3uint %gl_WorkGroupID_1
+         %16 = OpLoad %v3uint %gl_WorkGroupID_2
+         %17 = OpIAdd %v3uint %15 %16
+         %19 = OpAccessChain %_ptr_StorageBuffer_v3uint %_ %int_0
+               OpStore %19 %17
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint contains duplicate input variables with "
+                        "WorkgroupId builtin"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-09658"));
+}
+
+TEST_F(ValidateDecorations, MultipleBuiltinsOutputFragment) {
+  const std::string body = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_FragDepth_1 %gl_FragDepth_2
+               OpExecutionMode %main OriginUpperLeft
+               OpExecutionMode %main DepthReplacing
+               OpDecorate %gl_FragDepth_1 BuiltIn FragDepth
+               OpDecorate %gl_FragDepth_2 BuiltIn FragDepth
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_ptr_Output_float = OpTypePointer Output %float
+%gl_FragDepth_1 = OpVariable %_ptr_Output_float Output
+%gl_FragDepth_2 = OpVariable %_ptr_Output_float Output
+    %float_1 = OpConstant %float 1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpStore %gl_FragDepth_1 %float_1
+         %10 = OpLoad %float %gl_FragDepth_1
+         %11 = OpFAdd %float %10 %float_1
+               OpStore %gl_FragDepth_2 %11
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_2);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpEntryPoint contains duplicate output variables with "
+                        "FragDepth builtin"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-09659"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6625 (added in 1.3.285) (original issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2313)

This adds 

- VUID-StandaloneSpirv-OpEntryPoint-09658
- VUID-StandaloneSpirv-OpEntryPoint-09659

![image](https://github.com/KhronosGroup/SPIRV-Tools/assets/115671160/b33e8d55-84f3-4525-9267-f7d8bb03a188)
