### PR TITLE
Update SPIRV-Headers

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': '6dcd83d60f7944926bfd308cc13979fc53dd69ca',
 
-  'spirv_headers_revision': 'efb6b4099ddb8fa60f62956dee592c4b94ec6a49',
+  'spirv_headers_revision': '2a9b6f951c7d6b04b6c21fe1bf3f475b68b84801',
 }
 
 deps = {

--- a/test/opt/trim_capabilities_pass_test.cpp
+++ b/test/opt/trim_capabilities_pass_test.cpp
@@ -63,8 +63,8 @@ TEST_F(TrimCapabilitiesPassTest, CheckKnownAliasTransformations) {
                OpCapability DotProductInput4x8BitKHR
                OpCapability DotProductInput4x8BitPackedKHR
                OpCapability DotProductKHR
-               OpCapability ComputeDerivativeGroupQuadsNV
-               OpCapability ComputeDerivativeGroupLinearNV
+               OpCapability ComputeDerivativeGroupQuadsKHR
+               OpCapability ComputeDerivativeGroupLinearKHR
 ; CHECK: OpCapability Linkage
 ; CHECK-NOT: OpCapability StorageUniform16
 ; CHECK-NOT: OpCapability StorageUniformBufferBlock16
@@ -91,8 +91,8 @@ TEST_F(TrimCapabilitiesPassTest, CheckKnownAliasTransformations) {
 ; CHECK-NOT: OpCapability DotProductInput4x8BitKHR
 ; CHECK-NOT: OpCapability DotProductInput4x8BitPackedKHR
 ; CHECK-NOT: OpCapability DotProductKHR
-; CHECK-NOT: OpCapability ComputeDerivativeGroupQuadsNV
-; CHECK-NOT: OpCapability ComputeDerivativeGroupLinearNV
+; CHECK-NOT: OpCapability ComputeDerivativeGroupQuadsKHR
+; CHECK-NOT: OpCapability ComputeDerivativeGroupLinearKHR
 ; CHECK: OpCapability UniformAndStorageBuffer16BitAccess
 ; CHECK: OpCapability StorageBuffer16BitAccess
 ; CHECK: OpCapability ShaderViewportIndexLayerEXT
@@ -2136,11 +2136,11 @@ TEST_F(TrimCapabilitiesPassTest, Float64_RemainsWhenUsed) {
 TEST_F(TrimCapabilitiesPassTest,
        ComputeDerivativeGroupQuads_ReamainsWithExecMode) {
   const std::string kTest = R"(
-               OpCapability ComputeDerivativeGroupQuadsNV
-               OpCapability ComputeDerivativeGroupLinearNV
-; CHECK-NOT:   OpCapability ComputeDerivativeGroupLinearNV
-; CHECK:       OpCapability ComputeDerivativeGroupQuadsNV
-; CHECK-NOT:   OpCapability ComputeDerivativeGroupLinearNV
+               OpCapability ComputeDerivativeGroupQuadsKHR
+               OpCapability ComputeDerivativeGroupLinearKHR
+; CHECK-NOT:   OpCapability ComputeDerivativeGroupLinearKHR
+; CHECK:       OpCapability ComputeDerivativeGroupQuadsKHR
+; CHECK-NOT:   OpCapability ComputeDerivativeGroupLinearKHR
                OpCapability Shader
 ; CHECK:       OpExtension "SPV_NV_compute_shader_derivatives"
                OpExtension "SPV_NV_compute_shader_derivatives"
@@ -2162,11 +2162,11 @@ TEST_F(TrimCapabilitiesPassTest,
 TEST_F(TrimCapabilitiesPassTest,
        ComputeDerivativeGroupLinear_ReamainsWithExecMode) {
   const std::string kTest = R"(
-               OpCapability ComputeDerivativeGroupLinearNV
-               OpCapability ComputeDerivativeGroupQuadsNV
-; CHECK-NOT:   OpCapability ComputeDerivativeGroupQuadsNV
-; CHECK:       OpCapability ComputeDerivativeGroupLinearNV
-; CHECK-NOT:   OpCapability ComputeDerivativeGroupQuadsNV
+               OpCapability ComputeDerivativeGroupLinearKHR
+               OpCapability ComputeDerivativeGroupQuadsKHR
+; CHECK-NOT:   OpCapability ComputeDerivativeGroupQuadsKHR
+; CHECK:       OpCapability ComputeDerivativeGroupLinearKHR
+; CHECK-NOT:   OpCapability ComputeDerivativeGroupQuadsKHR
                OpCapability Shader
 ; CHECK:       OpExtension "SPV_NV_compute_shader_derivatives"
                OpExtension "SPV_NV_compute_shader_derivatives"


### PR DESCRIPTION
* Fix capability trimming tests to use KHR names for compute derivatives