### PR TITLE
[NFC] Apply small clang-tidy fixes

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -23,8 +23,10 @@
 #include <cassert>
 #include <cstring>
 #include <iomanip>
+#include <ios>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stack>
 #include <unordered_map>
 #include <utility>

--- a/source/disassemble.h
+++ b/source/disassemble.h
@@ -15,7 +15,7 @@
 #ifndef SOURCE_DISASSEMBLE_H_
 #define SOURCE_DISASSEMBLE_H_
 
-#include <iosfwd>
+#include <ios>
 #include <sstream>
 #include <string>
 
@@ -94,11 +94,11 @@ class InstructionDisassembler {
   // Emits an operand for the given instruction, where the instruction
   // is at offset words from the start of the binary.
   void EmitOperand(std::ostream& stream, const spv_parsed_instruction_t& inst,
-                   const uint16_t operand_index) const;
+                   uint16_t operand_index) const;
 
   // Emits a mask expression for the given mask word of the specified type.
-  void EmitMaskOperand(std::ostream& stream, const spv_operand_type_t type,
-                       const uint32_t word) const;
+  void EmitMaskOperand(std::ostream& stream, spv_operand_type_t type,
+                       uint32_t word) const;
 
   // Generate part of the instruction as a comment to be added to
   // |id_comments_|.

--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1790,6 +1790,7 @@ bool CompositeExtractFeedingConstruct(
       return false;
     }
   }
+  assert(first_element_inst != nullptr);
 
   // The last check it to see that the object being extracted from is the
   // correct type.

