### PR TITLE
spirv-val: Add missing NonSemantic.Shader.DebugInfo.100

### DIFF
--- a/source/val/function.h
+++ b/source/val/function.h
@@ -278,7 +278,7 @@ class Function {
   Construct& FindConstructForEntryBlock(const BasicBlock* entry_block,
                                         ConstructType t);
 
-  /// The result id of the OpLabel that defined this block
+  /// The result id of OpFunction
   uint32_t id_;
 
   /// The type of the function

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -3090,7 +3090,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         // validation.
         case NonSemanticShaderDebugInfo100DebugInfoNone:
         case NonSemanticShaderDebugInfo100DebugCompilationUnit:
-        case NonSemanticShaderDebugInfo100DebugTypeBasic:
         case NonSemanticShaderDebugInfo100DebugTypePointer:
         case NonSemanticShaderDebugInfo100DebugTypeQualifier:
         case NonSemanticShaderDebugInfo100DebugTypeArray:
@@ -3116,7 +3115,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         case NonSemanticShaderDebugInfo100DebugInlinedAt:
         case NonSemanticShaderDebugInfo100DebugLocalVariable:
         case NonSemanticShaderDebugInfo100DebugInlinedVariable:
-        case NonSemanticShaderDebugInfo100DebugDeclare:
         case NonSemanticShaderDebugInfo100DebugValue:
         case NonSemanticShaderDebugInfo100DebugOperation:
         case NonSemanticShaderDebugInfo100DebugExpression:
@@ -3125,6 +3123,24 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         case NonSemanticShaderDebugInfo100DebugImportedEntity:
         case NonSemanticShaderDebugInfo100DebugSource:
           break;
+
+        // These checks are for operands that are differnet in
+        // ShaderDebugInfo100
+        case NonSemanticShaderDebugInfo100DebugTypeBasic: {
+          CHECK_CONST_UINT_OPERAND("Flags", 8);
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugDeclare: {
+          for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
+            auto index_inst = _.FindDef(inst->word(word_index));
+            auto type_id = index_inst != nullptr ? index_inst->type_id() : 0;
+            if (type_id == 0 || !IsIntScalar(_, type_id, false, false))
+              return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                     << ext_inst_name() << ": "
+                     << "expected index must be scalar integer";
+          }
+          break;
+        }
         case NonSemanticShaderDebugInfo100DebugTypeMatrix: {
           CHECK_DEBUG_OPERAND("Vector Type", CommonDebugInfoDebugTypeVector, 5);
 
@@ -3146,14 +3162,83 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
           }
           break;
         }
