### PR TITLE
Relax DebugLine validation

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -3208,10 +3208,11 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << ext_inst_name() << ": operand Line End (" << line_end
                    << ") is less than Line Start (" << line_start << ")";
-          } else if (column_end < column_start) {
+          } else if (line_start == line_end && column_end < column_start) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << ext_inst_name() << ": operand Column End (" << column_end
-                   << ") is less than Column Start (" << column_start << ")";
+                   << ") is less than Column Start (" << column_start
+                   << ") when Line Start equals Line End";
           }
           break;
         }

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -5023,10 +5023,28 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineColumnEndSmaller) {
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
       src, "", dbg_inst_header, body, shader_extension, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr(
-          "DebugLine: operand Column End (0) is less than Column Start (1)"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("DebugLine: operand Column End (0) is less than Column "
+                        "Start (1) when Line Start equals Line End"));
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugLineColumnEndSmallerMultiline) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "int main() { }"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+)";
+
+  const std::string body = R"(
+%line1 = OpExtInst %void %DbgExt DebugLine %dbg_src %u32_1 %u32_2 %u32_1 %u32_0
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 }  // namespace


### PR DESCRIPTION
* In NonSemantic.Shader.DebugInfo.100, DebugLine validation should only check column end >= column start if line start == line end

See https://github.com/KhronosGroup/SPIRV-Registry/issues/302

cc @spencer-lunarg 