### PR TITLE
Improve the instruction diagnostic for some access chain errors

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1608,9 +1608,10 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
         // index: the index must be an OpConstant.
         int64_t cur_index;
         if (!_.EvalConstantValInt64(cur_word, &cur_index)) {
-          return _.diag(SPV_ERROR_INVALID_ID, cur_word_instr)
-                 << "The <id> passed to " << instr_name
-                 << " to index into a "
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << "The <id> passed to " << instr_name << " to index "
+                 << _.getIdName(cur_word)
+                 << " into a "
                     "structure must be an OpConstant.";
         }
 
@@ -1619,10 +1620,10 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
         const int64_t num_struct_members =
             static_cast<int64_t>(type_pointee->words().size() - 2);
         if (cur_index >= num_struct_members || cur_index < 0) {
-          return _.diag(SPV_ERROR_INVALID_ID, cur_word_instr)
-                 << "Index is out of bounds: " << instr_name
-                 << " cannot find index " << cur_index
-                 << " into the structure <id> "
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << "Index " << _.getIdName(cur_word)
+                 << " is out of bounds: " << instr_name << " cannot find index "
+                 << cur_index << " into the structure <id> "
                  << _.getIdName(type_pointee->id()) << ". This structure has "
                  << num_struct_members << " members. Largest valid index is "
                  << num_struct_members - 1 << ".";

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -4320,12 +4320,11 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexNotConstantBad) {
 OpReturn
 OpFunctionEnd
   )";
-  const std::string expected_err =
-      "The <id> passed to " + instr +
-      " to index into a structure must be an OpConstant.";
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr(expected_err));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("The <id> passed to " + instr));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("into a structure must be an OpConstant"));
 }
 
 // Invalid: Indexing up to a vec4 granularity, but result type expected float.
@@ -4379,7 +4378,7 @@ TEST_P(AccessChainInstructionTest, AccessChainStructIndexOutOfBoundBad) {
 OpReturn
 OpFunctionEnd
   )";
-  const std::string expected_err = "Index is out of bounds: " + instr +
+  const std::string expected_err = "is out of bounds: " + instr +
                                    " cannot find index 3 into the structure "
                                    "<id> '25[%_struct_25]'. This structure "
                                    "has 3 members. Largest valid index is 2.";

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -5673,7 +5673,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Index is out of bounds"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("is out of bounds"));
   EXPECT_THAT(getDiagnosticString(), HasSubstr("cannot find index -224"));
 }
 
@@ -5701,7 +5701,7 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("Index is out of bounds"));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("is out of bounds"));
   EXPECT_THAT(getDiagnosticString(), HasSubstr("cannot find index -224"));
 }
 


### PR DESCRIPTION
Fixes #3263

* The checks relating to structure indexing used the index disassembly instead of the access chain making it difficult to determine where the actual error occurred