-        // TODO: Add validation rules for remaining cases as well.
-        case NonSemanticShaderDebugInfo100DebugFunctionDefinition:
-        case NonSemanticShaderDebugInfo100DebugSourceContinued:
-        case NonSemanticShaderDebugInfo100DebugLine:
+        case NonSemanticShaderDebugInfo100DebugFunctionDefinition: {
+          CHECK_DEBUG_OPERAND("Function", CommonDebugInfoDebugFunction, 5);
+          CHECK_OPERAND("Definition", spv::Op::OpFunction, 6);
+          const auto* current_function = inst->function();
+          if (current_function->first_block()->id() != inst->block()->id()) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name()
+                   << ": must be in the entry basic block of the function";
+          }
+
+          const uint32_t definition_id = inst->word(6);
+          if (definition_id != current_function->id()) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name()
+                   << ": operand Definition must point to the OpFunction it is "
+                      "inside";
+          }
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugLine: {
+          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
+          CHECK_CONST_UINT_OPERAND("Line Start", 6);
+          CHECK_CONST_UINT_OPERAND("Line End", 7);
+          CHECK_CONST_UINT_OPERAND("Column Start", 8);
+          CHECK_CONST_UINT_OPERAND("Column End", 9);
+
+          // above already validates if 32-bit and non-spec constant
+          // but want to use EvalInt32IfConst to be consistent with other Eval
+          // locations
+          bool is_int32 = false, is_const_int32 = false;
+          uint32_t line_start = 0;
+          uint32_t line_end = 0;
+          uint32_t column_start = 0;
+          uint32_t column_end = 0;
+          std::tie(is_int32, is_const_int32, line_start) =
+              _.EvalInt32IfConst(inst->word(6));
+          std::tie(is_int32, is_const_int32, line_end) =
+              _.EvalInt32IfConst(inst->word(7));
+          std::tie(is_int32, is_const_int32, column_start) =
+              _.EvalInt32IfConst(inst->word(8));
+          std::tie(is_int32, is_const_int32, column_end) =
+              _.EvalInt32IfConst(inst->word(9));
+          if (line_end < line_start) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name() << ": operand Line End (" << line_end
+                   << ") is less than Line Start (" << line_start << ")";
+          } else if (column_end < column_start) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << ext_inst_name() << ": operand Column End (" << column_end
+                   << ") is less than Column Start (" << column_start << ")";
+          }
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugSourceContinued: {
+          CHECK_OPERAND("Text", spv::Op::OpString, 5);
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugBuildIdentifier: {
+          CHECK_OPERAND("Identifier", spv::Op::OpString, 5);
+          CHECK_CONST_UINT_OPERAND("Flags", 6);
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugStoragePath: {
+          CHECK_OPERAND("Path", spv::Op::OpString, 5);
+          break;
+        }
+        case NonSemanticShaderDebugInfo100DebugEntryPoint: {
+          CHECK_DEBUG_OPERAND("Entry Point", CommonDebugInfoDebugFunction, 5);
+          CHECK_DEBUG_OPERAND("Compilation Unit",
+                              CommonDebugInfoDebugCompilationUnit, 6);
+          CHECK_OPERAND("Compiler Signature", spv::Op::OpString, 7);
+          CHECK_OPERAND("Command-line Arguments", spv::Op::OpString, 8);
+          break;
+        }
+
+          // Has no additional checks
         case NonSemanticShaderDebugInfo100DebugNoLine:
-        case NonSemanticShaderDebugInfo100DebugBuildIdentifier:
-        case NonSemanticShaderDebugInfo100DebugStoragePath:
-        case NonSemanticShaderDebugInfo100DebugEntryPoint:
           break;
         case NonSemanticShaderDebugInfo100InstructionsMax:
           assert(0);
@@ -3455,9 +3540,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         }
         case CommonDebugInfoDebugFunction: {
           CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          auto validate_type = ValidateOperandDebugType(_, "Type", inst, 6,
-                                                        ext_inst_name, false);
-          if (validate_type != SPV_SUCCESS) return validate_type;
+          CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
           CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
           CHECK_CONST_UINT_OPERAND("Line", 8);
           CHECK_CONST_UINT_OPERAND("Column", 9);
@@ -3492,9 +3575,7 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
         }
         case CommonDebugInfoDebugFunctionDeclaration: {
           CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          auto validate_type = ValidateOperandDebugType(_, "Type", inst, 6,
-                                                        ext_inst_name, false);
-          if (validate_type != SPV_SUCCESS) return validate_type;
+          CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
           CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
           CHECK_CONST_UINT_OPERAND("Line", 8);
           CHECK_CONST_UINT_OPERAND("Column", 9);
@@ -3556,18 +3637,6 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
           }
 
           CHECK_DEBUG_OPERAND("Expression", CommonDebugInfoDebugExpression, 7);
-
-          if (vulkanDebugInfo) {
-            for (uint32_t word_index = 8; word_index < num_words;
-                 ++word_index) {
-              auto index_inst = _.FindDef(inst->word(word_index));
-              auto type_id = index_inst != nullptr ? index_inst->type_id() : 0;
-              if (type_id == 0 || !IsIntScalar(_, type_id, false, false))
-                return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                       << ext_inst_name() << ": "
-                       << "expected index must be scalar integer";
-            }
-          }
           break;
         }
         case CommonDebugInfoDebugExpression: {

--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -75,8 +75,8 @@ spv_result_t ModuleScopedInstructions(ValidationState_t& _,
 
         if (local_debug_info) {
           if (_.in_function_body() == false) {
-            // DebugScope, DebugNoScope, DebugDeclare, DebugValue must
-            // appear in a function body.
+            // TODO - Print the actual name of the instruction as this list is
+            // not complete (see ext_inst_name in ValidateExtInst() for example)
             return _.diag(SPV_ERROR_INVALID_LAYOUT, inst)
                    << "DebugScope, DebugNoScope, DebugDeclare, DebugValue "
                    << "of debug info extension must appear in a function "

--- a/test/opt/inline_test.cpp
+++ b/test/opt/inline_test.cpp
@@ -3749,13 +3749,13 @@ float4 main(float4 color : COLOR) : SV_TARGET {
       %color = OpFunctionParameter %_ptr_Function_v4float
    %bb_entry = OpLabel
         %140 = OpExtInst %void %1 DebugFunctionDefinition %22 %src_main
-        %141 = OpExtInst %void %1 DebugLine %5 %uint_1 %uint_1 %uint_1 %uint_1
+        %141 = OpExtInst %void %1 DebugLine %15 %uint_1 %uint_1 %uint_1 %uint_1
          %34 = OpExtInst %void %1 DebugScope %22
          %36 = OpExtInst %void %1 DebugDeclare %25 %color %13
          %38 = OpExtInst %void %1 DebugScope %26
-        %142 = OpExtInst %void %1 DebugLine %5 %uint_2 %uint_2 %uint_10 %uint_10
+        %142 = OpExtInst %void %1 DebugLine %15 %uint_2 %uint_2 %uint_10 %uint_10
          %39 = OpLoad %v4float %color
-        %143 = OpExtInst %void %1 DebugLine %5 %uint_2 %uint_2 %uint_3 %uint_3
+        %143 = OpExtInst %void %1 DebugLine %15 %uint_2 %uint_2 %uint_3 %uint_3
                OpReturnValue %39
                OpFunctionEnd
 )";

--- a/test/opt/loop_optimizations/unroll_simple.cpp
+++ b/test/opt/loop_optimizations/unroll_simple.cpp
@@ -510,36 +510,36 @@ OpBranch %24
 %24 = OpLabel
 %35 = OpPhi %8 %10 %23 %34 %26
 %s1 = OpExtInst %6 %ext DebugScope %dbg_main
-%d10 = OpExtInst %6 %ext DebugLine %file_name %uint_1 %uint_1 %uint_0 %uint_0
+%d10 = OpExtInst %6 %ext DebugLine %src %uint_1 %uint_1 %uint_0 %uint_0
 %value0 = OpExtInst %6 %ext DebugValue %dbg_f %35 %null_expr
 OpLoopMerge %25 %26 Unroll
 OpBranch %27
 %27 = OpLabel
 %s2 = OpExtInst %6 %ext DebugScope %dbg_main
-%d1 = OpExtInst %6 %ext DebugLine %file_name %uint_1 %uint_1 %uint_1 %uint_1
+%d1 = OpExtInst %6 %ext DebugLine %src %uint_1 %uint_1 %uint_1 %uint_1
 %29 = OpSLessThan %12 %35 %11
-%d2 = OpExtInst %6 %ext DebugLine %file_name %uint_2 %uint_2 %uint_0 %uint_0
+%d2 = OpExtInst %6 %ext DebugLine %src %uint_2 %uint_2 %uint_0 %uint_0
 OpBranchConditional %29 %30 %25
 %30 = OpLabel
 %s3 = OpExtInst %6 %ext DebugScope %bb
 %decl0 = OpExtInst %6 %ext DebugDeclare %dbg_f %5 %null_expr
 %decl1 = OpExtInst %6 %ext DebugValue %dbg_i %5 %deref_expr
-%d3 = OpExtInst %6 %ext DebugLine %file_name %uint_3 %uint_3 %uint_0 %uint_0
+%d3 = OpExtInst %6 %ext DebugLine %src %uint_3 %uint_3 %uint_0 %uint_0
 %32 = OpAccessChain %19 %5 %35
-%d4 = OpExtInst %6 %ext DebugLine %file_name %uint_4 %uint_4 %uint_0 %uint_0
+%d4 = OpExtInst %6 %ext DebugLine %src %uint_4 %uint_4 %uint_0 %uint_0
 OpStore %32 %18
-%d5 = OpExtInst %6 %ext DebugLine %file_name %uint_5 %uint_5 %uint_0 %uint_0
+%d5 = OpExtInst %6 %ext DebugLine %src %uint_5 %uint_5 %uint_0 %uint_0
 OpBranch %26
 %26 = OpLabel
 %s4 = OpExtInst %6 %ext DebugScope %dbg_main
-%d6 = OpExtInst %6 %ext DebugLine %file_name %uint_6 %uint_6 %uint_0 %uint_0
+%d6 = OpExtInst %6 %ext DebugLine %src %uint_6 %uint_6 %uint_0 %uint_0
 %34 = OpIAdd %8 %35 %20
 %value1 = OpExtInst %6 %ext DebugValue %dbg_f %34 %null_expr
-%d7 = OpExtInst %6 %ext DebugLine %file_name %uint_7 %uint_7 %uint_0 %uint_0
+%d7 = OpExtInst %6 %ext DebugLine %src %uint_7 %uint_7 %uint_0 %uint_0
 OpBranch %24
 %25 = OpLabel
 %s5 = OpExtInst %6 %ext DebugScope %dbg_main
-%d8 = OpExtInst %6 %ext DebugLine %file_name %uint_8 %uint_8 %uint_0 %uint_0
+%d8 = OpExtInst %6 %ext DebugLine %src %uint_8 %uint_8 %uint_0 %uint_0
 OpReturn
 OpFunctionEnd)";
 

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -118,6 +118,7 @@ OpCapability Int64
     ss << "OpExecutionMode %main OriginUpperLeft\n";
   }
 
+  ss << "%main_name = OpString \"main\"\n";
   ss << op_string_instructions;
 
   ss << R"(
@@ -181,6 +182,9 @@ OpCapability Int64
 %u32_1 = OpConstant %u32 1
 %u32_2 = OpConstant %u32 2
 %u32_3 = OpConstant %u32 3
+%u32_4 = OpConstant %u32 4
+%u32_5 = OpConstant %u32 5
+%u32_32 = OpConstant %u32 32
 
 %s32_0 = OpConstant %s32 0
 %s32_1 = OpConstant %s32 1
@@ -373,8 +377,6 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, OpenCLDebugInfo100DebugScope) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %int_name = OpString "int"
 %foo_name = OpString "foo"
 )";
