### PR TITLE
[SPV_KHR_untyped_pointers] Fix verification of vload/vstore OpenCL.std instructions

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2997,8 +2997,9 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         if (_.IsIntArrayType(format_data_type))
           format_data_type = _.GetComponentType(format_data_type);
 
-        if (!_.IsIntScalarType(format_data_type) ||
-            _.GetBitWidth(format_data_type) != 8) {
+        if ((!_.IsIntScalarType(format_data_type) ||
+             _.GetBitWidth(format_data_type) != 8) &&
+            !_.ContainsUntypedPointer(format_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected Format data type to be 8-bit int";

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -2701,8 +2701,9 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                     "Generic, CrossWorkgroup, Workgroup or Function";
         }
 
-        if (!_.IsFloatScalarType(p_data_type) ||
-            _.GetBitWidth(p_data_type) != 16) {
+        if ((!_.IsFloatScalarType(p_data_type) ||
+             _.GetBitWidth(p_data_type) != 16) &&
+            !_.ContainsUntypedPointer(p_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected operand P data type to be 16-bit float scalar";
@@ -2763,8 +2764,9 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                     "Generic, CrossWorkgroup, Workgroup or Function";
         }
 
-        if (!_.IsFloatScalarType(p_data_type) ||
-            _.GetBitWidth(p_data_type) != 16) {
+        if ((!_.IsFloatScalarType(p_data_type) ||
+             _.GetBitWidth(p_data_type) != 16) &&
+            !_.ContainsUntypedPointer(p_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected operand P data type to be 16-bit float scalar";
@@ -2855,8 +2857,9 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                     "CrossWorkgroup, Workgroup or Function";
         }
 
-        if (!_.IsFloatScalarType(p_data_type) ||
-            _.GetBitWidth(p_data_type) != 16) {
+        if ((!_.IsFloatScalarType(p_data_type) ||
+             _.GetBitWidth(p_data_type) != 16) &&
+            !_.ContainsUntypedPointer(p_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected operand P data type to be 16-bit float scalar";


### PR DESCRIPTION
Allow `p` to be untyped pointer:

```
operand must be a pointer(p1, ...).If it is a typed pointer, it must point to data types.

```

https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html#_modifications_to_the_opencl_std_extended_instruction_set