### PR TITLE
Fix layout checks with untyped pointers

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1476,10 +1476,12 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
       // array which should not have an explicit layout.
       if (data_type->opcode() == spv::Op::OpTypeArray ||
           data_type->opcode() == spv::Op::OpTypeRuntimeArray) {
-        const auto ele_type = vstate.FindDef(data_type->GetOperandAs<uint32_t>(1u));
+        const auto ele_type =
+            vstate.FindDef(data_type->GetOperandAs<uint32_t>(1u));
         if (ele_type->opcode() == spv::Op::OpTypeStruct &&
             (vstate.HasDecoration(ele_type->id(), spv::Decoration::Block) ||
-             vstate.HasDecoration(ele_type->id(), spv::Decoration::BufferBlock))) {
+             vstate.HasDecoration(ele_type->id(),
+                                  spv::Decoration::BufferBlock))) {
           data_type = ele_type;
           data_type_id = ele_type->id();
         }

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1464,11 +1464,27 @@ spv_result_t CheckDecorationsOfBuffers(ValidationState_t& vstate) {
                      : (sc == spv::StorageClass::Workgroup ? "Workgroup"
                                                            : "StorageBuffer"));
 
-      const auto data_type = vstate.FindDef(data_type_id);
+      auto data_type = vstate.FindDef(data_type_id);
       scalar_block_layout =
           sc == spv::StorageClass::Workgroup
               ? vstate.options()->workgroup_scalar_block_layout
               : vstate.options()->scalar_block_layout;
+
+      // If the data type is an array that contains a Block- or
+      // BufferBlock-decorated struct, then use the struct for layout checks
+      // instead of the array. In this case, the array represents a descriptor
+      // array which should not have an explicit layout.
+      if (data_type->opcode() == spv::Op::OpTypeArray ||
+          data_type->opcode() == spv::Op::OpTypeRuntimeArray) {
+        const auto ele_type = vstate.FindDef(data_type->GetOperandAs<uint32_t>(1u));
+        if (ele_type->opcode() == spv::Op::OpTypeStruct &&
+            (vstate.HasDecoration(ele_type->id(), spv::Decoration::Block) ||
+             vstate.HasDecoration(ele_type->id(), spv::Decoration::BufferBlock))) {
+          data_type = ele_type;
+          data_type_id = ele_type->id();
+        }
+      }
+
       // Assume uniform storage class uses block rules unless we see a
       // BufferBlock decorated struct in the data type.
       bool bufferRules = sc == spv::StorageClass::Uniform ? false : true;


### PR DESCRIPTION
* Handle the case where an untyped pointer represents a descriptor array
  * the array should not be required to have an array stride, but the element layout should be checked