### PR TITLE
spirv-val: Accept valid OpSizeOf instructions

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -163,6 +163,7 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
               !spvOpcodeGeneratesType(opcode) && !spvOpcodeIsDebug(opcode) &&
               !inst->IsDebugInfo() && !inst->IsNonSemantic() &&
               !spvOpcodeIsDecoration(opcode) && opcode != spv::Op::OpFunction &&
+              opcode != spv::Op::OpSizeOf &&
               opcode != spv::Op::OpCooperativeMatrixLengthNV &&
               opcode != spv::Op::OpCooperativeMatrixLengthKHR &&
               !spvOpcodeGeneratesUntypedPointer(opcode) &&
@@ -185,6 +186,7 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
                      opcode != spv::Op::OpSelectionMerge &&
                      opcode != spv::Op::OpLoopMerge &&
                      opcode != spv::Op::OpFunction &&
+                     opcode != spv::Op::OpSizeOf &&
                      opcode != spv::Op::OpCooperativeMatrixLengthNV &&
                      opcode != spv::Op::OpCooperativeMatrixLengthKHR &&
                      !spvOpcodeGeneratesUntypedPointer(opcode) &&

--- a/test/val/val_misc_test.cpp
+++ b/test/val/val_misc_test.cpp
@@ -84,6 +84,27 @@ OpMemoryModel Logical GLSL450
       HasSubstr("Cannot create undefined values with 8- or 16-bit types"));
 }
 
+TEST_F(ValidateMisc, SizeOfValid) {
+  const std::string spirv = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %f "f"
+       %void = OpTypeVoid
+        %i32 = OpTypeInt 32 0
+        %ptr = OpTypePointer CrossWorkgroup %i32
+       %fnTy = OpTypeFunction %void
+          %f = OpFunction %void None %fnTy
+      %entry = OpLabel
+          %s = OpSizeOf %i32 %ptr
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_1);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_1));
+}
+
 const std::string ShaderClockSpirv = R"(
 OpCapability Shader
 OpCapability Int64


### PR DESCRIPTION
Ensure valid `OpSizeOf` instructions are not rejected by spirv-val. Until now, validation of a valid `OpSizeOf` instruction would fail with the message that the operand "cannot be a type".