### PR TITLE
Use "docker compose" in wasm build

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Build web
-        run: docker-compose -f source/wasm/docker-compose.yml --project-directory . up
+        run: docker compose -f source/wasm/docker-compose.yml --project-directory . up
       - name: Run tests
         run: node test/wasm/test.js


### PR DESCRIPTION
The wasm github action is using the deprecated `docker-compose` command.
This is update to use `docker compose`.
