### PR TITLE
Workaround issue in MSVC arm64 compiler returning random upper 32-bits in function spvtools::util::CountSetBits.

### DIFF
--- a/source/util/bitutils.h
+++ b/source/util/bitutils.h
@@ -97,7 +97,7 @@ template <typename T>
 size_t CountSetBits(T word) {
   static_assert(std::is_integral<T>::value,
                 "CountSetBits requires integer type");
-  size_t count = 0;
+  uint32_t count = 0;
   while (word) {
     word &= word - 1;
     ++count;


### PR DESCRIPTION
Fix issue #5762