### PR TITLE
Remove implicit call to GetId in ConvertToSampledImagePass.

### DIFF
--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -329,12 +329,10 @@ bool ConvertToSampledImagePass::ConvertImageVariableToSampledImage(
   if (sampled_image_type == nullptr) return false;
   auto storage_class = GetStorageClass(*image_variable);
   if (storage_class == spv::StorageClass::Max) return false;
-  analysis::Pointer sampled_image_pointer(sampled_image_type, storage_class);
-
   // Make sure |image_variable| is behind its type i.e., avoid the forward
   // reference.
-  uint32_t type_id =
-      context()->get_type_mgr()->GetTypeInstruction(&sampled_image_pointer);
+  uint32_t type_id = context()->get_type_mgr()->FindPointerToType(
+      sampled_image_type_id, storage_class);
   MoveInstructionNextToType(image_variable, type_id);
   return true;
 }

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -454,12 +454,7 @@ uint32_t TypeManager::FindPointerToType(uint32_t type_id,
                                         spv::StorageClass storage_class) {
   Type* pointeeTy = GetType(type_id);
   Pointer pointerTy(pointeeTy, storage_class);
-  if (pointeeTy->IsUniqueType()) {
-    // Non-ambiguous type. Get the pointer type through the type manager.
-    return GetTypeInstruction(&pointerTy);
-  }
 
-  // Ambiguous type, do a linear search.
   Module::inst_iterator type_itr = context()->module()->types_values_begin();
   for (; type_itr != context()->module()->types_values_end(); ++type_itr) {
     const Instruction* type_inst = &*type_itr;
@@ -472,8 +467,10 @@ uint32_t TypeManager::FindPointerToType(uint32_t type_id,
   }
 
   // Must create the pointer type.
-  // TODO(1841): Handle id overflow.
   uint32_t resultId = context()->TakeNextId();
+  if (resultId == 0) {
+    return 0;
+  }
   std::unique_ptr<Instruction> type_inst(
       new Instruction(context(), spv::Op::OpTypePointer, 0, resultId,
                       {{spv_operand_type_t::SPV_OPERAND_TYPE_STORAGE_CLASS,


### PR DESCRIPTION
We replace getting the id of a poitner type with a specific funciton
call to FindPointerToType. Also, FindPointerToType is updated to not
indirectly call GetId. This leads to a linear search for an existing
type in all cases, but it is necessary.

Note that this function could have a similar problem. There could be two
pointer types with the same pointee and storage class, and the first one
will be returned. I have checked the ~20 uses, and they are all used in
situations where the id is used to create something new, and it does not
have to match an existing type. These will not cause problems.

Part of #5691