@@ -384,7 +386,7 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, OpenCLDebugInfo100DebugScope) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %int_info = OpExtInst %void %DbgExt DebugTypeBasic %int_name %u32_0 Signed
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %main
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %int_info %dbg_src 1 1 %main_info FlagIsLocal
 %expr = OpExtInst %void %DbgExt DebugExpression
 )";
@@ -412,8 +414,6 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, VulkanDebugInfo100DebugScope) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %int_name = OpString "int"
 %foo_name = OpString "foo"
 )";
@@ -423,7 +423,7 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, VulkanDebugInfo100DebugScope) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
 %int_info = OpExtInst %void %DbgExt DebugTypeBasic %int_name %u32_0 %u32_1 %u32_0
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src %u32_1 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_1
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src %u32_1 %u32_1 %comp_unit %main_name %u32_3 %u32_1
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %int_info %dbg_src %u32_1 %u32_1 %main_info %u32_4
 %expr = OpExtInst %void %DbgExt DebugExpression
 )";
@@ -439,13 +439,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header + GetParam(), body, extension, "Vertex"));
+      src, "", dbg_inst_header + GetParam(), body, extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugScope, DebugNoScope, DebugDeclare, DebugValue "
@@ -465,15 +460,13 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionForwardReference) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %main
 )";
 
   const std::string body = R"(
@@ -494,8 +487,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionMissingOpFunction) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 )";
 
   const std::string dbg_inst_header = R"(
@@ -503,7 +494,7 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionMissingOpFunction) {
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %dbgNone
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %dbgNone
 )";
 
   const std::string body = R"(
@@ -528,8 +519,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugScopeBeforeOpVariableInFunction) {
 }
 "
 %float_name = OpString "float"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string size_const = R"(
@@ -542,7 +531,7 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugScopeBeforeOpVariableInFunction) {
 %float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %int_32 Float
 %v4float_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %v4float_info %float_info
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main
 )";
 
   const std::string body = R"(
@@ -801,13 +790,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, dbg_inst,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
+                                                     extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Source must be a result id of "
@@ -858,12 +842,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailName) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -875,8 +853,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Name must be a result id of "
@@ -928,15 +906,13 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailSize) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
+%f32_32 = OpConstant %f32 32
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
-%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %float_name %u32_3 %u32_0
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_3 %u32_3 %f32_32
 )";
 
   const std::string extension = R"(
@@ -948,8 +924,8 @@ OpExtension "SPV_KHR_non_semantic_info"
       src, constants, dbg_inst_header, "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("expected operand Size must be a result id of "
-                        "OpConstant"));
+              HasSubstr("expected operand Flags must be a result id of 32-bit "
+                        "unsigned OpConstant"));
 }
 
 TEST_F(ValidateOpenCL100DebugInfo, DebugTypePointer) {
@@ -1092,12 +1068,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifier) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1110,8 +1080,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1126,12 +1096,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifierFail) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1144,8 +1108,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -1185,7 +1149,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayWithVariableSize) {
 %code = OpString "main() {}"
 %float_name = OpString "float"
 %int_name = OpString "int"
-%main_name = OpString "main"
 %foo_name = OpString "foo"
 )";
 
@@ -1344,7 +1307,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailVariableSizeTypeFloat) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-%main_name = OpString "main"
 %foo_name = OpString "foo"
 )";
 
@@ -1383,12 +1345,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArray) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1401,8 +1357,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1412,15 +1368,11 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayWithVariableSize) {
 %code = OpString "main() {}"
 %float_name = OpString "float"
 %uint_name = OpString "uint"
-%main_name = OpString "main"
 %foo_name = OpString "foo"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_6 = OpConstant %u32 6
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1451,12 +1403,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailBaseType) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1469,8 +1415,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type is not a valid debug "
@@ -1482,12 +1428,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCount) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1502,8 +1442,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1519,12 +1459,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCountFloat) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1537,8 +1471,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1554,12 +1488,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayComponentCountZero) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1572,8 +1500,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1582,15 +1510,11 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailVariableSizeTypeFloat) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-%main_name = OpString "main"
 %foo_name = OpString "foo"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_6 = OpConstant %u32 6
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1742,12 +1666,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVector) {
 %float_name = OpString "float"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -1760,8 +1678,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1770,12 +1688,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFail) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1790,8 +1702,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1803,12 +1715,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentZero) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1823,8 +1729,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1836,12 +1742,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentFive) {
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -1856,8 +1756,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1872,9 +1772,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrix) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %true = OpConstantTrue %bool
 )";
 
@@ -1904,9 +1801,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorTypeType) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %true = OpConstantTrue %bool
 )";
 
@@ -1939,9 +1833,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountType) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %true = OpConstantTrue %bool
 )";
 
@@ -1974,9 +1865,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountZero) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %true = OpConstantTrue %bool
 )";
 
@@ -2009,9 +1897,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountFive) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %true = OpConstantTrue %bool
 )";
 
@@ -2119,12 +2004,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypedef) {
 %foo_name = OpString "foo"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -2137,8 +2016,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2148,12 +2027,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypedef, Fail) {
 %code = OpString "main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const auto& param = GetParam();
@@ -2171,8 +2044,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
+                                                     extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second +
@@ -2200,8 +2073,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunction) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
 )";
 
@@ -2232,8 +2103,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunctionFailReturn) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
 )";
 
@@ -2264,8 +2133,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunctionFailParam) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
 )";
 
