### PR TITLE
More explicit layout validation

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -367,15 +367,18 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
   // Struct members start at word 2 of OpTypeStruct instruction.
   for (size_t word_i = 2; word_i < inst->words().size(); ++word_i) {
     auto member = inst->word(word_i);
-    if (_.ContainsType(member, [&_](const Instruction* type_inst) {
-          if (type_inst->opcode() == spv::Op::OpTypeStruct &&
-              (_.HasDecoration(type_inst->id(), spv::Decoration::Block) ||
-               _.HasDecoration(type_inst->id(),
-                               spv::Decoration::BufferBlock))) {
-            return true;
-          }
-          return false;
-        })) {
+    if (_.ContainsType(
+            member,
+            [&_](const Instruction* type_inst) {
+              if (type_inst->opcode() == spv::Op::OpTypeStruct &&
+                  (_.HasDecoration(type_inst->id(), spv::Decoration::Block) ||
+                   _.HasDecoration(type_inst->id(),
+                                   spv::Decoration::BufferBlock))) {
+                return true;
+              }
+              return false;
+            },
+            /* traverse_all_types = */ false)) {
       has_nested_blockOrBufferBlock_struct = true;
       break;
     }

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -215,6 +215,18 @@ spv_result_t ValidateTypeArray(ValidationState_t& _, const Instruction* inst) {
            << " is a void type.";
   }
 
+  if (_.HasCapability(spv::Capability::Shader)) {
+    if (element_type->opcode() == spv::Op::OpTypeStruct &&
+        (_.HasDecoration(element_type->id(), spv::Decoration::Block) ||
+         _.HasDecoration(element_type->id(), spv::Decoration::BufferBlock))) {
+      if (_.HasDecoration(inst->id(), spv::Decoration::ArrayStride)) {
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << "Array containing a Block or BufferBlock must not be "
+                  "decorated with ArrayStride";
+      }
+    }
+  }
+
   if (spvIsVulkanEnv(_.context()->target_env) &&
       element_type->opcode() == spv::Op::OpTypeRuntimeArray) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
@@ -271,6 +283,18 @@ spv_result_t ValidateTypeRuntimeArray(ValidationState_t& _,
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "OpTypeRuntimeArray Element Type <id> " << _.getIdName(element_id)
            << " is a void type.";
+  }
+
+  if (_.HasCapability(spv::Capability::Shader)) {
+    if (element_type->opcode() == spv::Op::OpTypeStruct &&
+        (_.HasDecoration(element_type->id(), spv::Decoration::Block) ||
+         _.HasDecoration(element_type->id(), spv::Decoration::BufferBlock))) {
+      if (_.HasDecoration(inst->id(), spv::Decoration::ArrayStride)) {
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << "Array containing a Block or BufferBlock must not be "
+                  "decorated with ArrayStride";
+      }
+    }
   }
 
   if (spvIsVulkanEnv(_.context()->target_env) &&
@@ -343,13 +367,17 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
   // Struct members start at word 2 of OpTypeStruct instruction.
   for (size_t word_i = 2; word_i < inst->words().size(); ++word_i) {
     auto member = inst->word(word_i);
-    auto memberTypeInstr = _.FindDef(member);
-    if (memberTypeInstr && spv::Op::OpTypeStruct == memberTypeInstr->opcode()) {
-      if (_.HasDecoration(memberTypeInstr->id(), spv::Decoration::Block) ||
-          _.HasDecoration(memberTypeInstr->id(),
-                          spv::Decoration::BufferBlock) ||
-          _.GetHasNestedBlockOrBufferBlockStruct(memberTypeInstr->id()))
-        has_nested_blockOrBufferBlock_struct = true;
+    if (_.ContainsType(member, [&_](const Instruction* type_inst) {
+          if (type_inst->opcode() == spv::Op::OpTypeStruct &&
+              (_.HasDecoration(type_inst->id(), spv::Decoration::Block) ||
+               _.HasDecoration(type_inst->id(),
+                               spv::Decoration::BufferBlock))) {
+            return true;
+          }
+          return false;
+        })) {
+      has_nested_blockOrBufferBlock_struct = true;
+      break;
     }
   }
 

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -3114,7 +3114,6 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
-OpDecorate %array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
 %uint_t = OpTypeInt 32 0
@@ -3360,7 +3359,6 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
 OpDecorate %inner_array_t ArrayStride 4
-OpDecorate %array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
 %uint_t = OpTypeInt 32 0
@@ -3390,7 +3388,6 @@ OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
 OpDecorate %inner_array_t ArrayStride 4
-OpDecorate %array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
 %uint_t = OpTypeInt 32 0


### PR DESCRIPTION
* Strengthen the checks that Block/BufferBlock cannot be nested in another Block/BufferBlock
  * previously missed arrays
* Add check that arrays containing a Block/BufferBlock must not be decorated with array stride

Relevant SPIR-V rules:
> Block and BufferBlock [decorations](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Decoration) must not decorate a structure type that is nested at any level inside another structure type decorated with Block or BufferBlock.

(within the explicit layout rules)
> Each array type must have an ArrayStride [decoration](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Decoration), unless it is an array that contains a structure decorated with Block or BufferBlock, in which case it must not have an ArrayStride decoration.