### PR TITLE
linker: remove LinkOnceODR decorations when linking executables

### DIFF
--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -676,8 +676,10 @@ spv_result_t RemoveLinkageSpecificInstructions(
       if (inst->opcode() == spv::Op::OpDecorate &&
           spv::Decoration(inst->GetSingleWordOperand(1u)) ==
               spv::Decoration::LinkageAttributes &&
-          spv::LinkageType(inst->GetSingleWordOperand(3u)) ==
-              spv::LinkageType::Export) {
+          (spv::LinkageType(inst->GetSingleWordOperand(3u)) ==
+               spv::LinkageType::Export ||
+           spv::LinkageType(inst->GetSingleWordOperand(3u)) ==
+               spv::LinkageType::LinkOnceODR)) {
         linked_context->KillInst(&*inst);
       }
     }

--- a/test/link/linker_fixture.h
+++ b/test/link/linker_fixture.h
@@ -155,6 +155,19 @@ class LinkerTest : public ::testing::Test {
     }
   }
 
+  void Match(const std::string& templateBody,
+             const spvtest::Binary& linked_binary) {
+    std::string result;
+    EXPECT_TRUE(
+        tools_.Disassemble(linked_binary, &result, disassemble_options_))
+        << GetErrorMessage();
+    auto match_res = effcee::Match(result, templateBody);
+    EXPECT_EQ(effcee::Result::Status::Ok, match_res.status())
+        << match_res.message() << "\nExpanded from:\n"
+        << templateBody << "\nChecking result:\n"
+        << result;
+  }
+
   // An alternative to ExpandAndCheck, which uses the |templateBody| as the
   // match pattern for the disassembled linked result.
   void ExpandAndMatch(
@@ -165,15 +178,7 @@ class LinkerTest : public ::testing::Test {
     EXPECT_EQ(SPV_SUCCESS, res) << GetErrorMessage() << "\nExpanded from:\n"
                                 << templateBody;
     if (res == SPV_SUCCESS) {
-      std::string result;
-      EXPECT_TRUE(
-          tools_.Disassemble(linked_binary, &result, disassemble_options_))
-          << GetErrorMessage();
-      auto match_res = effcee::Match(result, templateBody);
-      EXPECT_EQ(effcee::Result::Status::Ok, match_res.status())
-          << match_res.message() << "\nExpanded from:\n"
-          << templateBody << "\nChecking result:\n"
-          << result;
+      Match(templateBody, linked_binary);
     }
   }
 

--- a/test/link/matching_imports_to_exports_test.cpp
+++ b/test/link/matching_imports_to_exports_test.cpp
@@ -928,9 +928,16 @@ OpDecorate %1 LinkageAttributes "foo" Import
 %2 = OpTypeFloat 32
 %1 = OpVariable %2 Uniform
 )";
+
+  const std::string matchTemplate = R"(
+; CHECK-NOT: OpDecorate {{.*}} Import
+; CHECK-NOT: OpDecorate {{.*}} LinkOnceODR
+)";
+
   spvtest::Binary linked_binary;
   EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body2}, &linked_binary))
       << GetErrorMessage();
+  Match(matchTemplate, linked_binary);
 }
 
 TEST_F(MatchingImportsToExports, LinkOnceODRLinkageFunMultiple) {
@@ -961,9 +968,16 @@ OpDecorate %1 LinkageAttributes "foo" Import
 %1 = OpFunction %2 None %3
 OpFunctionEnd
 )";
+
+  const std::string matchTemplate = R"(
+; CHECK-NOT: OpDecorate {{.*}} Import
+; CHECK-NOT: OpDecorate {{.*}} LinkOnceODR
+)";
+
   spvtest::Binary linked_binary;
   EXPECT_EQ(SPV_SUCCESS, AssembleAndLink({body1, body1, body2}, &linked_binary))
       << GetErrorMessage();
+  Match(matchTemplate, linked_binary);
 }
 
 TEST_F(MatchingImportsToExports, LinkOnceODRAndExport) {


### PR DESCRIPTION
Just a small oversight with the original fix of linkonce_odr. spirv-val complains about those decoration existing while the linkage capability is missing. However, simply removing it as we do with other linking specific decoration is easy enough.

Fixes: 17321728 ("fix: handle LinkOnceODR correctly (#5938)")