@@ -2296,15 +2163,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionAndParams) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -2322,8 +2181,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2331,15 +2190,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailReturn) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -2354,8 +2205,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2366,15 +2217,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailParam) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 %float_name = OpString "float"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -2389,8 +2232,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2498,12 +2341,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeEnum) {
 %foo_name = OpString "foo"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -2519,8 +2356,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2530,12 +2367,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypeEnum, Fail) {
 %code = OpString "main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const auto& param = GetParam();
@@ -2553,8 +2384,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
+                                                     extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2604,8 +2435,6 @@ main() {}
 %foo_name = OpString "foo"
 %VS_OUTPUT_pos_name = OpString "pos : SV_POSITION"
 %VS_OUTPUT_linkage_name = OpString "VS_OUTPUT"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string size_const = R"(
@@ -2621,7 +2450,7 @@ main() {}
 %v4float_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
 %VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember %VS_OUTPUT_pos_name %v4float_info %dbg_src 2 3 %VS_OUTPUT_info %u32_0 %int_128 FlagIsPublic
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %v4float_info %float_info
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main
 %foo_info = OpExtInst %void %DbgExt DebugTypeComposite %foo_name Structure %dbg_src 1 1 %comp_unit %foo_name %u32_0 FlagIsPublic
 %child = OpExtInst %void %DbgExt DebugTypeInheritance %foo_info %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
 )";
@@ -2650,8 +2479,6 @@ main() {}
 %foo_name = OpString "foo"
 %VS_OUTPUT_pos_name = OpString "pos : SV_POSITION"
 %VS_OUTPUT_linkage_name = OpString "VS_OUTPUT"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string size_const = R"(
@@ -2672,7 +2499,7 @@ main() {}
 %v4float_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
 %VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember %VS_OUTPUT_pos_name %v4float_info %dbg_src 2 3 %VS_OUTPUT_info %u32_0 %int_128 FlagIsPublic
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %v4float_info %float_info
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main
 %foo_info = OpExtInst %void %DbgExt DebugTypeComposite %foo_name Structure %dbg_src 1 1 %comp_unit %foo_name %u32_0 FlagIsPublic
 %child = OpExtInst %void %DbgExt DebugTypeInheritance %foo_info %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
 )";
@@ -2849,14 +2676,9 @@ main() {}
 %foo_name = OpString "foo"
 %VS_OUTPUT_pos_name = OpString "pos : SV_POSITION"
 %VS_OUTPUT_linkage_name = OpString "VS_OUTPUT"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %u32_128 = OpConstant %u32 128
 )";
 
@@ -2895,14 +2717,9 @@ main() {}
 %foo_name = OpString "foo"
 %VS_OUTPUT_pos_name = OpString "pos : SV_POSITION"
 %VS_OUTPUT_linkage_name = OpString "VS_OUTPUT"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %u32_128 = OpConstant %u32 128
 )";
 
@@ -2971,9 +2788,6 @@ main() {}
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 %u32_128 = OpConstant %u32 128
 )";
 
@@ -3033,16 +2847,14 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionDeclaration) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main)";
+%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main)";
 
   const std::string extension = R"(
 %DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
@@ -3061,8 +2873,6 @@ TEST_P(ValidateOpenCL100DebugInfoDebugFunction, Fail) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const auto& param = GetParam();
@@ -3072,7 +2882,7 @@ main() {}
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic
+%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic
 %main_info = OpExtInst %void %DbgExt DebugFunction )"
      << param.first;
 
@@ -3091,25 +2901,25 @@ INSTANTIATE_TEST_SUITE_P(
     AllOpenCL100DebugInfoFail, ValidateOpenCL100DebugInfoDebugFunction,
     ::testing::ValuesIn(std::vector<std::pair<std::string, std::string>>{
         std::make_pair(
-            R"(%u32_0 %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main)",
+            R"(%u32_0 %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main)",
             "Name"),
         std::make_pair(
-            R"(%main_name %dbg_src %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main)",
+            R"(%main_name %dbg_src %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main)",
             "Type"),
         std::make_pair(
-            R"(%main_name %main_type_info %comp_unit 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main)",
+            R"(%main_name %main_type_info %comp_unit 12 1 %comp_unit %main_name FlagIsPublic 13 %main)",
             "Source"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src 12 1 %dbg_src %main_linkage_name FlagIsPublic 13 %main)",
+            R"(%main_name %main_type_info %dbg_src 12 1 %dbg_src %main_name FlagIsPublic 13 %main)",
             "Parent"),
         std::make_pair(
             R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %void FlagIsPublic 13 %main)",
             "Linkage Name"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %void)",
+            R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %void)",
             "Function"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic 13 %main %dbg_src)",
+            R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main %dbg_src)",
             "Declaration"),
     }));
 
@@ -3121,8 +2931,6 @@ TEST_P(ValidateOpenCL100DebugInfoDebugFunctionDeclaration, Fail) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const auto& param = GetParam();
@@ -3151,16 +2959,16 @@ INSTANTIATE_TEST_SUITE_P(
     ValidateOpenCL100DebugInfoDebugFunctionDeclaration,
     ::testing::ValuesIn(std::vector<std::pair<std::string, std::string>>{
         std::make_pair(
-            R"(%u32_0 %main_type_info %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic)",
+            R"(%u32_0 %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic)",
             "Name"),
         std::make_pair(
-            R"(%main_name %dbg_src %dbg_src 12 1 %comp_unit %main_linkage_name FlagIsPublic)",
+            R"(%main_name %dbg_src %dbg_src 12 1 %comp_unit %main_name FlagIsPublic)",
             "Type"),
         std::make_pair(
-            R"(%main_name %main_type_info %comp_unit 12 1 %comp_unit %main_linkage_name FlagIsPublic)",
+            R"(%main_name %main_type_info %comp_unit 12 1 %comp_unit %main_name FlagIsPublic)",
             "Source"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src 12 1 %dbg_src %main_linkage_name FlagIsPublic)",
+            R"(%main_name %main_type_info %dbg_src 12 1 %dbg_src %main_name FlagIsPublic)",
             "Parent"),
         std::make_pair(
             R"(%main_name %main_type_info %dbg_src 12 1 %comp_unit %void FlagIsPublic)",
@@ -3175,13 +2983,9 @@ TEST_F(ValidateVulkan100DebugInfo, DebugFunctionDeclaration) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_12 = OpConstant %u32 12
 %u32_13 = OpConstant %u32 13
 )";
@@ -3190,8 +2994,8 @@ main() {}
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %void
-%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_13
+%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13
 )";
 
   const std::string extension = R"(
@@ -3212,13 +3016,9 @@ TEST_P(ValidateVulkan100DebugInfoDebugFunction, Fail) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_12 = OpConstant %u32 12
 %u32_13 = OpConstant %u32 13
 )";
@@ -3230,7 +3030,7 @@ main() {}
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %void
-%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3
+%main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3
 %main_info = OpExtInst %void %DbgExt DebugFunction )"
      << param.first;
 
