### PR TITLE
ci: Update MacOS to latest OS

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-          os: [ macos-12, macos-13 ]
+          os: [ macos-latest ]
     steps:
         - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         - uses: lukka/get-cmake@b516803a3c5fac40e2e922349d15cdebdba01e60 # v3.30.5


### PR DESCRIPTION
> The macOS 12 runner image will be removed by December 3rd, 2024.
> ...
> Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest.