### PR TITLE
Add missing include headers

### DIFF
--- a/source/cfa.h
+++ b/source/cfa.h
@@ -15,6 +15,8 @@
 #ifndef SOURCE_CFA_H_
 #define SOURCE_CFA_H_
 
+#include <stddef.h>
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>

--- a/tools/util/flags.cpp
+++ b/tools/util/flags.cpp
@@ -14,6 +14,7 @@
 
 #include "flags.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
This is for C++ modules build in chromium.