@@ -3250,22 +3050,22 @@ INSTANTIATE_TEST_SUITE_P(
     AllVulkan100DebugInfoFail, ValidateVulkan100DebugInfoDebugFunction,
     ::testing::ValuesIn(std::vector<std::pair<std::string, std::string>>{
         std::make_pair(
-            R"(%u32_0 %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_13)",
+            R"(%u32_0 %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13)",
             "Name"),
         std::make_pair(
-            R"(%main_name %dbg_src %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_13)",
+            R"(%main_name %dbg_src %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13)",
             "Type"),
         std::make_pair(
-            R"(%main_name %main_type_info %comp_unit %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_13)",
+            R"(%main_name %main_type_info %comp_unit %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13)",
             "Source"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %dbg_src %main_linkage_name %u32_3 %u32_13)",
+            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %dbg_src %main_name %u32_3 %u32_13)",
             "Parent"),
         std::make_pair(
             R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %void %u32_3 %u32_13)",
             "Linkage Name"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3 %u32_13 %dbg_src)",
+            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13 %dbg_src)",
             "Declaration"),
     }));
 
@@ -3277,13 +3077,9 @@ TEST_P(ValidateVulkan100DebugInfoDebugFunctionDeclaration, Fail) {
 };
 main() {}
 "
-%main_name = OpString "main"
-%main_linkage_name = OpString "v4f_main_f"
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_12 = OpConstant %u32 12
 %u32_13 = OpConstant %u32 13
 )";
@@ -3315,16 +3111,16 @@ INSTANTIATE_TEST_SUITE_P(
     ValidateVulkan100DebugInfoDebugFunctionDeclaration,
     ::testing::ValuesIn(std::vector<std::pair<std::string, std::string>>{
         std::make_pair(
-            R"(%u32_0 %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3)",
+            R"(%u32_0 %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3)",
             "Name"),
         std::make_pair(
-            R"(%main_name %dbg_src %dbg_src %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3)",
+            R"(%main_name %dbg_src %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3)",
             "Type"),
         std::make_pair(
-            R"(%main_name %main_type_info %comp_unit %u32_12 %u32_1 %comp_unit %main_linkage_name %u32_3)",
+            R"(%main_name %main_type_info %comp_unit %u32_12 %u32_1 %comp_unit %main_name %u32_3)",
             "Source"),
         std::make_pair(
-            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %dbg_src %main_linkage_name %u32_3)",
+            R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %dbg_src %main_name %u32_3)",
             "Parent"),
         std::make_pair(
             R"(%main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %void %u32_3)",
@@ -3335,7 +3131,6 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugLexicalBlock) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
 )";
 
   const std::string dbg_inst_header = R"(
@@ -3356,7 +3151,6 @@ TEST_P(ValidateOpenCL100DebugInfoDebugLexicalBlock, Fail) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
 )";
 
   const auto& param = GetParam();
@@ -3441,12 +3235,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLexicalBlock) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 )";
 
   const std::string dbg_inst_header = R"(
@@ -3460,8 +3248,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3469,12 +3257,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugLexicalBlock, Fail) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
-%main_name = OpString "main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 )";
 
   const auto& param = GetParam();
@@ -3491,8 +3273,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
+                                                     extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3514,11 +3296,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailScope) {
 %code = OpString "void main() {}"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -3534,7 +3311,7 @@ OpExtension "SPV_KHR_non_semantic_info"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -3543,11 +3320,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailInlinedAt) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 )";
 
   const std::string dbg_inst_header = R"(
@@ -3565,7 +3337,7 @@ OpExtension "SPV_KHR_non_semantic_info"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined At"));
 }
@@ -3657,10 +3429,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLocalVariable) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -3689,10 +3458,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugLocalVariable, Fail) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const auto& param = GetParam();
@@ -3887,10 +3653,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugDeclare) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -3994,10 +3757,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugDeclare, Fail) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4189,7 +3949,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
 )";
 
   const std::string size_const = R"(
@@ -4226,7 +3985,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
 )";
 
   const std::string size_const = R"(
@@ -4264,7 +4022,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
 )";
 
   const std::string size_const = R"(
@@ -4308,12 +4065,6 @@ main() {}
 %t_name = OpString "T"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_none = OpExtInst %void %DbgExt DebugInfoNone
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
@@ -4329,8 +4080,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4344,12 +4095,6 @@ main() {}
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4368,8 +4113,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4382,13 +4127,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4407,8 +4145,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4421,13 +4159,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4444,8 +4175,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Target must be DebugTypeComposite or "
@@ -4461,13 +4192,6 @@ main() {}
 %float_name = OpString "float"
 %ty_name = OpString "Texture"
 %t_name = OpString "T"
-%main_name = OpString "main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4485,8 +4209,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -4674,12 +4398,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariable) {
 %foo_name = OpString "foo"
 )";
 
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
-)";
-
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
@@ -4692,8 +4410,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4703,12 +4421,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableStaticMember) {
 %code = OpString "float foo; void main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4725,8 +4437,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4736,12 +4448,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableDebugInfoNone) {
 %code = OpString "float foo; void main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4757,8 +4463,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4768,12 +4474,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableConst) {
 %code = OpString "float foo; void main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4788,8 +4488,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
+                                                     "", extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4799,12 +4499,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugGlobalVariable, Fail) {
 %code = OpString "float foo; void main() {}"
 %float_name = OpString "float"
 %foo_name = OpString "foo"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const auto& param = GetParam();
@@ -4822,8 +4516,8 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
+                                                     extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4857,15 +4551,13 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAt) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %main
 %inlined_at = OpExtInst %void %DbgExt DebugInlinedAt 0 %main_info
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt 0 %main_info %inlined_at
 )";
@@ -4888,15 +4580,13 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAtFail) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %main
 %inlined_at = OpExtInst %void %DbgExt DebugInlinedAt 0 %main_info
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt 0 %inlined_at
 )";
@@ -4920,15 +4610,13 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAtFail2) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
 )";
 
   const std::string dbg_inst_header = R"(
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void
-%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_linkage_name FlagIsPublic 1 %main
+%main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 1 1 %comp_unit %main_name FlagIsPublic 1 %main
 %inlined_at = OpExtInst %void %DbgExt DebugInlinedAt 0 %main_info
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt 0 %main_info %main_info
 )";
@@ -4952,14 +4640,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAt) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -4981,7 +4661,7 @@ OpExtension "SPV_KHR_non_semantic_info"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4990,14 +4670,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -5019,7 +4691,7 @@ OpExtension "SPV_KHR_non_semantic_info"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -5029,14 +4701,6 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail2) {
 %src = OpString "simple.hlsl"
 %code = OpString "void main() {}"
 %void_name = OpString "void"
-%main_name = OpString "main"
-%main_linkage_name = OpString "v_main"
-)";
-
-  const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -5058,7 +4722,7 @@ OpExtension "SPV_KHR_non_semantic_info"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined"));
 }
@@ -5192,10 +4856,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValue) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -5232,10 +4893,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValueWithVariableIndex) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(
@@ -5272,10 +4930,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugValue, Fail) {
 )";
 
   const std::string constants = R"(
-%u32_4 = OpConstant %u32 4
-%u32_5 = OpConstant %u32 5
 %u32_10 = OpConstant %u32 10
