### PR TITLE
misc: fix encoding read for Python2.7

### DIFF
--- a/utils/generate_registry_tables.py
+++ b/utils/generate_registry_tables.py
@@ -17,6 +17,7 @@
 import errno
 import io
 import os.path
+import platform
 from xml.etree.ElementTree import XML, XMLParser, TreeBuilder
 
 
@@ -80,8 +81,15 @@ def main():
     args = parser.parse_args()
 
     with io.open(args.xml, encoding='utf-8') as xml_in:
+      # Python3 default str to UTF-8. But Python2.7 (in case of NDK build,
+      # don't be fooled by the shebang) is returning a unicode string.
+      # So depending of the version, we need to make sure the correct
+      # encoding is used.
+      content = xml_in.read()
+      if platform.python_version_tuple()[0] == '2':
+        content = content.encode('utf-8')
       parser = XMLParser(target=TreeBuilder(), encoding='utf-8')
-      registry = XML(xml_in.read(), parser=parser)
+      registry = XML(content, parser=parser)
 
     mkdir_p(os.path.dirname(args.generator_output))
     with open(args.generator_output, 'w') as f:


### PR DESCRIPTION
Those scripts are running on Python2.7 if build with the NDK tools. Under python2.7, io.open will load as "utf-8" since we give the encoding option, and return a "unicode" string.
Under Python3, the open() function will return a UTF-8 string. This means the XMLParser needs to have a different 'encoding' option depending on the python version.

For some reason I don't know, the XMLParser still fails if we use 'unicode' under Python2.7. But converting the unicode string to utf-8 does work.