### PR TITLE
Update proto JSON options call.

### DIFF
--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -145,7 +145,7 @@ void DumpTransformationsJson(
     const protobufs::TransformationSequence& transformations,
     const char* filename) {
   std::string json_string;
-  auto json_options = google::protobuf::util::JsonOptions();
+  auto json_options = google::protobuf::util::JsonPrintOptions();
   json_options.add_whitespace = true;
   auto json_generation_status = google::protobuf::util::MessageToJsonString(
       transformations, &json_string, json_options);

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -673,7 +673,7 @@ void DumpTransformationsJson(
     const spvtools::fuzz::protobufs::TransformationSequence& transformations,
     const char* filename) {
   std::string json_string;
-  auto json_options = google::protobuf::util::JsonOptions();
+  auto json_options = google::protobuf::util::JsonPrintOptions();
   json_options.add_whitespace = true;
   auto json_generation_status = google::protobuf::util::MessageToJsonString(
       transformations, &json_string, json_options);
@@ -801,7 +801,7 @@ int main(int argc, const char** argv) {
     }
 
     std::string json_string;
-    auto json_options = google::protobuf::util::JsonOptions();
+    auto json_options = google::protobuf::util::JsonPrintOptions();
     json_options.add_whitespace = true;
     auto json_generation_status = google::protobuf::util::MessageToJsonString(
         transformations_applied, &json_string, json_options);


### PR DESCRIPTION
This CL updates the usage of JsonOptions which is deprecated to the newer JsonPrintOptions.