### PR TITLE
opt: keep all OpSource instructions

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -676,6 +676,7 @@ void AggressiveDCEPass::InitializeModuleScopeLiveInstructions() {
     auto op = dbg.GetShader100DebugOpcode();
     if (op == NonSemanticShaderDebugInfo100DebugCompilationUnit ||
         op == NonSemanticShaderDebugInfo100DebugEntryPoint ||
+        op == NonSemanticShaderDebugInfo100DebugSource ||
         op == NonSemanticShaderDebugInfo100DebugSourceContinued) {
       AddToWorklist(&dbg);
     }


### PR DESCRIPTION
This PR stops the optimizer from removing OpSource instructions.  If an OpSource contains solely preprocessor instructions, it was being eliminated.  Debuggers cannot recompile shaders unless all OpSource instructions are present.