### PR TITLE
spirv-val: Consider target env for OpReadClockKHR scope

### DIFF
--- a/test/val/val_misc_test.cpp
+++ b/test/val/val_misc_test.cpp
@@ -222,7 +222,7 @@ OpReturn
 OpFunctionEnd)";
 
   CompileSuccessfully(spirv);
-  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Scope must be Subgroup or Device"));
 }
@@ -249,6 +249,59 @@ OpFunctionEnd)";
               AnyVUID("VUID-StandaloneSpirv-OpReadClockKHR-04652"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Scope must be Subgroup or Device"));
+}
+
+std::string GenKernelClockSpirv(const std::string& scope) {
+  const std::string s = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Physical32 OpenCL
+OpEntryPoint Kernel %main "main"
+OpExecutionMode %main ContractionOff
+OpSource OpenCL_C 200000
+OpName %main "main"
+OpName %time1 "time1"
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%ulong = OpTypeInt 64 0
+%uint = OpTypeInt 32 0
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%scope = OpConstant %uint )" +
+                        scope + R"(
+%main = OpFunction %void None %3
+%5 = OpLabel
+%time1 = OpVariable %_ptr_Function_ulong Function
+%11 = OpReadClockKHR %ulong %scope
+OpStore %time1 %11
+OpReturn
+OpFunctionEnd
+)";
+  return s;
+}
+
+TEST_F(ValidateMisc, KernelClockScopeDevice) {
+  CompileSuccessfully(GenKernelClockSpirv("1"), SPV_ENV_OPENCL_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_OPENCL_1_2));
+}
+
+TEST_F(ValidateMisc, KernelClockScopeWorkgroup) {
+  CompileSuccessfully(GenKernelClockSpirv("2"), SPV_ENV_OPENCL_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_OPENCL_1_2));
+}
+
+TEST_F(ValidateMisc, KernelClockScopeSubgroup) {
+  CompileSuccessfully(GenKernelClockSpirv("3"), SPV_ENV_OPENCL_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_OPENCL_1_2));
+}
+
+TEST_F(ValidateMisc, KernelClockScopeInvalid) {
+  CompileSuccessfully(GenKernelClockSpirv("0"), SPV_ENV_OPENCL_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_OPENCL_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Scope must be Subgroup, Workgroup, or Device"));
 }
 
 TEST_F(ValidateMisc, UndefVoid) {


### PR DESCRIPTION
The Scope operand of `OpReadClockKHR` was always validated using the Vulkan environment rules, which only allow `Subgroup` or `Device`. For the OpenCL environment, [`Workgroup` is also a valid Scope](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#_cl_khr_kernel_clock), so `Workgroup` should not be rejected in the universal environment.

Guard the existing Scope check behind `spvIsVulkanEnv()` and add a new Scope check for the OpenCL environment.