### PR TITLE
assembler: ensure progress when seeking the version string

### DIFF
--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -230,7 +230,7 @@ bool spvReadEnvironmentFromText(const std::vector<char>& text,
       // If no match, determine whether the header has ended (in which case,
       // assumption has failed.)
       // Skip until the next line.
-      i = j;
+      i += j;
       for (; i < text.size(); ++i) {
         if (text[i] == '\n') break;
       }

--- a/test/target_env_test.cpp
+++ b/test/target_env_test.cpp
@@ -221,6 +221,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"     \t ; Version: 1.1", true, SPV_ENV_UNIVERSAL_1_1},
         // Previous lines
         {"; SPIR-V\n; Version: 1.1", true, SPV_ENV_UNIVERSAL_1_1},
+        {"; -\n; SPIR-V\n; Version: 1.1", true, SPV_ENV_UNIVERSAL_1_1},
 
         // After a non-header line
         {"OpCapability Shader\n; Version: 1.1", false, kSentinelEnv}}));


### PR DESCRIPTION
When trying to parse SPIR-V version from assembly comments, ensure a match against an initial comment doesn't cause the scanner to go back to the beginning of the assembly text.

Fixed: #5909