-%u32_32 = OpConstant %u32 32
 )";
 
   const std::string dbg_inst_header = R"(

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -84,6 +84,15 @@ using ValidateVulkan100DebugInfoDebugValue =
     spvtest::ValidateBase<std::pair<std::string, std::string>>;
 using ValidateVulkan100DebugInfo = spvtest::ValidateBase<std::string>;
 
+const static std::string shader_extension = R"(
+OpExtension "SPV_KHR_non_semantic_info"
+%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+)";
+
+const static std::string opencl_extension = R"(
+%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
+)";
+
 std::string GenerateShaderCodeForDebugInfo(
     const std::string& op_string_instructions,
     const std::string& op_const_instructions,
@@ -312,12 +321,8 @@ TEST_F(ValidateOpenCL100DebugInfo, UseDebugInstructionOutOfFunction) {
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -331,12 +336,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugSourceInFunction) {
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", "", dbg_inst,
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", "", dbg_inst, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -356,13 +357,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceInFunction) {
 %dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", "", dbg_inst,
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", "", dbg_inst, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -396,12 +392,8 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, OpenCLDebugInfo100DebugScope) {
 %foo_val = OpLoad %u32 %foo
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header + GetParam(), body, extension, "Vertex"));
+      src, "", dbg_inst_header + GetParam(), body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugScope, DebugNoScope, DebugDeclare, DebugValue "
@@ -434,13 +426,8 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, VulkanDebugInfo100DebugScope) {
 %foo_val = OpLoad %u32 %foo
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header + GetParam(), body, extension, "Vertex"));
+      src, "", dbg_inst_header + GetParam(), body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugScope, DebugNoScope, DebugDeclare, DebugValue "
@@ -473,12 +460,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionForwardReference) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -501,12 +484,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugFunctionMissingOpFunction) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -539,12 +518,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugScopeBeforeOpVariableInFunction) {
 %foo = OpVariable %f32_ptr_function Function
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, body, extension, "Vertex"));
+      src, size_const, dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -564,12 +539,8 @@ main() {}
 %opaque = OpExtInst %void %DbgExt DebugTypeComposite %ty_name Class %dbg_src 1 1 %comp_unit %ty_name %dbg_none FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -604,12 +575,8 @@ main() {}
 %VS_OUTPUT_color_info = OpExtInst %void %DbgExt DebugTypeMember %VS_OUTPUT_color_name %v4float_info %dbg_src 3 3 %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -643,12 +610,8 @@ main() {}
 %VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember %VS_OUTPUT_pos_name %v4float_info %dbg_src 2 3 %VS_OUTPUT_info %u32_0 %int_128 FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("forward referenced IDs have not been defined"));
@@ -742,12 +705,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugCompilationUnit) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -762,12 +721,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugCompilationUnitFail) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %src HLSL
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Source must be a result id of "
@@ -785,13 +740,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugCompilationUnitFail) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %src %u32_5
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst, "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Source must be a result id of "
@@ -819,12 +769,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeBasicFailName) {
 %float_info = OpExtInst %void %DbgExt DebugTypeBasic %int_32 %int_32 Float
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Name must be a result id of "
@@ -848,13 +794,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailName) {
 %float_info = OpExtInst %void %DbgExt DebugTypeBasic %u32_32 %u32_32 %u32_3 %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Name must be a result id of "
@@ -882,12 +823,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeBasicFailSize) {
 %float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %float_name Float
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Size must be a result id of "
@@ -915,13 +852,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailSize) {
 %float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_3 %u32_3 %f32_32
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Flags must be a result id of 32-bit "
@@ -950,12 +882,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypePointer) {
 %pfloat_info = OpExtInst %void %DbgExt DebugTypePointer %float_info Function FlagIsLocal
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -981,12 +909,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypePointerFail) {
 %pfloat_info = OpExtInst %void %DbgExt DebugTypePointer %dbg_src Function FlagIsLocal
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -1015,12 +939,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifier) {
 %cfloat_info = OpExtInst %void %DbgExt DebugTypeQualifier %float_info ConstType
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1046,12 +966,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeQualifierFail) {
 %cfloat_info = OpExtInst %void %DbgExt DebugTypeQualifier %comp_unit ConstType
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -1075,13 +991,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifier) {
 %cfloat_info = OpExtInst %void %DbgExt DebugTypeQualifier %float_info %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1103,13 +1014,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifierFail) {
 %cfloat_info = OpExtInst %void %DbgExt DebugTypeQualifier %comp_unit %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -1134,12 +1040,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArray) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %int_32
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1167,12 +1069,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayWithVariableSize) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %foo_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1194,12 +1092,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailBaseType) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %comp_unit %int_32
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type is not a valid debug "
@@ -1224,12 +1118,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailComponentCount) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %float_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1256,12 +1146,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailComponentCountFloat) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %f32_4
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1288,12 +1174,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailComponentCountZero) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %u32_0
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1324,12 +1206,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeArrayFailVariableSizeTypeFloat) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %foo_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1352,13 +1230,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArray) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %u32_32
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1386,13 +1259,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayWithVariableSize) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %foo_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1410,13 +1278,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailBaseType) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %comp_unit %u32_32
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type is not a valid debug "
@@ -1437,13 +1300,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCount) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %float_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1466,13 +1324,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCountFloat) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %f32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1495,13 +1348,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayComponentCountZero) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1527,13 +1375,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailVariableSizeTypeFloat) {
 %float_arr_info = OpExtInst %void %DbgExt DebugTypeArray %float_info %foo_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be OpConstant with a 32- or "
@@ -1560,12 +1403,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVector) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %float_info 4
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1587,12 +1426,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFail) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src 4
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1617,12 +1452,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFailComponentZero) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src 0
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1647,12 +1478,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeVectorFailComponentFive) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src 5
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1673,13 +1500,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVector) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %float_info %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1697,13 +1519,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFail) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %dbg_src %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1724,13 +1541,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentZero) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %float_info %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1751,13 +1563,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentFive) {
 %vfloat_info = OpExtInst %void %DbgExt DebugTypeVector %float_info %u32_5
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1783,13 +1590,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrix) {
 %mfloat_info = OpExtInst %void %DbgExt DebugTypeMatrix %vfloat_info %u32_4 %true
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1812,13 +1614,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorTypeType) {
 %mfloat_info = OpExtInst %void %DbgExt DebugTypeMatrix %dbg_src %u32_4 %true
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Vector Type must be a result id of "
@@ -1844,13 +1641,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountType) {
 %mfloat_info = OpExtInst %void %DbgExt DebugTypeMatrix %vfloat_info %dbg_src %true
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Vector Count must be a result id of "
@@ -1876,13 +1668,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountZero) {
 %mfloat_info = OpExtInst %void %DbgExt DebugTypeMatrix %vfloat_info %u32_0 %true
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Vector Count must be positive "
@@ -1908,13 +1695,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountFive) {
 %mfloat_info = OpExtInst %void %DbgExt DebugTypeMatrix %vfloat_info %u32_5 %true
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Vector Count must be positive "
@@ -1940,12 +1722,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypedef) {
 %foo_info = OpExtInst %void %DbgExt DebugTypedef %foo_name %float_info %dbg_src 1 1 %comp_unit
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1971,12 +1749,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugTypedef, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugTypedef )";
   ss << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second +
