### PR TITLE
Revert "OpSampledImage extra validation"

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1005,8 +1005,7 @@ bool IsAllowedSampledImageOperand(spv::Op opcode, ValidationState_t& _) {
 
 spv_result_t ValidateSampledImage(ValidationState_t& _,
                                   const Instruction* inst) {
-  auto type_inst = _.FindDef(inst->type_id());
-  if (type_inst->opcode() != spv::Op::OpTypeSampledImage) {
+  if (_.GetIdOpcode(inst->type_id()) != spv::Op::OpTypeSampledImage) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected Result Type to be OpTypeSampledImage.";
   }
@@ -1015,11 +1014,6 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
   if (_.GetIdOpcode(image_type) != spv::Op::OpTypeImage) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected Image to be of type OpTypeImage.";
-  }
-
-  if (type_inst->GetOperandAs<uint32_t>(1) != image_type) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Expected Image to have the same type as Result Type Image";
   }
 
   ImageTypeInfo info;

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -4451,7 +4451,7 @@ TEST_F(ValidateImage, QuerySizeNotImage) {
   const std::string body = R"(
 %img = OpLoad %type_image_f32_2d_0011 %uniform_image_f32_2d_0011
 %sampler = OpLoad %type_sampler %uniform_sampler
-%simg = OpSampledImage %type_sampled_image_f32_2d_0011 %img %sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
 %res1 = OpImageQuerySize %u32vec2 %sampler
 )";
 
@@ -4465,7 +4465,7 @@ TEST_F(ValidateImage, QuerySizeSampledImageDirectly) {
   const std::string body = R"(
 %img = OpLoad %type_image_f32_2d_0011 %uniform_image_f32_2d_0011
 %sampler = OpLoad %type_sampler %uniform_sampler
-%simg = OpSampledImage %type_sampled_image_f32_2d_0011 %img %sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
 %res1 = OpImageQuerySize %u32vec2 %simg
 )";
 
@@ -10645,44 +10645,6 @@ TEST_F(ValidateImage, ImageMSArray_ArrayedTypeDoesNotRequireCapability) {
   CompileSuccessfully(code, env);
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(), Eq(""));
-}
-
-TEST_F(ValidateImage, SampledImageTypeMismatch) {
-  const std::string code = R"(
-OpCapability Shader
-OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %main "main"
-OpExecutionMode %main LocalSize 1 1 1
-OpDecorate %im_var DescriptorSet 0
-OpDecorate %im_var Binding 0
-OpDecorate %s_var DescriptorSet 1
-OpDecorate %s_var Binding 0
-%void = OpTypeVoid
-%float = OpTypeFloat 32
-%im1_ty = OpTypeImage %float 2D 0 0 0 1 Unknown
-%im2_ty = OpTypeImage %float 2D 1 0 0 1 Unknown
-%s_ty = OpTypeSampler
-%s_im_ty = OpTypeSampledImage %im2_ty
-%ptr_im = OpTypePointer UniformConstant %im1_ty
-%ptr_s = OpTypePointer UniformConstant %s_ty
-%im_var = OpVariable %ptr_im UniformConstant
-%s_var = OpVariable %ptr_s UniformConstant
-%void_fn = OpTypeFunction %void
-%main = OpFunction %void None %void_fn
-%entry = OpLabel
-%im_ld = OpLoad %im1_ty %im_var
-%s_ld = OpLoad %s_ty %s_var
-%sampled_image = OpSampledImage %s_im_ty %im_ld %s_ld
-OpReturn
-OpFunctionEnd
-)";
-
-  const spv_target_env env = SPV_ENV_VULKAN_1_0;
-  CompileSuccessfully(code, env);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Expected Image to have the same type as Result Type Image"));
 }
 
 }  // namespace


### PR DESCRIPTION
Reverts KhronosGroup/SPIRV-Tools#5695

Contributes to #5781 

SPIR WG 2024-09-04: decision to relax validation requirement in the spec.