### PR TITLE
Update downloads badges and matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,20 +440,17 @@ also work, but are not verified.
 SPIRV-Tools is regularly tested with the following compilers:
 
 On Linux
-- GCC version 9.3
+- GCC version 9.4
 - Clang version 10.0
 
 On MacOS
-- AppleClang 11.0
+- AppleClang 15.0
 
 On Windows
-- Visual Studio 2017
 - Visual Studio 2019
 - Visual Studio 2022
 
-Note: Visual Studio 2017 has incomplete c++17 support. We might stop
-testing it soon. Other compilers or later versions may work, but they are not
-tested.
+Note: Other compilers or later versions may work, but they are not tested.
 
 ### CMake options
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -20,14 +20,12 @@ Vulkan SDK.
 
 Download the latest builds of the [main](https://github.com/KhronosGroup/SPIRV-Tools/tree/main) branch.
 
-### Release build
-| Windows | Linux | MacOS |
-| --- | --- | --- |
-| [MSVC 2017](https://storage.googleapis.com/spirv-tools/badges/build_link_windows_vs2017_release.html) | [clang](https://storage.googleapis.com/spirv-tools/badges/build_link_linux_clang_release.html) | [clang](https://storage.googleapis.com/spirv-tools/badges/build_link_macos_clang_release.html) |
-| | [gcc](https://storage.googleapis.com/spirv-tools/badges/build_link_linux_gcc_release.html) | |
+| Platform | Processor | Compiler | Release build | Debug build |
+| --- | --- | --- | --- | --- |
+| Windows | x86-64 | VisualStudio 2019 (MSVC v142) | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_windows_vs2019_release.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_windows_vs2019_release.svg" alt="status of VS 2019 release build"></a> | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_windows_vs2019_debug.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_windows_vs2019_debug.svg" alt="status of VS 2019 debug build"></a> |
+| Linux | x86-64 | GCC 9.4 | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_linux_gcc_release.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_linux_gcc_release.svg" alt="status of Linux GCC build"></a> | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_linux_gcc_debug.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_linux_gcc_debug.svg" alt="status of Linux GCC debug build"></a> |
+| macOS | x86-64 | Clang 15 | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_macos_clang_release.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_macos_clang_release.svg" alt="status of macOS Clang build"></a> | Download: <a href="https://storage.googleapis.com/spirv-tools/badges/build_link_macos_clang_debug.html"> <img src="https://storage.googleapis.com/spirv-tools/badges/build_status_macos_clang_debug.svg" alt="status of macOS Clang build"></a> |
 
-### Debug build
-| Windows | Linux | MacOS |
-| --- | --- | --- |
-| [MSVC 2017](https://storage.googleapis.com/spirv-tools/badges/build_link_windows_vs2017_debug.html) | [clang](https://storage.googleapis.com/spirv-tools/badges/build_link_linux_clang_debug.html) | [clang](https://storage.googleapis.com/spirv-tools/badges/build_link_macos_clang_debug.html) |
-| | [gcc](https://storage.googleapis.com/spirv-tools/badges/build_link_linux_gcc_debug.html) | |
+Note: If you suspect something is wrong with the compiler versions mentioned,
+check the scripts and configurations in the [kokoro](../kokoro) source tree,
+or the results of the checks on the latest commits on the `main` branch.


### PR DESCRIPTION
- Point to MSVC from VS 2019 instead of defunct MSVC from VS 2017
- Rearrange the table and add badges to show build status.
- Update compiler versions in the README.