@@ -2011,13 +1785,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypedef) {
 %foo_info = OpExtInst %void %DbgExt DebugTypedef %foo_name %float_info %dbg_src %u32_1 %u32_1 %comp_unit
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2039,13 +1808,8 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypedef, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugTypedef )";
   ss << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second +
@@ -2090,12 +1854,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunction) {
 %main_type_info4 = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %void %float_info %float_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2117,12 +1877,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunctionFailReturn) {
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %dbg_src %float_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2147,12 +1903,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeFunctionFailParam) {
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction FlagIsPublic %float_info %void
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2176,13 +1928,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionAndParams) {
 %main_type_info4 = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %void %float_info %float_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2200,13 +1947,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailReturn) {
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %dbg_src %float_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2227,13 +1969,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailParam) {
 %main_type_info = OpExtInst %void %DbgExt DebugTypeFunction %u32_3 %float_info %void
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2262,12 +1999,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugTypeEnum) {
 %foo_info3 = OpExtInst %void %DbgExt DebugTypeEnum %foo_name %none %dbg_src 1 1 %comp_unit %int_32 FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2293,12 +2026,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugTypeEnum, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugTypeEnum )";
   ss << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2351,13 +2080,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeEnum) {
 %foo_info3 = OpExtInst %void %DbgExt DebugTypeEnum %foo_name %none %dbg_src %u32_1 %u32_1 %comp_unit %u32_32 %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2379,13 +2103,8 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypeEnum, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugTypeEnum )";
   ss << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2455,12 +2174,8 @@ main() {}
 %child = OpExtInst %void %DbgExt DebugTypeInheritance %foo_info %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2504,12 +2219,8 @@ main() {}
 %child = OpExtInst %void %DbgExt DebugTypeInheritance %foo_info %VS_OUTPUT_info %int_128 %int_128 FlagIsPublic
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second + " must be "));
@@ -2573,12 +2284,8 @@ main() {}
 %VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember )";
   ss << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   if (!param.second.empty()) {
     EXPECT_THAT(getDiagnosticString(),
@@ -2632,12 +2339,8 @@ struct foo : VS_OUTPUT {};
 %child = OpExtInst %void %DbgExt DebugTypeInheritance )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2692,13 +2395,8 @@ main() {}
 %foo_info = OpExtInst %void %DbgExt DebugTypeComposite %foo_name %u32_1 %dbg_src %u32_1 %u32_1 %comp_unit %foo_name %u32_0 %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2735,13 +2433,8 @@ main() {}
 %VS_OUTPUT_info = OpExtInst %void %DbgExt DebugTypeComposite )";
   ss << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second + " must be "));
@@ -2801,13 +2494,8 @@ main() {}
 %VS_OUTPUT_pos_info = OpExtInst %void %DbgExt DebugTypeMember )";
   ss << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   if (!param.second.empty()) {
     EXPECT_THAT(getDiagnosticString(),
@@ -2856,12 +2544,8 @@ main() {}
 %main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic
 %main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src 12 1 %comp_unit %main_name FlagIsPublic 13 %main)";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2886,12 +2570,8 @@ main() {}
 %main_info = OpExtInst %void %DbgExt DebugFunction )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2943,12 +2623,8 @@ main() {}
 %main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2998,13 +2674,8 @@ main() {}
 %main_info = OpExtInst %void %DbgExt DebugFunction %main_name %main_type_info %dbg_src %u32_12 %u32_1 %comp_unit %main_name %u32_3 %u32_13
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3034,13 +2705,8 @@ main() {}
 %main_info = OpExtInst %void %DbgExt DebugFunction )"
      << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3094,13 +2760,8 @@ main() {}
 %main_decl = OpExtInst %void %DbgExt DebugFunctionDeclaration )"
      << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3138,12 +2799,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugLexicalBlock) {
 %comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit 2 4 %dbg_src HLSL
 %main_block = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src 1 1 %comp_unit %main_name)";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3162,12 +2819,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugLexicalBlock, Fail) {
 %main_block = OpExtInst %void %DbgExt DebugLexicalBlock )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3196,12 +2849,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugScopeFailScope) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %dbg_src
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -3221,12 +2870,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugScopeFailInlinedAt) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %comp_unit %dbg_src
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined At"));
 }
@@ -3243,13 +2888,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLexicalBlock) {
 %main_block = OpExtInst %void %DbgExt DebugLexicalBlock %dbg_src %u32_1 %u32_1 %comp_unit %main_name
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3268,13 +2908,8 @@ TEST_P(ValidateVulkan100DebugInfoDebugLexicalBlock, Fail) {
 %main_block = OpExtInst %void %DbgExt DebugLexicalBlock )"
      << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3305,13 +2940,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailScope) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %dbg_src
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -3331,13 +2961,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailInlinedAt) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %comp_unit %dbg_src
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined At"));
 }
@@ -3361,12 +2986,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugLocalVariable) {
 %foo = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src 1 10 %comp_unit FlagIsLocal 0
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3392,12 +3013,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugLocalVariable, Fail) {
 %foo = OpExtInst %void %DbgExt DebugLocalVariable )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3439,13 +3056,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLocalVariable) {
 %foo = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src %u32_1 %u32_10 %comp_unit %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3471,13 +3083,8 @@ TEST_P(ValidateVulkan100DebugInfoDebugLocalVariable, Fail) {
 %foo = OpExtInst %void %DbgExt DebugLocalVariable )"
      << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, constants, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3525,12 +3132,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugDeclare) {
 %decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, body, extension, "Vertex"));
+      src, size_const, dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3625,12 +3228,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugDeclare, Fail) {
 %decl = OpExtInst %void %DbgExt DebugDeclare )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, ss.str(), extension, "Vertex"));
