### PR TITLE
Add re2 dep back to Bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -499,6 +499,7 @@ cc_library(
         ":spirv_tools_link",
         ":test_lib",
         "@effcee//:effcee",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -499,7 +499,7 @@ cc_library(
         ":spirv_tools_link",
         ":test_lib",
         "@effcee//:effcee",
-        "@com_googlesource_code_re2//:re2",
+        "@re2//:re2",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,12 @@ local_path_override(
     path = "external/googletest",
 )
 
+bazel_dep(name = "re2", dev_dependency = True)
+local_path_override(
+    module_name = "re2",
+    path = "external/re2",
+)
+
 bazel_dep(name = "effcee", dev_dependency = True)
 local_path_override(
     module_name = "effcee",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,6 @@ local_repository(
 )
 
 local_repository(
-    name = "com_googlesource_code_re2",
-    path = "external/re2",
-)
-
-local_repository(
     name = "abseil-cpp",
     path = "external/abseil_cpp",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,11 @@ local_repository(
 )
 
 local_repository(
+    name = "com_googlesource_code_re2",
+    path = "external/re2",
+)
+
+local_repository(
     name = "abseil-cpp",
     path = "external/abseil_cpp",
 )


### PR DESCRIPTION
This explicit dep was removed in #5707 but it is still used by the test library. Not sure why the Bazel build didn't catch the indirect dependence on another module but it is causing build failures downstream.