### PR TITLE
[SPV_KHR_untyped_pointers] Fix verification for OpenCL.std instructions

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1980,7 +1980,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                     "CrossWorkgroup, Workgroup or Function";
         }
 
-        if (result_type != p_data_type) {
+        if (!_.ContainsUntypedPointer(p_type) && result_type != p_data_type) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected data type of the pointer to be equal to Result "
@@ -2042,15 +2042,17 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                     "CrossWorkgroup, Workgroup or Function";
         }
 
-        if (!_.IsIntScalarOrVectorType(p_data_type) ||
-            _.GetBitWidth(p_data_type) != 32) {
+        if ((!_.IsIntScalarOrVectorType(p_data_type) ||
+             _.GetBitWidth(p_data_type) != 32) &&
+            !_.ContainsUntypedPointer(p_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected data type of the pointer to be a 32-bit int "
                     "scalar or vector type";
         }
 
-        if (_.GetDimension(p_data_type) != num_components) {
+        if (!_.ContainsUntypedPointer(p_type) &&
+            _.GetDimension(p_data_type) != num_components) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << ext_inst_name() << ": "
                  << "expected data type of the pointer to have the same number "

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -463,7 +463,9 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
     const auto initializer_id = inst->GetOperandAs<uint32_t>(initializer_index);
     const auto initializer = _.FindDef(initializer_id);
     const auto is_module_scope_var =
-        initializer && (initializer->opcode() == spv::Op::OpVariable) &&
+        initializer &&
+        (initializer->opcode() == spv::Op::OpVariable ||
+         initializer->opcode() == spv::Op::OpUntypedVariableKHR) &&
         (initializer->GetOperandAs<spv::StorageClass>(storage_class_index) !=
          spv::StorageClass::Function);
     const auto is_constant =


### PR DESCRIPTION
Allow `p` to be untyped pointer for `fract`, `frexp`, `lgamma_r`, `modf`, `remquo`, and `sincos`:
```
operand must be a pointer(p1, ...).If it is a typed pointer, it must
point to data types.

```
https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.html#_modifications_to_the_opencl_std_extended_instruction_set

Also fix check for module-scope variables.