+      src, size_const, dbg_inst_header, ss.str(), opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3664,18 +3263,13 @@ TEST_F(ValidateVulkan100DebugInfo, DebugDeclare) {
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src %u32_1 %u32_10 %comp_unit %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %foo = OpVariable %f32_ptr_function Function
 %decl = OpExtInst %void %DbgExt DebugDeclare %foo_info %foo %null_expr
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3768,11 +3362,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugDeclare, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %float_info %dbg_src %u32_1 %u32_10 %comp_unit %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const auto& param = GetParam();
 
   std::ostringstream ss;
@@ -3782,7 +3371,7 @@ OpExtension "SPV_KHR_non_semantic_info"
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, ss.str(), extension, "Vertex"));
+      src, constants, dbg_inst_header, ss.str(), shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3803,12 +3392,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugExpression) {
 %null_expr = OpExtInst %void %DbgExt DebugExpression %op0 %op1
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo("", "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      "", "", dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3818,12 +3403,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugExpressionFail) {
 %null_expr = OpExtInst %void %DbgExt DebugExpression %op %void
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo("", "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      "", "", dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -3838,13 +3419,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugExpression) {
 %null_expr = OpExtInst %void %DbgExt DebugExpression %op0 %op1
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo("", "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      "", "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3854,13 +3430,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugExpressionFail) {
 %null_expr = OpExtInst %void %DbgExt DebugExpression %op %void
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo("", "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      "", "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -3894,12 +3465,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %opaque %param
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3931,12 +3498,8 @@ main() {}
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %temp %dbg_src 0 0 %comp_unit %foo_name %f32_input FlagIsProtected|FlagIsPrivate
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3967,12 +3530,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %main_info %param
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4001,12 +3560,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %float_info %param
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Target must be DebugTypeComposite or "
@@ -4040,12 +3595,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %main_info %float_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -4075,13 +3626,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %opaque %param
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4108,13 +3654,8 @@ main() {}
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %temp %dbg_src %u32_0 %u32_0 %comp_unit %foo_name %f32_input %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4140,13 +3681,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %main_info %param
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4170,13 +3706,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %float_info %param
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Target must be DebugTypeComposite or "
@@ -4204,13 +3735,8 @@ main() {}
 %temp = OpExtInst %void %DbgExt DebugTypeTemplate %opaque %float_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -4238,12 +3764,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugGlobalVariable) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src 0 0 %comp_unit %foo_name %f32_input FlagIsProtected|FlagIsPrivate
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4268,12 +3790,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugGlobalVariableStaticMember) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src 0 0 %comp_unit %foo_name %f32_input FlagIsProtected|FlagIsPrivate %a
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4297,12 +3815,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugGlobalVariableDebugInfoNone) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src 0 0 %comp_unit %foo_name %dbgNone FlagIsProtected|FlagIsPrivate
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4325,12 +3839,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugGlobalVariableConst) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src 0 0 %comp_unit %foo_name %int_32 FlagIsProtected|FlagIsPrivate
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, "", extension, "Vertex"));
+      src, size_const, dbg_inst_header, "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4356,12 +3866,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugGlobalVariable, Fail) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, size_const, ss.str(),
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, size_const, ss.str(), "", opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4405,13 +3911,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariable) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src %u32_0 %u32_0 %comp_unit %foo_name %f32_input %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4432,13 +3933,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableStaticMember) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %t %dbg_src %u32_0 %u32_0 %comp_unit %foo_name %f32_input %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4458,13 +3954,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableDebugInfoNone) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src %u32_0 %u32_0 %comp_unit %foo_name %dbgNone %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4483,13 +3974,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableConst) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable %foo_name %float_info %dbg_src %u32_0 %u32_0 %comp_unit %foo_name %u32_32 %u32_3
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header,
-                                                     "", extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4511,13 +3997,8 @@ TEST_P(ValidateVulkan100DebugInfoDebugGlobalVariable, Fail) {
 %foo = OpExtInst %void %DbgExt DebugGlobalVariable )"
      << param.first;
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(src, "", ss.str(), "",
-                                                     extension, "Vertex"));
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", ss.str(), "", shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4566,12 +4047,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAt) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4595,12 +4072,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAtFail) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -4625,12 +4098,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugInlinedAtFail2) {
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined"));
 }
@@ -4651,17 +4120,12 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAt) {
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt %u32_0 %main_info %inlined_at
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4681,17 +4145,12 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail) {
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt %u32_0 %inlined_at %inlined_at
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -4712,17 +4171,12 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail2) {
 %inlined_at_recursive = OpExtInst %void %DbgExt DebugInlinedAt %u32_0 %main_info %main_info
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %main_scope = OpExtInst %void %DbgExt DebugScope %main_info %inlined_at
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined"));
 }
@@ -4753,12 +4207,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugValue) {
 %value = OpExtInst %void %DbgExt DebugValue %foo_info %int_32 %null_expr %int_3
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, body, extension, "Vertex"));
+      src, size_const, dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4792,12 +4242,8 @@ TEST_F(ValidateOpenCL100DebugInfo, DebugValueWithVariableIndex) {
 %value = OpExtInst %void %DbgExt DebugValue %foo_info %int_32 %null_expr %len_info
 )";
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, body, extension, "Vertex"));
+      src, size_const, dbg_inst_header, body, opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4828,12 +4274,8 @@ TEST_P(ValidateOpenCL100DebugInfoDebugValue, Fail) {
 %decl = OpExtInst %void %DbgExt DebugValue )"
      << param.first;
 
-  const std::string extension = R"(
-%DbgExt = OpExtInstImport "OpenCL.DebugInfo.100"
-)";
-
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, size_const, dbg_inst_header, ss.str(), extension, "Vertex"));
+      src, size_const, dbg_inst_header, ss.str(), opencl_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4868,17 +4310,12 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValue) {
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %v4float_info %dbg_src %u32_1 %u32_10 %comp_unit %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %value = OpExtInst %void %DbgExt DebugValue %foo_info %u32_32 %null_expr %u32_3
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4907,17 +4344,12 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValueWithVariableIndex) {
 %len_info = OpExtInst %void %DbgExt DebugLocalVariable %len_name %int_info %dbg_src %u32_0 %u32_0 %comp_unit %u32_4
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const std::string body = R"(
 %value = OpExtInst %void %DbgExt DebugValue %foo_info %u32_32 %null_expr %len_info
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4942,11 +4374,6 @@ TEST_P(ValidateVulkan100DebugInfoDebugValue, Fail) {
 %foo_info = OpExtInst %void %DbgExt DebugLocalVariable %foo_name %v4float_info %dbg_src %u32_1 %u32_10 %comp_unit %u32_4 %u32_0
 )";
 
-  const std::string extension = R"(
-OpExtension "SPV_KHR_non_semantic_info"
-%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
-)";
-
   const auto& param = GetParam();
 
   std::ostringstream ss;
@@ -4955,7 +4382,7 @@ OpExtension "SPV_KHR_non_semantic_info"
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, ss.str(), extension, "Vertex"));
+      src, constants, dbg_inst_header, ss.str(), shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));


### PR DESCRIPTION
Adds missing coverage for NonSemantic.Shader.DebugInfo.100 where it was different from `OpenCL.DebugInfo.100`

(Created 2 commits prior to reduce the copy-and-pasting in the tests)