### PR TITLE
build(deps): automatically pull in dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,30 @@ cmake_minimum_required(VERSION 3.22.1)
 
 project(spirv-tools)
 
+include(FetchContent)
+function(fetch_content content_name)
+    message(STATUS "Fetching  ${content_name}...")
+
+    list(REMOVE_AT ARGV 0)  # remove content_name
+
+    FetchContent_Declare(
+        ${content_name}
+        ${ARGV}
+    )
+
+    FetchContent_MakeAvailable(${content_name})
+endfunction()
+
+# TODO: these should probably be locked to a specific commit?
+fetch_content(
+  SPIRV-Headers
+  GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Headers.git
+  GIT_TAG origin/main
+  OVERRIDE_FIND_PACKAGE
+)
+get_target_property(SPIRV_HEADER_INCLUDE_DIR SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
+
+
 # Avoid a bug in CMake 3.22.1. By default it will set -std=c++11 for
 # targets in test/*, when those tests need -std=c++17.
 # https://github.com/KhronosGroup/SPIRV-Tools/issues/5340
@@ -239,6 +263,7 @@ endif()
 
 # Tests require Python3
 find_host_package(Python3 REQUIRED)
+find_package(SPIRV-Headers CONFIG REQUIRED)
 
 # Check for symbol exports on Linux.
 # At the moment, this check will fail on the OSX build machines for the Android NDK.
@@ -317,7 +342,6 @@ macro(spvtools_pch SRCS PCHPREFIX)
   endif()
 endmacro(spvtools_pch)
 
-add_subdirectory(external)
 
 # Warning about extra semi-colons.
 #
@@ -386,8 +410,8 @@ add_custom_command(
                       -DSPIRV_SHARED_LIBRARIES=${SPIRV_SHARED_LIBRARIES}
                       -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
         DEPENDS "CHANGES" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/SPIRV-Tools-shared.pc.in" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake")
-add_custom_target(spirv-tools-pkg-config 
-        ALL 
+add_custom_target(spirv-tools-pkg-config
+        ALL
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools-shared.pc ${CMAKE_CURRENT_BINARY_DIR}/SPIRV-Tools.pc)
 
 # Install pkg-config file

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -33,61 +33,9 @@ else()
   set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
 endif()
 
-if (IS_DIRECTORY ${SPIRV_HEADER_DIR})
-  # TODO(dneto): We should not be modifying the parent scope.
-  set(SPIRV_HEADER_INCLUDE_DIR ${SPIRV_HEADER_DIR}/include PARENT_SCOPE)
-
-  # Add SPIRV-Headers as a sub-project if it isn't already defined.
-  # Do this so enclosing projects can use SPIRV-Headers_SOURCE_DIR to find
-  # headers to include.
-  if (NOT DEFINED SPIRV-Headers_SOURCE_DIR)
-    add_subdirectory(${SPIRV_HEADER_DIR})
-  endif()
-else()
-  message(FATAL_ERROR
-    "SPIRV-Headers was not found - please checkout a copy at external/spirv-headers.")
-endif()
-
 if (NOT ${SPIRV_SKIP_TESTS})
   # Find gmock if we can. If it's not already configured, then try finding
   # it in external/googletest.
-  if (TARGET gmock)
-    message(STATUS "Google Mock already configured")
-  else()
-    if (NOT GMOCK_DIR)
-      set(GMOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
-    endif()
-    if(EXISTS ${GMOCK_DIR})
-      if(MSVC)
-        # Our tests use ::testing::Combine.  Work around a compiler
-        # detection problem in googletest, where that template is
-        # accidentally disabled for VS 2017.
-        # See https://github.com/google/googletest/issues/1352
-        add_definitions(-DGTEST_HAS_COMBINE=1)
-      endif()
-      if(WIN32)
-        option(gtest_force_shared_crt
-          "Use shared (DLL) run-time lib even when Google Test is built as static lib."
-          ON)
-      endif()
-      # gtest requires special defines for building as a shared
-      # library, simply always build as static.
-      push_variable(BUILD_SHARED_LIBS 0)
-      add_subdirectory(${GMOCK_DIR} ${CMAKE_CURRENT_BINARY_DIR}/googletest EXCLUDE_FROM_ALL)
-      pop_variable(BUILD_SHARED_LIBS)
-    endif()
-  endif()
-  if (TARGET gmock)
-    set(GTEST_TARGETS
-      gtest
-      gtest_main
-      gmock
-      gmock_main
-    )
-    foreach(target ${GTEST_TARGETS})
-      set_property(TARGET ${target} PROPERTY FOLDER GoogleTest)
-    endforeach()
-  endif()
 
   # Find Effcee and RE2, for testing.
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -113,12 +113,10 @@ macro(spvtools_opencl_tables CONFIG_VERSION)
   list(APPEND EXTINST_CPP_DEPENDS ${GRAMMAR_INC_FILE})
 endmacro(spvtools_opencl_tables)
 
+message("HEADER DIR: ${SPIRV_HEADER_INCLUDE_DIR}")
 macro(spvtools_vendor_tables VENDOR_TABLE SHORT_NAME OPERAND_KIND_PREFIX)
   set(INSTS_FILE "${spirv-tools_BINARY_DIR}/${VENDOR_TABLE}.insts.inc")
   set(GRAMMAR_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/unified1/extinst.${VENDOR_TABLE}.grammar.json")
-  if(NOT EXISTS ${GRAMMAR_FILE})
-    set(GRAMMAR_FILE "${spirv-tools_SOURCE_DIR}/source/extinst.${VENDOR_TABLE}.grammar.json")
-  endif()
   add_custom_command(OUTPUT ${INSTS_FILE}
     COMMAND Python3::Interpreter ${GRAMMAR_PROCESSING_SCRIPT}
       --extinst-vendor-grammar=${GRAMMAR_FILE}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,13 +15,49 @@
 if (${SPIRV_SKIP_TESTS})
   return()
 endif()
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+fetch_content(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG origin/main
+  FIND_PACKAGE_ARGS NAMES GTest
+)
+find_package(GTest CONFIG REQUIRED)
 
-if (TARGET gmock_main)
-  message(STATUS "Found Google Mock, building tests.")
-else()
-  message(STATUS "Did not find googletest, tests will not be built. "
-    "To enable tests place googletest in '<spirv-dir>/external/googletest'.")
-endif()
+fetch_content(
+  protobuf
+  GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
+  GIT_TAG origin/main
+  OVERRIDE_FIND_PACKAGE
+)
+
+set(ABSL_ENABLE_INSTALL ON)
+fetch_content(
+  absl
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+  GIT_TAG origin/master
+  OVERRIDE_FIND_PACKAGE
+)
+
+fetch_content(
+  re2
+  GIT_REPOSITORY https://github.com/google/re2.git
+  GIT_TAG origin/main
+  OVERRIDE_FIND_PACKAGE
+)
+
+set(EFFCEE_BUILD_TESTING OFF)
+fetch_content(
+  effcee
+  GIT_REPOSITORY https://github.com/google/effcee.git
+  GIT_TAG origin/main
+  OVERRIDE_FIND_PACKAGE
+)
+
+find_package(re2 CONFIG REQUIRED)
+find_package(effcee CONFIG REQUIRED)
+find_package(protobuf CONFIG REQUIRED)
+
 
 # Add a SPIR-V Tools unit test. Signature:
 #   add_spvtools_unittest(
@@ -60,14 +96,16 @@ function(add_spvtools_unittest)
       target_compile_options(${target} PRIVATE /DGTEST_HAS_COMBINE=1)
     endif()
     target_include_directories(${target} PRIVATE
-      ${SPIRV_HEADER_INCLUDE_DIR}
       ${spirv-tools_SOURCE_DIR}
       ${spirv-tools_SOURCE_DIR}/include
       ${spirv-tools_SOURCE_DIR}/test
       ${spirv-tools_BINARY_DIR}
-      ${gtest_SOURCE_DIR}/include
-      ${gmock_SOURCE_DIR}/include
     )
+    target_link_libraries(${target} PRIVATE
+      SPIRV-Headers
+      googletest
+    )
+
     if (TARGET effcee)
       # If using Effcee for testing, then add its include directory.
       target_include_directories(${target} PRIVATE ${effcee_SOURCE_DIR})


### PR DESCRIPTION
To ease development, this patch pulls in dependencies automatically using
FetchContent[^1]. Test dependencies are only pulled in if tests are enabled.

There' still a few open questions, I opened this PR to see if the direction 
I'm going with is good.

Open questions:

- The path will now be "dynamic" as it depends what is passed to 
  `cmake -B ${BUILD_FOLDER}`. This means that scripts like
  `tools/sva/tools/process_grammar.rb` which has a hard coded path
  will need to account for this. My suggestion is for example to cache
  the SPIRV headers directory and  have the script run something like
  `cmake -LA -N | grep SPIRV_HEADERS_DIR`.

- I'm not familiar with bazel, does the build config there need to be
  adjusted to reflect these changes as well?

[^1]: https://cmake.org/cmake/help/latest/module/FetchContent.html