--- a/source/opt/loop_fission.cpp
+++ b/source/opt/loop_fission.cpp
@@ -499,6 +499,7 @@ Pass::Status LoopFissionPass::Process() {
       // next iteration.
       if (split_multiple_times_) {
         inner_most_loops = std::move(new_loops_to_split);
+        new_loops_to_split = {};
       } else {
         break;
       }

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -169,7 +169,7 @@ uint32_t getBaseAlignment(uint32_t member_id, bool roundUp,
     case spv::Op::OpTypeSampler:
     case spv::Op::OpTypeImage:
       if (vstate.HasCapability(spv::Capability::BindlessTextureNV))
-        return baseAlignment = vstate.samplerimage_variable_address_mode() / 8;
+        return vstate.samplerimage_variable_address_mode() / 8;
       assert(0);
       return 0;
     case spv::Op::OpTypeInt:

--- a/source/val/validate_function.cpp
+++ b/source/val/validate_function.cpp
@@ -283,7 +283,7 @@ spv_result_t ValidateFunctionCall(ValidationState_t& _,
         function_type->GetOperandAs<uint32_t>(param_index);
     const auto parameter_type = _.FindDef(parameter_type_id);
     if (!parameter_type || argument_type->id() != parameter_type->id()) {
-      if (!_.options()->before_hlsl_legalization ||
+      if (!parameter_type || !_.options()->before_hlsl_legalization ||
           !DoPointeesLogicallyMatch(argument_type, parameter_type, _)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "OpFunctionCall Argument <id> " << _.getIdName(argument_id)

--- a/source/val/validate_non_uniform.cpp
+++ b/source/val/validate_non_uniform.cpp
@@ -390,9 +390,8 @@ spv_result_t ValidateGroupNonUniformRotateKHR(ValidationState_t& _,
   if (inst->words().size() > 6) {
     const uint32_t cluster_size_op_id = inst->GetOperandAs<uint32_t>(5);
     const Instruction* cluster_size_inst = _.FindDef(cluster_size_op_id);
-    const uint32_t cluster_size_type =
-        cluster_size_inst ? cluster_size_inst->type_id() : 0;
-    if (!_.IsUnsignedIntScalarType(cluster_size_type)) {
+    if (!cluster_size_inst ||
+        !_.IsUnsignedIntScalarType(cluster_size_inst->type_id())) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "ClusterSize must be a scalar of integer type, whose "
                 "Signedness operand is 0.";

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -841,6 +841,13 @@ TEST_P(CapabilitySetForEachTest, CopyConstructor) {
   EXPECT_THAT(ElementsIn(copy), Eq(GetParam().expected));
 }
 
+TEST_P(CapabilitySetForEachTest, MoveConstructor) {
+  // We need a writable copy to move from.
+  CapabilitySet copy(GetParam().capabilities);
+  CapabilitySet moved(std::move(copy));
+  EXPECT_THAT(ElementsIn(moved), Eq(GetParam().expected));
+}
+
 TEST_P(CapabilitySetForEachTest, OperatorEquals) {
   CapabilitySet assigned = GetParam().capabilities;
   EXPECT_THAT(ElementsIn(assigned), Eq(GetParam().expected));

--- a/test/enum_set_test.cpp
+++ b/test/enum_set_test.cpp
@@ -841,16 +841,6 @@ TEST_P(CapabilitySetForEachTest, CopyConstructor) {
   EXPECT_THAT(ElementsIn(copy), Eq(GetParam().expected));
 }
 
-TEST_P(CapabilitySetForEachTest, MoveConstructor) {
-  // We need a writable copy to move from.
-  CapabilitySet copy(GetParam().capabilities);
-  CapabilitySet moved(std::move(copy));
-  EXPECT_THAT(ElementsIn(moved), Eq(GetParam().expected));
-
-  // The moved-from set is empty.
-  EXPECT_THAT(ElementsIn(copy), Eq(std::vector<spv::Capability>{}));
-}
-
 TEST_P(CapabilitySetForEachTest, OperatorEquals) {
   CapabilitySet assigned = GetParam().capabilities;
   EXPECT_THAT(ElementsIn(assigned), Eq(GetParam().expected));
@@ -858,7 +848,7 @@ TEST_P(CapabilitySetForEachTest, OperatorEquals) {
 
 TEST_P(CapabilitySetForEachTest, OperatorEqualsSelfAssign) {
   CapabilitySet assigned{GetParam().capabilities};
-  assigned = assigned;
+  assigned = assigned;  // NOLINT
   EXPECT_THAT(ElementsIn(assigned), Eq(GetParam().expected));
 }
 

--- a/test/opt/ir_context_test.cpp
+++ b/test/opt/ir_context_test.cpp
@@ -871,6 +871,7 @@ TEST_F(IRContextTest, AsanErrorTest) {
   opt::Function* fun =
       context->cfg()->block(5)->GetParent();  // Computes the CFG analysis
   opt::DominatorAnalysis* dom = nullptr;
+  // NOLINTNEXTLINE
   dom = context->GetDominatorAnalysis(fun);  // Computes the dominator analysis,
                                              // which depends on the CFG
                                              // analysis

--- a/test/opt/propagator_test.cpp
+++ b/test/opt/propagator_test.cpp
@@ -184,7 +184,7 @@ TEST_F(PropagatorTest, PropagateThroughPhis) {
       }
     } else if (instr->opcode() == spv::Op::OpPhi) {
       phi_instr = instr;
-      SSAPropagator::PropStatus retval;
+      SSAPropagator::PropStatus retval = SSAPropagator::kNotInteresting;
       for (uint32_t i = 2; i < instr->NumOperands(); i += 2) {
         uint32_t phi_arg_id = instr->GetSingleWordOperand(i);
         auto it = values_.find(phi_arg_id);

--- a/test/opt/trim_capabilities_pass_test.cpp
+++ b/test/opt/trim_capabilities_pass_test.cpp
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <tuple>
+
 #include "spirv-tools/optimizer.hpp"
 #include "test/opt/pass_fixture.h"
 #include "test/opt/pass_utils.h"


### PR DESCRIPTION
- const for passed-by-value has no effect on prototypes.
- transitive includes.
- dead stores
- uses after move