### PR TITLE
opt: add OpExtInst forward ref fixup pass

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -157,6 +157,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/merge_return_pass.cpp \
 		source/opt/modify_maximal_reconvergence.cpp \
 		source/opt/module.cpp \
+		source/opt/opextinst_forward_ref_fixup_pass.cpp \
 		source/opt/optimizer.cpp \
 		source/opt/pass.cpp \
 		source/opt/pass_manager.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -742,6 +742,8 @@ static_library("spvtools_opt") {
     "source/opt/module.cpp",
     "source/opt/module.h",
     "source/opt/null_pass.h",
+    "source/opt/opextinst_forward_ref_fixup_pass.cpp",
+    "source/opt/opextinst_forward_ref_fixup_pass.h",
     "source/opt/optimizer.cpp",
     "source/opt/pass.cpp",
     "source/opt/pass.h",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -856,6 +856,12 @@ Optimizer::PassToken CreateAmdExtToKhrPass();
 // propagated into their final positions.
 Optimizer::PassToken CreateInterpolateFixupPass();
 
+// Replace OpExtInst instructions with OpExtInstWithForwardRefsKHR when
+// the instruction contains a forward references, and replaces
+// OpExtInstWithForwardRefsKHR with OpExtInst when there is no forward
+// references.
+Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass();
+
 // Removes unused components from composite input variables. Current
 // implementation just removes trailing unused components from input arrays
 // and structs. The pass performs best after maximizing dead code removal.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -857,9 +857,9 @@ Optimizer::PassToken CreateAmdExtToKhrPass();
 Optimizer::PassToken CreateInterpolateFixupPass();
 
 // Replace OpExtInst instructions with OpExtInstWithForwardRefsKHR when
-// the instruction contains a forward references, and replaces
-// OpExtInstWithForwardRefsKHR with OpExtInst when there is no forward
-// references.
+// the instruction contains a forward reference to another debug instuction.
+// Replace OpExtInstWithForwardRefsKHR with OpExtInst when there are no forward
+// reference to another debug instruction.
 Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass();
 
 // Removes unused components from composite input variables. Current

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   interface_var_sroa.h
   invocation_interlock_placement_pass.h
   interp_fixup_pass.h
+  opextinst_forward_ref_fixup_pass.h
   ir_builder.h
   ir_context.h
   ir_loader.h
@@ -191,6 +192,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   interface_var_sroa.cpp
   invocation_interlock_placement_pass.cpp
   interp_fixup_pass.cpp
+  opextinst_forward_ref_fixup_pass.cpp
   ir_context.cpp
   ir_loader.cpp
   licm_pass.cpp

--- a/source/opt/opextinst_forward_ref_fixup_pass.cpp
+++ b/source/opt/opextinst_forward_ref_fixup_pass.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/opextinst_forward_ref_fixup_pass.h"
+
+#include <set>
+#include <string>
+
+#include "source/extensions.h"
+#include "source/opt/ir_context.h"
+#include "type_manager.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+bool Fixup(IRContext* ctx, const std::unordered_set<uint32_t>& all_debug_ids,
+           std::unordered_set<uint32_t>& seen_ids,
+           bool* hasAtLeastOneForwardReference, Instruction* inst) {
+  seen_ids.insert(inst->result_id());
+
+  if (inst->opcode() != spv::Op::OpExtInst &&
+      inst->opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
+    return false;
+
+  const uint32_t num_in_operands = inst->NumInOperands();
+  bool hasForwardReferences = false;
+  for (uint32_t i = 0; i < num_in_operands; ++i) {
+    const Operand& op = inst->GetInOperand(i);
+    if (!spvIsIdType(op.type)) continue;
+
+    if (all_debug_ids.count(op.AsId()) == 0) continue;
+
+    if (seen_ids.count(op.AsId()) == 0) {
+      hasForwardReferences = true;
+      *hasAtLeastOneForwardReference = true;
+      break;
+    }
+  }
+
+  if (hasForwardReferences &&
+      inst->opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
+    inst->SetOpcode(spv::Op::OpExtInstWithForwardRefsKHR);
+  else if (!hasForwardReferences && inst->opcode() != spv::Op::OpExtInst)
+    inst->SetOpcode(spv::Op::OpExtInst);
+  else
+    return false;
+
+  ctx->AnalyzeUses(inst);
+  return true;
+}
+
+}  // namespace
+
+Pass::Status OpExtInstWithForwardReferenceFixupPass::Process() {
+  std::unordered_set<uint32_t> seen_ids;
+  std::unordered_set<uint32_t> all_debug_ids;
+
+  for (const auto& it : get_module()->ext_inst_debuginfo())
+    all_debug_ids.insert(it.result_id());
+
+  for (const auto& it : get_module()->ext_inst_imports()) {
+    all_debug_ids.insert(it.result_id());
+    seen_ids.insert(it.result_id());
+  }
+
+  bool changed = false;
+  bool hasAtLeastOneForwardReference = false;
+  IRContext* ctx = context();
+  for (auto& it : get_module()->ext_inst_debuginfo())
+    changed |= Fixup(ctx, all_debug_ids, seen_ids,
+                     &hasAtLeastOneForwardReference, &it);
+
+  if (hasAtLeastOneForwardReference !=
+      ctx->get_feature_mgr()->HasExtension(
+          kSPV_KHR_relaxed_extended_instruction)) {
+    if (hasAtLeastOneForwardReference)
+      ctx->AddExtension("SPV_KHR_relaxed_extended_instruction");
+    else
+      ctx->RemoveExtension(Extension::kSPV_KHR_relaxed_extended_instruction);
+    changed = true;
+  }
+
+  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/opextinst_forward_ref_fixup_pass.cpp
+++ b/source/opt/opextinst_forward_ref_fixup_pass.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Google Inc.
+// Copyright (c) 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 #include "source/opt/opextinst_forward_ref_fixup_pass.h"
 
-#include <set>
 #include <string>
+#include <unordered_set>
 
 #include "source/extensions.h"
 #include "source/opt/ir_context.h"
@@ -25,62 +25,66 @@ namespace spvtools {
 namespace opt {
 namespace {
 
-bool Fixup(IRContext* ctx, const std::unordered_set<uint32_t>& all_debug_ids,
-           std::unordered_set<uint32_t>& seen_ids,
-           bool* hasAtLeastOneForwardReference, Instruction* inst) {
-  seen_ids.insert(inst->result_id());
-
-  if (inst->opcode() != spv::Op::OpExtInst &&
-      inst->opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
-    return false;
-
-  const uint32_t num_in_operands = inst->NumInOperands();
-  bool hasForwardReferences = false;
+bool HasForwardReference(const Instruction& inst,
+                         const std::unordered_set<uint32_t>& debug_ids,
+                         const std::unordered_set<uint32_t>& seen_ids) {
+  const uint32_t num_in_operands = inst.NumInOperands();
   for (uint32_t i = 0; i < num_in_operands; ++i) {
-    const Operand& op = inst->GetInOperand(i);
+    const Operand& op = inst.GetInOperand(i);
     if (!spvIsIdType(op.type)) continue;
 
-    if (all_debug_ids.count(op.AsId()) == 0) continue;
+    if (debug_ids.count(op.AsId()) == 0) continue;
 
-    if (seen_ids.count(op.AsId()) == 0) {
-      hasForwardReferences = true;
-      *hasAtLeastOneForwardReference = true;
-      break;
-    }
+    if (seen_ids.count(op.AsId()) == 0) return true;
   }
 
+  return false;
+}
+
+bool ReplaceOpcodeIfRequired(Instruction& inst, bool hasForwardReferences) {
   if (hasForwardReferences &&
-      inst->opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
-    inst->SetOpcode(spv::Op::OpExtInstWithForwardRefsKHR);
-  else if (!hasForwardReferences && inst->opcode() != spv::Op::OpExtInst)
-    inst->SetOpcode(spv::Op::OpExtInst);
+      inst.opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
+    inst.SetOpcode(spv::Op::OpExtInstWithForwardRefsKHR);
+  else if (!hasForwardReferences && inst.opcode() != spv::Op::OpExtInst)
+    inst.SetOpcode(spv::Op::OpExtInst);
   else
     return false;
-
-  ctx->AnalyzeUses(inst);
   return true;
+}
+
+template <typename T>
+std::unordered_set<uint32_t> gatherResultIds(const T& list) {
+  std::unordered_set<uint32_t> output;
+  for (const auto& it : list) output.insert(it.result_id());
+  return output;
 }
 
 }  // namespace
 
 Pass::Status OpExtInstWithForwardReferenceFixupPass::Process() {
-  std::unordered_set<uint32_t> seen_ids;
-  std::unordered_set<uint32_t> all_debug_ids;
+  std::unordered_set<uint32_t> seen_ids =
+      gatherResultIds(get_module()->ext_inst_imports());
+  std::unordered_set<uint32_t> debug_ids =
+      gatherResultIds(get_module()->ext_inst_debuginfo());
+  for (uint32_t id : seen_ids) debug_ids.insert(id);
 
-  for (const auto& it : get_module()->ext_inst_debuginfo())
-    all_debug_ids.insert(it.result_id());
-
-  for (const auto& it : get_module()->ext_inst_imports()) {
-    all_debug_ids.insert(it.result_id());
-    seen_ids.insert(it.result_id());
-  }
-
-  bool changed = false;
+  bool moduleChanged = false;
   bool hasAtLeastOneForwardReference = false;
   IRContext* ctx = context();
-  for (auto& it : get_module()->ext_inst_debuginfo())
-    changed |= Fixup(ctx, all_debug_ids, seen_ids,
-                     &hasAtLeastOneForwardReference, &it);
+  for (Instruction& inst : get_module()->ext_inst_debuginfo()) {
+    if (inst.opcode() != spv::Op::OpExtInst &&
+        inst.opcode() != spv::Op::OpExtInstWithForwardRefsKHR)
+      continue;
+
+    seen_ids.insert(inst.result_id());
+    bool hasForwardReferences = HasForwardReference(inst, debug_ids, seen_ids);
+    hasAtLeastOneForwardReference |= hasForwardReferences;
+
+    if (ReplaceOpcodeIfRequired(inst, hasForwardReferences)) {
+      moduleChanged = true;
+      ctx->AnalyzeUses(&inst);
+    }
+  }
 
   if (hasAtLeastOneForwardReference !=
       ctx->get_feature_mgr()->HasExtension(
@@ -89,10 +93,11 @@ Pass::Status OpExtInstWithForwardReferenceFixupPass::Process() {
       ctx->AddExtension("SPV_KHR_relaxed_extended_instruction");
     else
       ctx->RemoveExtension(Extension::kSPV_KHR_relaxed_extended_instruction);
-    changed = true;
+    moduleChanged = true;
   }
 
-  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+  return moduleChanged ? Status::SuccessWithChange
+                       : Status::SuccessWithoutChange;
 }
 
 }  // namespace opt

--- a/source/opt/opextinst_forward_ref_fixup_pass.cpp
+++ b/source/opt/opextinst_forward_ref_fixup_pass.cpp
@@ -46,7 +46,7 @@ bool HasForwardReference(const Instruction& inst,
   return false;
 }
 
-// Replaced |inst| opcode with OpExtInstWithForwardRefsKHR or OpExtInst
+// Replace |inst| opcode with OpExtInstWithForwardRefsKHR or OpExtInst
 // if required to comply with forward references.
 bool ReplaceOpcodeIfRequired(Instruction& inst, bool hasForwardReferences) {
   if (hasForwardReferences &&

--- a/source/opt/opextinst_forward_ref_fixup_pass.h
+++ b/source/opt/opextinst_forward_ref_fixup_pass.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SOURCE_OPT_OPEXTINST_FORWARD_REF_FIXUP_H
+#define SOURCE_OPT_OPEXTINST_FORWARD_REF_FIXUP_H
+
+#include "source/opt/ir_context.h"
+#include "source/opt/module.h"
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+class OpExtInstWithForwardReferenceFixupPass : public Pass {
+ public:
+  const char* name() const override { return "opextinst-fwdref-fixup"; }
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    return IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+           IRContext::kAnalysisCFG | IRContext::kAnalysisDominatorAnalysis |
+           IRContext::kAnalysisLoopAnalysis | IRContext::kAnalysisNameMap |
+           IRContext::kAnalysisScalarEvolution |
+           IRContext::kAnalysisRegisterPressure |
+           IRContext::kAnalysisValueNumberTable |
+           IRContext::kAnalysisStructuredCFG |
+           IRContext::kAnalysisBuiltinVarId |
+           IRContext::kAnalysisIdToFuncMapping | IRContext::kAnalysisTypes |
+           IRContext::kAnalysisDefUse | IRContext::kAnalysisConstants;
+  }
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // SOURCE_OPT_OPEXTINST_FORWARD_REF_FIXUP_H

--- a/source/opt/opextinst_forward_ref_fixup_pass.h
+++ b/source/opt/opextinst_forward_ref_fixup_pass.h
@@ -24,7 +24,7 @@ namespace opt {
 
 class OpExtInstWithForwardReferenceFixupPass : public Pass {
  public:
-  const char* name() const override { return "opextinst-fwdref-fixup"; }
+  const char* name() const override { return "fix-opextinst-opcodes"; }
   Status Process() override;
 
   IRContext::Analysis GetPreservedAnalyses() override {

--- a/source/opt/opextinst_forward_ref_fixup_pass.h
+++ b/source/opt/opextinst_forward_ref_fixup_pass.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Google Inc.
+// Copyright (c) 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -1076,11 +1076,6 @@ Optimizer::PassToken CreateInterpolateFixupPass() {
       MakeUnique<opt::InterpFixupPass>());
 }
 
-Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass() {
-  return MakeUnique<Optimizer::PassToken::Impl>(
-      MakeUnique<opt::OpExtInstWithForwardReferenceFixupPass>());
-}
-
 Optimizer::PassToken CreateEliminateDeadInputComponentsPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::EliminateDeadIOComponentsPass>(spv::StorageClass::Input,
@@ -1154,6 +1149,12 @@ Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ModifyMaximalReconvergence>(add));
 }
+
+Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::OpExtInstWithForwardReferenceFixupPass>());
+}
+
 }  // namespace spvtools
 
 extern "C" {

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -169,7 +169,8 @@ Optimizer& Optimizer::RegisterLegalizationPasses(bool preserve_interface) {
           .RegisterPass(CreateAggressiveDCEPass(preserve_interface))
           .RegisterPass(CreateRemoveUnusedInterfaceVariablesPass())
           .RegisterPass(CreateInterpolateFixupPass())
-          .RegisterPass(CreateInvocationInterlockPlacementPass());
+          .RegisterPass(CreateInvocationInterlockPlacementPass())
+          .RegisterPass(CreateOpExtInstWithForwardReferenceFixupPass());
 }
 
 Optimizer& Optimizer::RegisterLegalizationPasses() {
@@ -323,6 +324,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag,
     RegisterPass(CreateStripReflectInfoPass());
   } else if (pass_name == "strip-nonsemantic") {
     RegisterPass(CreateStripNonSemanticInfoPass());
+  } else if (pass_name == "fix-opextinst-opcodes") {
+    RegisterPass(CreateOpExtInstWithForwardReferenceFixupPass());
   } else if (pass_name == "set-spec-const-default-value") {
     if (pass_args.size() > 0) {
       auto spec_ids_vals =
@@ -1071,6 +1074,11 @@ Optimizer::PassToken CreateAmdExtToKhrPass() {
 Optimizer::PassToken CreateInterpolateFixupPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::InterpFixupPass>());
+}
+
+Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::OpExtInstWithForwardReferenceFixupPass>());
 }
 
 Optimizer::PassToken CreateEliminateDeadInputComponentsPass() {

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -65,6 +65,7 @@
 #include "source/opt/merge_return_pass.h"
 #include "source/opt/modify_maximal_reconvergence.h"
 #include "source/opt/null_pass.h"
+#include "source/opt/opextinst_forward_ref_fixup_pass.h"
 #include "source/opt/private_to_local_pass.h"
 #include "source/opt/reduce_load_size.h"
 #include "source/opt/redundancy_elimination.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -79,6 +79,7 @@ add_spvtools_unittest(TARGET opt
        modify_maximal_reconvergence_test.cpp
        module_test.cpp
        module_utils.h
+       opextinst_forward_ref_fixup_pass_test.cpp
        optimizer_test.cpp
        pass_manager_test.cpp
        pass_merge_return_test.cpp

--- a/test/opt/opextinst_forward_ref_fixup_pass_test.cpp
+++ b/test/opt/opextinst_forward_ref_fixup_pass_test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Google Inc.
+// Copyright (c) 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ namespace {
 
 using OpExtInstForwardRefFixupPassTest = PassTest<::testing::Test>;
 
-TEST_F(OpExtInstForwardRefFixupPassTest, HealthCheck) {
+TEST_F(OpExtInstForwardRefFixupPassTest, NoChangeWithougExtendedInstructions) {
   const std::string kTest = R"(
 ; CHECK-NOT:   SomeOpcode
                OpCapability Shader
@@ -43,104 +43,100 @@ TEST_F(OpExtInstForwardRefFixupPassTest, HealthCheck) {
 }
 
 TEST_F(OpExtInstForwardRefFixupPassTest, NoForwardRef_NoChange) {
-  const std::string kTest = R"(
-                   OpCapability Shader
-                   OpExtension "SPV_KHR_non_semantic_info"
-              %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-                   OpMemoryModel Logical GLSL450
-                   OpEntryPoint GLCompute %main "main"
-                   OpExecutionMode %main LocalSize 1 1 1
-              %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
-              %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+  const std::string kTest = R"(OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+%4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
 
 [numthreads(1, 1, 1)]
 void main() {
 }
 "
-              %5 = OpString "main"
-              %6 = OpString ""
-              %7 = OpString "3f3d3740"
-              %8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
-                   OpName %main "main"
-           %void = OpTypeVoid
-           %uint = OpTypeInt 32 0
-         %uint_3 = OpConstant %uint 3
-         %uint_1 = OpConstant %uint 1
-         %uint_4 = OpConstant %uint 4
-         %uint_5 = OpConstant %uint 5
-             %20 = OpTypeFunction %void
-             %10 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
-             %12 = OpExtInst %void %1 DebugSource %3 %4
-             %13 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %12 %uint_5
-             %17 = OpExtInst %void %1 DebugFunction %5 %10 %12 %uint_4 %uint_1 %13 %6 %uint_3 %uint_4
-             %18 = OpExtInst %void %1 DebugEntryPoint %17 %13 %7 %8
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugSource {{.*}} {{.*}}
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
-           %main = OpFunction %void None %20
-             %21 = OpLabel
-             %22 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
-             %23 = OpExtInst %void %1 DebugLine %12 %uint_5 %uint_5 %uint_1 %uint_1
-; CHECK:  {{.*}} = OpExtInst %void %1 DebugFunctionDefinition {{.*}} %main
-; CHECK:  {{.*}} = OpExtInst %void %1 DebugLine {{.*}} %uint_5 %uint_5 %uint_1 %uint_1
-                   OpReturn
-                   OpFunctionEnd
-  )";
-  const auto result =
-      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
-          kTest, /* do_validation= */ true);
-  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+%5 = OpString "main"
+%6 = OpString ""
+%7 = OpString "3f3d3740"
+%8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
+OpName %main "main"
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%uint_3 = OpConstant %uint 3
+%uint_1 = OpConstant %uint 1
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%15 = OpTypeFunction %void
+%16 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%17 = OpExtInst %void %1 DebugSource %3 %4
+%18 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %17 %uint_5
+%19 = OpExtInst %void %1 DebugFunction %5 %16 %17 %uint_4 %uint_1 %18 %6 %uint_3 %uint_4
+%20 = OpExtInst %void %1 DebugEntryPoint %19 %18 %7 %8
+%main = OpFunction %void None %15
+%21 = OpLabel
+%22 = OpExtInst %void %1 DebugFunctionDefinition %19 %main
+%23 = OpExtInst %void %1 DebugLine %17 %uint_5 %uint_5 %uint_1 %uint_1
+OpReturn
+OpFunctionEnd
+)";
+  SinglePassRunAndCheck<OpExtInstWithForwardReferenceFixupPass>(
+      kTest, kTest, /* skip_nop= */ false);
 }
 
-TEST_F(OpExtInstForwardRefFixupPassTest, NoForwardRef_Replaced) {
+TEST_F(OpExtInstForwardRefFixupPassTest,
+       NoForwardRef_ReplaceOpExtInstWithForwardWithOpExtInst) {
   const std::string kTest = R"(
-                   OpCapability Shader
-                   OpExtension "SPV_KHR_non_semantic_info"
-                   OpExtension "SPV_KHR_relaxed_extended_instruction"
-; CHECK-NOT:       OpExtension "SPV_KHR_relaxed_extended_instruction"
-              %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-                   OpMemoryModel Logical GLSL450
-                   OpEntryPoint GLCompute %main "main"
-                   OpExecutionMode %main LocalSize 1 1 1
-              %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
-              %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+                       OpCapability Shader
+                       OpExtension "SPV_KHR_non_semantic_info"
+                       OpExtension "SPV_KHR_relaxed_extended_instruction"
+; CHECK-NOT:           OpExtension "SPV_KHR_relaxed_extended_instruction"
+                  %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                       OpMemoryModel Logical GLSL450
+                       OpEntryPoint GLCompute %main "main"
+                       OpExecutionMode %main LocalSize 1 1 1
+                  %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+                  %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
 
 [numthreads(1, 1, 1)]
 void main() {
 }
 "
-              %5 = OpString "main"
-              %6 = OpString ""
-              %7 = OpString "3f3d3740"
-              %8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
-                   OpName %main "main"
-           %void = OpTypeVoid
-           %uint = OpTypeInt 32 0
-         %uint_3 = OpConstant %uint 3
-         %uint_1 = OpConstant %uint 1
-         %uint_4 = OpConstant %uint 4
-         %uint_5 = OpConstant %uint 5
-             %20 = OpTypeFunction %void
-             %10 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeFunction %uint_3 %void
-             %12 = OpExtInstWithForwardRefsKHR %void %1 DebugSource %3 %4
-             %13 = OpExtInstWithForwardRefsKHR %void %1 DebugCompilationUnit %uint_1 %uint_4 %12 %uint_5
-             %17 = OpExtInstWithForwardRefsKHR %void %1 DebugFunction %5 %10 %12 %uint_4 %uint_1 %13 %6 %uint_3 %uint_4
-             %18 = OpExtInstWithForwardRefsKHR %void %1 DebugEntryPoint %17 %13 %7 %8
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugSource {{.*}} {{.*}}
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
-;  CHECK: {{.*}} = OpExtInst %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
-           %main = OpFunction %void None %20
-             %21 = OpLabel
-             %22 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
-             %23 = OpExtInst %void %1 DebugLine %12 %uint_5 %uint_5 %uint_1 %uint_1
-; CHECK:  {{.*}} = OpExtInst %void %1 DebugFunctionDefinition {{.*}} %main
-; CHECK:  {{.*}} = OpExtInst %void %1 DebugLine {{.*}} %uint_5 %uint_5 %uint_1 %uint_1
-                   OpReturn
-                   OpFunctionEnd
+                  %5 = OpString "main"
+                  %6 = OpString ""
+                  %7 = OpString "3f3d3740"
+                  %8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
+                       OpName %main "main"
+               %void = OpTypeVoid
+               %uint = OpTypeInt 32 0
+             %uint_3 = OpConstant %uint 3
+             %uint_1 = OpConstant %uint 1
+             %uint_4 = OpConstant %uint 4
+             %uint_5 = OpConstant %uint 5
+                 %20 = OpTypeFunction %void
+                 %10 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeFunction %uint_3 %void
+                 %12 = OpExtInstWithForwardRefsKHR %void %1 DebugSource %3 %4
+                 %13 = OpExtInstWithForwardRefsKHR %void %1 DebugCompilationUnit %uint_1 %uint_4 %12 %uint_5
+                 %17 = OpExtInstWithForwardRefsKHR %void %1 DebugFunction %5 %10 %12 %uint_4 %uint_1 %13 %6 %uint_3 %uint_4
+                 %18 = OpExtInstWithForwardRefsKHR %void %1 DebugEntryPoint %17 %13 %7 %8
+;  CHECK-NOT: {{.*}} = OpExtInstWithForwardRefsKHR %void %1 DebugTypeFunction %uint_3 %void
+;  CHECK-NOT: {{.*}} = OpExtInstWithForwardRefsKHR %void %1 DebugSource {{.*}} {{.*}}
+;  CHECK-NOT: {{.*}} = OpExtInstWithForwardRefsKHR %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
+;  CHECK-NOT: {{.*}} = OpExtInstWithForwardRefsKHR %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
+;  CHECK-NOT: {{.*}} = OpExtInstWithForwardRefsKHR %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
+;  CHECK:     {{.*}} = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+;  CHECK:     {{.*}} = OpExtInst %void %1 DebugSource {{.*}} {{.*}}
+;  CHECK:     {{.*}} = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
+;  CHECK:     {{.*}} = OpExtInst %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
+;  CHECK:     {{.*}} = OpExtInst %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
+               %main = OpFunction %void None %20
+                 %21 = OpLabel
+                 %22 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+                 %23 = OpExtInst %void %1 DebugLine %12 %uint_5 %uint_5 %uint_1 %uint_1
+; CHECK:      {{.*}} = OpExtInst %void %1 DebugFunctionDefinition {{.*}} %main
+; CHECK:      {{.*}} = OpExtInst %void %1 DebugLine {{.*}} %uint_5 %uint_5 %uint_1 %uint_1
+                       OpReturn
+                       OpFunctionEnd
   )";
   const auto result =
       SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
@@ -149,16 +145,15 @@ void main() {
 }
 
 TEST_F(OpExtInstForwardRefFixupPassTest, ForwardRefs_NoChange) {
-  const std::string kTest = R"(
-                        OpCapability Shader
-                        OpExtension "SPV_KHR_non_semantic_info"
-                        OpExtension "SPV_KHR_relaxed_extended_instruction"
-                   %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-                        OpMemoryModel Logical GLSL450
-                        OpEntryPoint GLCompute %main "main"
-                        OpExecutionMode %main LocalSize 1 1 1
-                   %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
-                   %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+  const std::string kTest = R"(OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_relaxed_extended_instruction"
+%1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+%4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
 
 class A {
   void foo() {
@@ -171,90 +166,67 @@ void main() {
   a.foo();
 }
 "
-                   %5 = OpString "A"
-                   %6 = OpString "A.foo"
-                   %7 = OpString ""
-                   %8 = OpString "this"
-                   %9 = OpString "main"
-                  %10 = OpString "a"
-                  %11 = OpString "d59ae9c2"
-                  %12 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Vd -Qembed_debug"
-                        OpName %main "main"
-                        OpName %A "A"
-                %void = OpTypeVoid
-                %uint = OpTypeInt 32 0
-              %uint_1 = OpConstant %uint 1
-              %uint_4 = OpConstant %uint 4
-              %uint_5 = OpConstant %uint 5
-              %uint_0 = OpConstant %uint 0
-              %uint_3 = OpConstant %uint 3
-              %uint_7 = OpConstant %uint 7
-            %uint_288 = OpConstant %uint 288
-              %uint_9 = OpConstant %uint 9
-             %uint_13 = OpConstant %uint 13
-             %uint_10 = OpConstant %uint 10
-                  %40 = OpTypeFunction %void
-             %uint_12 = OpConstant %uint 12
-                   %A = OpTypeStruct
-         %_ptr_Function_A = OpTypePointer Function %A
-             %uint_11 = OpConstant %uint 11
-                  %15 = OpExtInst %void %1 DebugExpression
-                  %16 = OpExtInst %void %1 DebugSource %3 %4
-                  %17 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %16 %uint_5
-                  %21 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeComposite %5 %uint_0 %16 %uint_3 %uint_7 %17 %5 %uint_0 %uint_3 %25
-                  %26 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void %21
-                  %25 = OpExtInst %void %1 DebugFunction %6 %26 %16 %uint_4 %uint_3 %21 %7 %uint_3 %uint_4
-                  %27 = OpExtInst %void %1 DebugLocalVariable %8 %21 %16 %uint_4 %uint_3 %25 %uint_288 %uint_1
-                  %29 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
-                  %30 = OpExtInst %void %1 DebugFunction %9 %29 %16 %uint_9 %uint_1 %17 %7 %uint_3 %uint_9
-                  %32 = OpExtInst %void %1 DebugLexicalBlock %16 %uint_9 %uint_13 %30
-                  %34 = OpExtInst %void %1 DebugLocalVariable %10 %21 %16 %uint_10 %uint_5 %32 %uint_4
-                  %36 = OpExtInst %void %1 DebugEntryPoint %30 %17 %11 %12
-                  %37 = OpExtInst %void %1 DebugInlinedAt %uint_11 %32
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugExpression
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugSource
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugCompilationUnit
-; CHECK:       {{.*}} = OpExtInstWithForwardRefsKHR %void {{.*}} DebugTypeComposite
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLexicalBlock
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugEntryPoint
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugInlinedAt
-                %main = OpFunction %void None %40
-                  %43 = OpLabel
-                  %44 = OpVariable %_ptr_Function_A Function
-                  %45 = OpExtInst %void %1 DebugFunctionDefinition %30 %main
-                  %51 = OpExtInst %void %1 DebugScope %32
-                  %46 = OpExtInst %void %1 DebugLine %16 %uint_10 %uint_10 %uint_3 %uint_5
-                  %47 = OpExtInst %void %1 DebugDeclare %34 %44 %15
-                  %52 = OpExtInst %void %1 DebugScope %25 %37
-                  %48 = OpExtInst %void %1 DebugLine %16 %uint_4 %uint_5 %uint_3 %uint_3
-                  %49 = OpExtInst %void %1 DebugDeclare %27 %44 %15
-                  %53 = OpExtInst %void %1 DebugNoScope
-                  %50 = OpExtInst %void %1 DebugLine %16 %uint_12 %uint_12 %uint_1 %uint_1
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunctionDefinition
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugNoScope
-; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
-                        OpReturn
-                        OpFunctionEnd
-  )";
-  const auto result =
-      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
-          kTest, /* do_validation= */ true);
-  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+%5 = OpString "A"
+%6 = OpString "A.foo"
+%7 = OpString ""
+%8 = OpString "this"
+%9 = OpString "main"
+%10 = OpString "a"
+%11 = OpString "d59ae9c2"
+%12 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Vd -Qembed_debug"
+OpName %main "main"
+OpName %A "A"
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%uint_1 = OpConstant %uint 1
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_0 = OpConstant %uint 0
+%uint_3 = OpConstant %uint 3
+%uint_7 = OpConstant %uint 7
+%uint_288 = OpConstant %uint 288
+%uint_9 = OpConstant %uint 9
+%uint_13 = OpConstant %uint 13
+%uint_10 = OpConstant %uint 10
+%26 = OpTypeFunction %void
+%uint_12 = OpConstant %uint 12
+%A = OpTypeStruct
+%_ptr_Function_A = OpTypePointer Function %A
+%uint_11 = OpConstant %uint 11
+%30 = OpExtInst %void %1 DebugExpression
+%31 = OpExtInst %void %1 DebugSource %3 %4
+%32 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %31 %uint_5
+%33 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeComposite %5 %uint_0 %31 %uint_3 %uint_7 %32 %5 %uint_0 %uint_3 %34
+%35 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void %33
+%34 = OpExtInst %void %1 DebugFunction %6 %35 %31 %uint_4 %uint_3 %33 %7 %uint_3 %uint_4
+%36 = OpExtInst %void %1 DebugLocalVariable %8 %33 %31 %uint_4 %uint_3 %34 %uint_288 %uint_1
+%37 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%38 = OpExtInst %void %1 DebugFunction %9 %37 %31 %uint_9 %uint_1 %32 %7 %uint_3 %uint_9
+%39 = OpExtInst %void %1 DebugLexicalBlock %31 %uint_9 %uint_13 %38
+%40 = OpExtInst %void %1 DebugLocalVariable %10 %33 %31 %uint_10 %uint_5 %39 %uint_4
+%41 = OpExtInst %void %1 DebugEntryPoint %38 %32 %11 %12
+%42 = OpExtInst %void %1 DebugInlinedAt %uint_11 %39
+%main = OpFunction %void None %26
+%43 = OpLabel
+%44 = OpVariable %_ptr_Function_A Function
+%45 = OpExtInst %void %1 DebugFunctionDefinition %38 %main
+%57 = OpExtInst %void %1 DebugScope %39
+%47 = OpExtInst %void %1 DebugLine %31 %uint_10 %uint_10 %uint_3 %uint_5
+%48 = OpExtInst %void %1 DebugDeclare %40 %44 %30
+%58 = OpExtInst %void %1 DebugScope %34 %42
+%50 = OpExtInst %void %1 DebugLine %31 %uint_4 %uint_5 %uint_3 %uint_3
+%51 = OpExtInst %void %1 DebugDeclare %36 %44 %30
+%59 = OpExtInst %void %1 DebugNoScope
+%53 = OpExtInst %void %1 DebugLine %31 %uint_12 %uint_12 %uint_1 %uint_1
+OpReturn
+OpFunctionEnd
+)";
+  SinglePassRunAndCheck<OpExtInstWithForwardReferenceFixupPass>(
+      kTest, kTest, /* skip_nop= */ false);
 }
 
-TEST_F(OpExtInstForwardRefFixupPassTest, ForwardRefs_Fixup) {
+TEST_F(OpExtInstForwardRefFixupPassTest,
+       ForwardRefs_ReplaceOpExtInstWithOpExtInstWithForwardRefs) {
   const std::string kTest = R"(
                         OpCapability Shader
                         OpExtension "SPV_KHR_non_semantic_info"
@@ -321,6 +293,7 @@ void main() {
 ; CHECK:       {{.*}} = OpExtInst %void %1 DebugSource
 ; CHECK:       {{.*}} = OpExtInst %void %1 DebugCompilationUnit
 ; CHECK:       {{.*}} = OpExtInstWithForwardRefsKHR %void {{.*}} DebugTypeComposite
+; CHECK-NOT:   {{.*}} = OpExtInst %void {{.*}} DebugTypeComposite
 ; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
 ; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
 ; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable

--- a/test/opt/opextinst_forward_ref_fixup_pass_test.cpp
+++ b/test/opt/opextinst_forward_ref_fixup_pass_test.cpp
@@ -1,0 +1,365 @@
+// Copyright (c) 2024 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "spirv-tools/optimizer.hpp"
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+using OpExtInstForwardRefFixupPassTest = PassTest<::testing::Test>;
+
+TEST_F(OpExtInstForwardRefFixupPassTest, HealthCheck) {
+  const std::string kTest = R"(
+; CHECK-NOT:   SomeOpcode
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd;
+  )";
+  const auto result =
+      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
+          kTest, /* do_validation= */ true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+}
+
+TEST_F(OpExtInstForwardRefFixupPassTest, NoForwardRef_NoChange) {
+  const std::string kTest = R"(
+                   OpCapability Shader
+                   OpExtension "SPV_KHR_non_semantic_info"
+              %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                   OpMemoryModel Logical GLSL450
+                   OpEntryPoint GLCompute %main "main"
+                   OpExecutionMode %main LocalSize 1 1 1
+              %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+              %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+
+[numthreads(1, 1, 1)]
+void main() {
+}
+"
+              %5 = OpString "main"
+              %6 = OpString ""
+              %7 = OpString "3f3d3740"
+              %8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
+                   OpName %main "main"
+           %void = OpTypeVoid
+           %uint = OpTypeInt 32 0
+         %uint_3 = OpConstant %uint 3
+         %uint_1 = OpConstant %uint 1
+         %uint_4 = OpConstant %uint 4
+         %uint_5 = OpConstant %uint 5
+             %20 = OpTypeFunction %void
+             %10 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+             %12 = OpExtInst %void %1 DebugSource %3 %4
+             %13 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %12 %uint_5
+             %17 = OpExtInst %void %1 DebugFunction %5 %10 %12 %uint_4 %uint_1 %13 %6 %uint_3 %uint_4
+             %18 = OpExtInst %void %1 DebugEntryPoint %17 %13 %7 %8
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugSource {{.*}} {{.*}}
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
+           %main = OpFunction %void None %20
+             %21 = OpLabel
+             %22 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+             %23 = OpExtInst %void %1 DebugLine %12 %uint_5 %uint_5 %uint_1 %uint_1
+; CHECK:  {{.*}} = OpExtInst %void %1 DebugFunctionDefinition {{.*}} %main
+; CHECK:  {{.*}} = OpExtInst %void %1 DebugLine {{.*}} %uint_5 %uint_5 %uint_1 %uint_1
+                   OpReturn
+                   OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
+          kTest, /* do_validation= */ true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+}
+
+TEST_F(OpExtInstForwardRefFixupPassTest, NoForwardRef_Replaced) {
+  const std::string kTest = R"(
+                   OpCapability Shader
+                   OpExtension "SPV_KHR_non_semantic_info"
+                   OpExtension "SPV_KHR_relaxed_extended_instruction"
+; CHECK-NOT:       OpExtension "SPV_KHR_relaxed_extended_instruction"
+              %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                   OpMemoryModel Logical GLSL450
+                   OpEntryPoint GLCompute %main "main"
+                   OpExecutionMode %main LocalSize 1 1 1
+              %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+              %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+
+[numthreads(1, 1, 1)]
+void main() {
+}
+"
+              %5 = OpString "main"
+              %6 = OpString ""
+              %7 = OpString "3f3d3740"
+              %8 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Qembed_debug"
+                   OpName %main "main"
+           %void = OpTypeVoid
+           %uint = OpTypeInt 32 0
+         %uint_3 = OpConstant %uint 3
+         %uint_1 = OpConstant %uint 1
+         %uint_4 = OpConstant %uint 4
+         %uint_5 = OpConstant %uint 5
+             %20 = OpTypeFunction %void
+             %10 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeFunction %uint_3 %void
+             %12 = OpExtInstWithForwardRefsKHR %void %1 DebugSource %3 %4
+             %13 = OpExtInstWithForwardRefsKHR %void %1 DebugCompilationUnit %uint_1 %uint_4 %12 %uint_5
+             %17 = OpExtInstWithForwardRefsKHR %void %1 DebugFunction %5 %10 %12 %uint_4 %uint_1 %13 %6 %uint_3 %uint_4
+             %18 = OpExtInstWithForwardRefsKHR %void %1 DebugEntryPoint %17 %13 %7 %8
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugSource {{.*}} {{.*}}
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 {{.*}} %uint_5
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugFunction {{.*}} {{.*}} {{.*}} %uint_4 %uint_1 {{.*}} {{.*}} %uint_3 %uint_4
+;  CHECK: {{.*}} = OpExtInst %void %1 DebugEntryPoint {{.*}} {{.*}} {{.*}} {{.*}}
+           %main = OpFunction %void None %20
+             %21 = OpLabel
+             %22 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+             %23 = OpExtInst %void %1 DebugLine %12 %uint_5 %uint_5 %uint_1 %uint_1
+; CHECK:  {{.*}} = OpExtInst %void %1 DebugFunctionDefinition {{.*}} %main
+; CHECK:  {{.*}} = OpExtInst %void %1 DebugLine {{.*}} %uint_5 %uint_5 %uint_1 %uint_1
+                   OpReturn
+                   OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
+          kTest, /* do_validation= */ true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+TEST_F(OpExtInstForwardRefFixupPassTest, ForwardRefs_NoChange) {
+  const std::string kTest = R"(
+                        OpCapability Shader
+                        OpExtension "SPV_KHR_non_semantic_info"
+                        OpExtension "SPV_KHR_relaxed_extended_instruction"
+                   %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                        OpMemoryModel Logical GLSL450
+                        OpEntryPoint GLCompute %main "main"
+                        OpExecutionMode %main LocalSize 1 1 1
+                   %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+                   %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+
+class A {
+  void foo() {
+  }
+};
+
+[numthreads(1, 1, 1)]
+void main() {
+  A a;
+  a.foo();
+}
+"
+                   %5 = OpString "A"
+                   %6 = OpString "A.foo"
+                   %7 = OpString ""
+                   %8 = OpString "this"
+                   %9 = OpString "main"
+                  %10 = OpString "a"
+                  %11 = OpString "d59ae9c2"
+                  %12 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Vd -Qembed_debug"
+                        OpName %main "main"
+                        OpName %A "A"
+                %void = OpTypeVoid
+                %uint = OpTypeInt 32 0
+              %uint_1 = OpConstant %uint 1
+              %uint_4 = OpConstant %uint 4
+              %uint_5 = OpConstant %uint 5
+              %uint_0 = OpConstant %uint 0
+              %uint_3 = OpConstant %uint 3
+              %uint_7 = OpConstant %uint 7
+            %uint_288 = OpConstant %uint 288
+              %uint_9 = OpConstant %uint 9
+             %uint_13 = OpConstant %uint 13
+             %uint_10 = OpConstant %uint 10
+                  %40 = OpTypeFunction %void
+             %uint_12 = OpConstant %uint 12
+                   %A = OpTypeStruct
+         %_ptr_Function_A = OpTypePointer Function %A
+             %uint_11 = OpConstant %uint 11
+                  %15 = OpExtInst %void %1 DebugExpression
+                  %16 = OpExtInst %void %1 DebugSource %3 %4
+                  %17 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %16 %uint_5
+                  %21 = OpExtInstWithForwardRefsKHR %void %1 DebugTypeComposite %5 %uint_0 %16 %uint_3 %uint_7 %17 %5 %uint_0 %uint_3 %25
+                  %26 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void %21
+                  %25 = OpExtInst %void %1 DebugFunction %6 %26 %16 %uint_4 %uint_3 %21 %7 %uint_3 %uint_4
+                  %27 = OpExtInst %void %1 DebugLocalVariable %8 %21 %16 %uint_4 %uint_3 %25 %uint_288 %uint_1
+                  %29 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+                  %30 = OpExtInst %void %1 DebugFunction %9 %29 %16 %uint_9 %uint_1 %17 %7 %uint_3 %uint_9
+                  %32 = OpExtInst %void %1 DebugLexicalBlock %16 %uint_9 %uint_13 %30
+                  %34 = OpExtInst %void %1 DebugLocalVariable %10 %21 %16 %uint_10 %uint_5 %32 %uint_4
+                  %36 = OpExtInst %void %1 DebugEntryPoint %30 %17 %11 %12
+                  %37 = OpExtInst %void %1 DebugInlinedAt %uint_11 %32
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugExpression
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugSource
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugCompilationUnit
+; CHECK:       {{.*}} = OpExtInstWithForwardRefsKHR %void {{.*}} DebugTypeComposite
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLexicalBlock
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugEntryPoint
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugInlinedAt
+                %main = OpFunction %void None %40
+                  %43 = OpLabel
+                  %44 = OpVariable %_ptr_Function_A Function
+                  %45 = OpExtInst %void %1 DebugFunctionDefinition %30 %main
+                  %51 = OpExtInst %void %1 DebugScope %32
+                  %46 = OpExtInst %void %1 DebugLine %16 %uint_10 %uint_10 %uint_3 %uint_5
+                  %47 = OpExtInst %void %1 DebugDeclare %34 %44 %15
+                  %52 = OpExtInst %void %1 DebugScope %25 %37
+                  %48 = OpExtInst %void %1 DebugLine %16 %uint_4 %uint_5 %uint_3 %uint_3
+                  %49 = OpExtInst %void %1 DebugDeclare %27 %44 %15
+                  %53 = OpExtInst %void %1 DebugNoScope
+                  %50 = OpExtInst %void %1 DebugLine %16 %uint_12 %uint_12 %uint_1 %uint_1
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunctionDefinition
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugNoScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+                        OpReturn
+                        OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
+          kTest, /* do_validation= */ true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+}
+
+TEST_F(OpExtInstForwardRefFixupPassTest, ForwardRefs_Fixup) {
+  const std::string kTest = R"(
+                        OpCapability Shader
+                        OpExtension "SPV_KHR_non_semantic_info"
+; CHECK:                OpExtension "SPV_KHR_relaxed_extended_instruction"
+                   %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+                        OpMemoryModel Logical GLSL450
+                        OpEntryPoint GLCompute %main "main"
+                        OpExecutionMode %main LocalSize 1 1 1
+                   %3 = OpString "/usr/local/google/home/nathangauer/projects/DirectXShaderCompiler/repro.hlsl"
+                   %4 = OpString "// RUN: %dxc -T cs_6_0 %s -E main -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source | FileCheck %s
+
+class A {
+  void foo() {
+  }
+};
+
+[numthreads(1, 1, 1)]
+void main() {
+  A a;
+  a.foo();
+}
+"
+                   %5 = OpString "A"
+                   %6 = OpString "A.foo"
+                   %7 = OpString ""
+                   %8 = OpString "this"
+                   %9 = OpString "main"
+                  %10 = OpString "a"
+                  %11 = OpString "d59ae9c2"
+                  %12 = OpString " -E main -T cs_6_0 -spirv -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source -Vd -Qembed_debug"
+                        OpName %main "main"
+                        OpName %A "A"
+                %void = OpTypeVoid
+                %uint = OpTypeInt 32 0
+              %uint_1 = OpConstant %uint 1
+              %uint_4 = OpConstant %uint 4
+              %uint_5 = OpConstant %uint 5
+              %uint_0 = OpConstant %uint 0
+              %uint_3 = OpConstant %uint 3
+              %uint_7 = OpConstant %uint 7
+            %uint_288 = OpConstant %uint 288
+              %uint_9 = OpConstant %uint 9
+             %uint_13 = OpConstant %uint 13
+             %uint_10 = OpConstant %uint 10
+                  %40 = OpTypeFunction %void
+             %uint_12 = OpConstant %uint 12
+                   %A = OpTypeStruct
+         %_ptr_Function_A = OpTypePointer Function %A
+             %uint_11 = OpConstant %uint 11
+                  %15 = OpExtInst %void %1 DebugExpression
+                  %16 = OpExtInst %void %1 DebugSource %3 %4
+                  %17 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %16 %uint_5
+                  %21 = OpExtInst %void %1 DebugTypeComposite %5 %uint_0 %16 %uint_3 %uint_7 %17 %5 %uint_0 %uint_3 %25
+                  %26 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void %21
+                  %25 = OpExtInst %void %1 DebugFunction %6 %26 %16 %uint_4 %uint_3 %21 %7 %uint_3 %uint_4
+                  %27 = OpExtInst %void %1 DebugLocalVariable %8 %21 %16 %uint_4 %uint_3 %25 %uint_288 %uint_1
+                  %29 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+                  %30 = OpExtInst %void %1 DebugFunction %9 %29 %16 %uint_9 %uint_1 %17 %7 %uint_3 %uint_9
+                  %32 = OpExtInst %void %1 DebugLexicalBlock %16 %uint_9 %uint_13 %30
+                  %34 = OpExtInst %void %1 DebugLocalVariable %10 %21 %16 %uint_10 %uint_5 %32 %uint_4
+                  %36 = OpExtInst %void %1 DebugEntryPoint %30 %17 %11 %12
+                  %37 = OpExtInst %void %1 DebugInlinedAt %uint_11 %32
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugExpression
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugSource
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugCompilationUnit
+; CHECK:       {{.*}} = OpExtInstWithForwardRefsKHR %void {{.*}} DebugTypeComposite
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugTypeFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunction
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLexicalBlock
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLocalVariable
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugEntryPoint
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugInlinedAt
+                %main = OpFunction %void None %40
+                  %43 = OpLabel
+                  %44 = OpVariable %_ptr_Function_A Function
+                  %45 = OpExtInst %void %1 DebugFunctionDefinition %30 %main
+                  %51 = OpExtInst %void %1 DebugScope %32
+                  %46 = OpExtInst %void %1 DebugLine %16 %uint_10 %uint_10 %uint_3 %uint_5
+                  %47 = OpExtInst %void %1 DebugDeclare %34 %44 %15
+                  %52 = OpExtInst %void %1 DebugScope %25 %37
+                  %48 = OpExtInst %void %1 DebugLine %16 %uint_4 %uint_5 %uint_3 %uint_3
+                  %49 = OpExtInst %void %1 DebugDeclare %27 %44 %15
+                  %53 = OpExtInst %void %1 DebugNoScope
+                  %50 = OpExtInst %void %1 DebugLine %16 %uint_12 %uint_12 %uint_1 %uint_1
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugFunctionDefinition
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugDeclare
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugNoScope
+; CHECK:       {{.*}} = OpExtInst %void %1 DebugLine
+                        OpReturn
+                        OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<OpExtInstWithForwardReferenceFixupPass>(
+          kTest, /* do_validation= */ true);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools


### PR DESCRIPTION
This pass fixups the opcode used for OpExtInst instructions to use OpExtInstWithForwardRefsKHR when it contains a forward reference.
This pass is agnostic to the extension used, hence the validity of the code depends of the validity of the usage:

If a forward reference is used on a non-semantic extended instruction, the generated code will remain invalid, but the opcode will change. What this pass guarantees is valid code won't become invalid.