### PR TITLE
[OPT] Add SPV_KHR_ray_tracing to allow list

### DIFF
--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -145,7 +145,8 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
                                 "SPV_NV_cooperative_matrix",
                                 "SPV_KHR_cooperative_matrix",
                                 "SPV_KHR_ray_tracing_position_fetch",
-                                "SPV_KHR_fragment_shading_rate"});
+                                "SPV_KHR_fragment_shading_rate",
+                                "SPV_KHR_ray_tracing"});
 }
 bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {
   std::vector<Instruction*> users;

--- a/test/opt/local_single_store_elim_test.cpp
+++ b/test/opt/local_single_store_elim_test.cpp
@@ -24,6 +24,56 @@ namespace {
 
 using LocalSingleStoreElimTest = PassTest<::testing::Test>;
 
+TEST_F(LocalSingleStoreElimTest, DoSomethingWithExtensions) {
+  const std::string capabilities_and_extensions =
+      R"(OpCapability Shader
+OpExtension "SPV_EXT_fragment_shader_interlock"
+OpExtension "SPV_NV_compute_shader_derivatives"
+OpExtension "SPV_KHR_ray_query"
+OpExtension "SPV_NV_shader_subgroup_partitioned"
+OpExtension "SPV_KHR_ray_tracing"
+OpExtension "SPV_EXT_descriptor_indexing"
+)";
+
+  const std::string before = capabilities_and_extensions +
+                             R"(%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %2 "main"
+OpExecutionMode %2 OriginUpperLeft
+OpSource GLSL 140
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0 = OpConstant %float 0
+%2 = OpFunction %void None %4
+%8 = OpLabel
+%9 = OpVariable %_ptr_Function_float Function
+OpStore %9 %float_0
+%10 = OpLoad %float %9
+OpReturn
+OpFunctionEnd
+)";
+  const std::string after = capabilities_and_extensions +
+                            R"(%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %2 "main"
+OpExecutionMode %2 OriginUpperLeft
+OpSource GLSL 140
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0 = OpConstant %float 0
+%2 = OpFunction %void None %4
+%8 = OpLabel
+%9 = OpVariable %_ptr_Function_float Function
+OpStore %9 %float_0
+OpReturn
+OpFunctionEnd
+)";
+  SinglePassRunAndCheck<LocalSingleStoreElimPass>(before, after, true, true);
+}
 TEST_F(LocalSingleStoreElimTest, PositiveAndNegative) {
   // Single store to v is optimized. Multiple store to
   // f is not optimized.


### PR DESCRIPTION
When adding SPV_KHR_ray_tracing to the allow lists, we missed the list
in local-single-store-elim. Adding it now.

https://github.com/microsoft/DirectXShaderCompiler/issues/7063
