### PR TITLE
build: Add missing include headers

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stddef.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 #include <vector>

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -18,6 +18,7 @@
 #include <charconv>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/source/val/function.h
+++ b/source/val/function.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
This is to fix build error when we set use_libcxx_modules=true in chromium build.