### PR TITLE
Add assert header to val/decoration.h

### DIFF
--- a/source/val/decoration.h
+++ b/source/val/decoration.h
@@ -15,6 +15,7 @@
 #ifndef SOURCE_VAL_DECORATION_H_
 #define SOURCE_VAL_DECORATION_H_
 
+#include <cassert>
 #include <cstdint>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
Some platforms fail to compile if the cassert header is not included in
decoration.h. Adding it to make those work.