### PR TITLE
spirv-opt: fix crash in function declarations

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -267,6 +267,7 @@ void AggressiveDCEPass::AddBreaksAndContinuesToWorklist(
 }
 
 bool AggressiveDCEPass::AggressiveDCE(Function* func) {
+  if (func->IsDeclaration()) return false;
   std::list<BasicBlock*> structured_order;
   cfg()->ComputeStructuredOrder(func, &*func->begin(), &structured_order);
   live_local_vars_.clear();

--- a/source/opt/mem_pass.cpp
+++ b/source/opt/mem_pass.cpp
@@ -415,6 +415,7 @@ void MemPass::RemoveBlock(Function::iterator* bi) {
 }
 
 bool MemPass::RemoveUnreachableBlocks(Function* func) {
+  if (func->IsDeclaration()) return false;
   bool modified = false;
 
   // Mark reachable all blocks reachable from the function's entry block.


### PR DESCRIPTION
Function declarations contain no blocks, so bail before segfaulting in function optimization passes that operate on blocks.

Fixes #5795