### PR TITLE
[NFC] Fix potential buffer overflow

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -605,7 +605,7 @@ uint32_t GetLineLengthWithoutColor(const std::string line) {
     if (line[i] == '\x1b') {
       do {
         ++i;
-      } while (line[i] != 'm');
+      } while (i < line.size() && line[i] != 'm');
       continue;
     }
 


### PR DESCRIPTION
Fixing a clusterfuzz finding.
If the given binary has debug instruction which contained a badly formatted ANSI escape sequence, the iteration could go beyond the string length.