### PR TITLE
spirv-val: Fix indentation of --version output

### DIFF
--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
         printf("%s\n", spvSoftwareVersionDetailsString());
         printf(
             "Targets:\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  %s\n  "
-            "%s\n %s\n %s\n %s\n",
+            "%s\n  %s\n  %s\n  %s\n",
             spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0),
             spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_1),
             spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_2),


### PR DESCRIPTION
The last three elements in the list of supported targets were misaligned:

```
Targets:
  SPIR-V 1.0
  SPIR-V 1.1
  ...
  SPIR-V 1.3 (under Vulkan 1.1 semantics)
 SPIR-V 1.4 (under Vulkan 1.1 semantics)
 SPIR-V 1.5 (under Vulkan 1.2 semantics)
 SPIR-V 1.6 (under Vulkan 1.3 semantics)
```