### PR TITLE
Remove local attribute from build_version_inc genrule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -110,7 +110,6 @@ genrule(
     outs = ["build-version.inc"],
     cmd = "SOURCE_DATE_EPOCH=0 $(location :update_build_version) $(location CHANGES) $(location build-version.inc)",
     cmd_bat = "set SOURCE_DATE_EPOCH=0  && $(location :update_build_version) $(location CHANGES) $(location build-version.inc)",
-    local = True,
     tools = [":update_build_version"],
 )
 


### PR DESCRIPTION
I know I said I tested the Bazel rules back in [PR 5280](https://github.com/KhronosGroup/SPIRV-Tools/pull/5280#issuecomment-1601387655), however I must have done something wrong because the existing rules don't work on my Mac laptop (Mac host platform) when compiling using RBE (a Linux execution platform) for a Linux target platform. (This use-case didn't come up for some time, thus the delay in noticing/fixing).

I think this is because of the `local` flag. Having the `update_build_version` binary be listed in genrule's `tools` mean the python binary that runs the script is for `the exec configuration, since these tools are executed as part of the build` [citation](https://bazel.build/reference/be/general#genrule.tools), that is, the Linux RBE environment, however the rule is being run locally on my Mac, leading to errors like:
```
ERROR: /private/var/tmp/_bazel_home/a7603406973e08c3a2bee5f529cc5261/external/spirv_tools/BUILD.bazel:107:8: Executing genrule @spirv_tools//:build_version_inc failed: (Exit 1): bash failed: error executing command (from target @spirv_tools//:build_version_inc) /bin/bash -c ... (remaining 1 argument skipped)
Traceback (most recent call last):
  File "bazel-out/darwin_arm64-opt-exec-81C6BA4F/bin/external/spirv_tools/update_build_version", line 559, in <module>
    Main()
  File "bazel-out/darwin_arm64-opt-exec-81C6BA4F/bin/external/spirv_tools/update_build_version", line 544, in Main
    ExecuteFile(
  File "bazel-out/darwin_arm64-opt-exec-81C6BA4F/bin/external/spirv_tools/update_build_version", line 351, in ExecuteFile
    _RunExecv(python_program, main_filename, args, env)
  File "bazel-out/darwin_arm64-opt-exec-81C6BA4F/bin/external/spirv_tools/update_build_version", line 374, in _RunExecv
    os.execv(python_program, [python_program, main_filename] + args)
OSError: [Errno 8] Exec format error: '/private/var/tmp/_bazel_home/a7603406973e08c3a2bee5f529cc5261/execroot/skia/bazel-out/darwin_arm64-opt-exec-81C6BA4F/bin/external/spirv_tools/update_build_version.runfiles/python3_9_x86_64-unknown-linux-gnu/bin/python3'
```
Looking at the script and git history, I think the original intent of setting `local` was to run `git` as part of the script and look at the current checkout. However, in the world of Bazel and reproducible builds, that is not actually desired, as evidenced by the setting of `SOURCE_DATE_EPOCH=0` to override the contents of `build-version.inc` with something fixed.

The script only needs to parse the CHANGES file (which is correctly specified as an input) and so we shouldn't need `local` set anymore.

I looked at the contents of the generated `build-version.inc` file before and after my change and it was the same:
`"v2024.3", "SPIRV-Tools v2024.3 unknown hash, 1970-01-01T00:00:00+00:00"`
