### PR TITLE
ci: Make MacOS builds only run if other things pass

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -13,9 +13,32 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, windows-2019]
 
     runs-on: ${{matrix.os}}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: '0'
+      - name: Download dependencies
+        run: python3 utils/git-sync-deps
+      - name: Mount Bazel cache
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        with:
+          path: ~/.bazel/cache
+          key: bazel-cache-${{ runner.os }}
+      - name: Build All
+        run: bazel --output_user_root=~/.bazel/cache build //...
+      - name: Test All
+        run: bazel --output_user_root=~/.bazel/cache test //...
+
+  # iOS is 10x expensive to run on GitHub machines, so only run if we know something else passed
+  # The steps are unfortunately duplicated because github actions requires 2 jobs for a dependency
+  build-macos:
+    needs: build
+    timeout-minutes: 120
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -2,14 +2,17 @@ name: iOS
 permissions:
   contents: read
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_run:
+    # iOS is 10x expensive to run on GitHub machines, so only run if we know something else passed
+    workflows: ["Wasm Build"]
+    types:
+      - completed
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-        matrix:
-          os: [ macos-latest ]
+    runs-on: macos-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         - uses: lukka/get-cmake@b516803a3c5fac40e2e922349d15cdebdba01e60 # v3.30.5


### PR DESCRIPTION
Recently we have found productivty slow down in other KhronosGroups repos because it can take hours for CI to run due to running out of Github Actions minutes. We have found that MacOS/iOS are charged as 10x the minute cost which really starts to add up. The goal is to not have those expensive CI actions run unless we know other things work first.

(There is an internal issue on this, but for short term, I have just been apply these types of YAML chanegs aroudn the repos https://gitlab.khronos.org/khronos-general/khronos-issues/-/issues/127)