### PR TITLE
linker: fix LinkOnceODR handling

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -420,6 +420,7 @@ spv_result_t GetImportExportPairs(const MessageConsumer& consumer,
 
   std::vector<LinkageSymbolInfo> imports;
   std::unordered_map<std::string, std::vector<LinkageSymbolInfo>> exports;
+  std::unordered_map<std::string, LinkageSymbolInfo> linkonce;
 
   // Figure out the imports and exports
   for (const auto& decoration : linked_context.annotations()) {
@@ -478,10 +479,24 @@ spv_result_t GetImportExportPairs(const MessageConsumer& consumer,
              << " LinkageAttributes; " << id << " is neither of them.\n";
     }
 
-    if (spv::LinkageType(type) == spv::LinkageType::Import)
+    if (spv::LinkageType(type) == spv::LinkageType::Import) {
       imports.push_back(symbol_info);
-    else if (spv::LinkageType(type) == spv::LinkageType::Export)
+    } else if (spv::LinkageType(type) == spv::LinkageType::Export) {
       exports[symbol_info.name].push_back(symbol_info);
+    } else if (spv::LinkageType(type) == spv::LinkageType::LinkOnceODR) {
+      if (linkonce.find(symbol_info.name) == linkonce.end())
+        linkonce[symbol_info.name] = symbol_info;
+    }
+  }
+
+  for (const auto& possible_export : linkonce) {
+    if (exports.find(possible_export.first) == exports.end())
+      exports[possible_export.first].push_back(possible_export.second);
+    else
+      return DiagnosticStream(position, consumer, "", SPV_ERROR_INVALID_BINARY)
+             << "Combination of Export and LinkOnceODR is not allowed, found "
+                "for \""
+             << possible_export.second.name << "\".";
   }
 
   // Find the import/export pairs


### PR DESCRIPTION
I ran into issue with linker in OpenCl-CTS [tests for LinkOnceODR extension](https://github.com/KhronosGroup/OpenCL-CTS/blob/d99b302f901867fc1e5b196f5f6071c1dd0a10c1/test_conformance/spirv_new/test_linkage.cpp)

It didn't link 2 binaries:
[First](https://github.com/KhronosGroup/OpenCL-CTS/blob/d99b302f901867fc1e5b196f5f6071c1dd0a10c1/test_conformance/spirv_new/spirv_asm/linkage_linkonce_odr_obj.spvasm64#L11)
```
...
OpDecorate %a LinkageAttributes "a" LinkOnceODR
...
```
[Second](https://github.com/KhronosGroup/OpenCL-CTS/blob/d99b302f901867fc1e5b196f5f6071c1dd0a10c1/test_conformance/spirv_new/spirv_asm/linkage_linkonce_odr_noa_main.spvasm64#L16)
```
...
OpDecorate %a LinkageAttributes "a" Import
...
```
Linking failed with error `Unresolved external reference to "a".` so the issue was not exporting the symbol with `linkonce` attribute

I fixed the following:
- if there is combination of `export` and `linkonce`, linking fails
- if all symbols with the same name (one or more) are `linkonce`, one of them is exported

Tests:
- linking variable and function with `linkonce` attribute
- invalid combination of `linkonce` and `export`