### PR TITLE
Validation for relaxed control barrier with storage class semantics

### DIFF
--- a/source/val/validate_memory_semantics.cpp
+++ b/source/val/validate_memory_semantics.cpp
@@ -66,8 +66,7 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << spvOpcodeString(opcode)
            << ": Memory Semantics can have at most one of the following "
-              "bits "
-              "set: Acquire, Release, AcquireRelease or "
+              "bits set: Acquire, Release, AcquireRelease or "
               "SequentiallyConsistent";
   }
 
@@ -176,10 +175,8 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << _.VkErrorID(4732) << spvOpcodeString(opcode)
              << ": Vulkan specification requires Memory Semantics to have "
-                "one "
-                "of the following bits set: Acquire, Release, "
-                "AcquireRelease "
-                "or SequentiallyConsistent";
+                "one of the following bits set: Acquire, Release, "
+                "AcquireRelease or SequentiallyConsistent";
     } else if (opcode != spv::Op::OpMemoryBarrier &&
                num_memory_order_set_bits) {
       // should leave only atomics and control barriers for Vulkan env
@@ -203,11 +200,20 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
                 "storage class";
     }
 
-    if (opcode == spv::Op::OpControlBarrier && value && !includes_storage_class) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << _.VkErrorID(4650) << spvOpcodeString(opcode)
-             << ": expected Memory Semantics to include a Vulkan-supported "
-                "storage class if Memory Semantics is not None";
+    if (opcode == spv::Op::OpControlBarrier && value) {
+      if (!num_memory_order_set_bits) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(4649) << spvOpcodeString(opcode)
+               << ": Vulkan specification requires non-zero Memory Semantics "
+                  "to have one of the following bits set: Acquire, Release, "
+                  "AcquireRelease or SequentiallyConsistent";
+      }
+      if (!includes_storage_class) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(4650) << spvOpcodeString(opcode)
+               << ": expected Memory Semantics to include a Vulkan-supported "
+                  "storage class if Memory Semantics is not None";
+      }
     }
   }
 

--- a/source/val/validate_memory_semantics.cpp
+++ b/source/val/validate_memory_semantics.cpp
@@ -203,7 +203,7 @@ spv_result_t ValidateMemorySemantics(ValidationState_t& _,
     if (opcode == spv::Op::OpControlBarrier && value) {
       if (!num_memory_order_set_bits) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << _.VkErrorID(4649) << spvOpcodeString(opcode)
+               << _.VkErrorID(10609) << spvOpcodeString(opcode)
                << ": Vulkan specification requires non-zero Memory Semantics "
                   "to have one of the following bits set: Acquire, Release, "
                   "AcquireRelease or SequentiallyConsistent";

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2311,8 +2311,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-04644);
     case 4645:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04645);
-    case 4649:
-      return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04649);
+    case 10609:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-10609);
     case 4650:
       return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04650);
     case 4651:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2311,6 +2311,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-04644);
     case 4645:
       return VUID_WRAP(VUID-StandaloneSpirv-None-04645);
+    case 4649:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04649);
     case 4650:
       return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04650);
     case 4651:

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -535,7 +535,7 @@ OpControlBarrier %workgroup %workgroup %workgroup_memory
   CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-OpControlBarrier-04649"));
+              AnyVUID("VUID-StandaloneSpirv-OpControlBarrier-10609"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(

--- a/test/val/val_barriers_test.cpp
+++ b/test/val/val_barriers_test.cpp
@@ -511,6 +511,39 @@ OpControlBarrier %workgroup %device %acquire_release_subgroup
           "Vulkan-supported storage class if Memory Semantics is not None"));
 }
 
+TEST_F(ValidateBarriers, OpControlBarrierVulkanAcquireRelease) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %device %acquire_release
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpControlBarrier-04650"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "ControlBarrier: expected Memory Semantics to include a "
+          "Vulkan-supported storage class if Memory Semantics is not None"));
+}
+
+TEST_F(ValidateBarriers, OpControlBarrierVulkanWorkgroupMemory) {
+  const std::string body = R"(
+OpControlBarrier %workgroup %workgroup %workgroup_memory
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body), SPV_ENV_VULKAN_1_0);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpControlBarrier-04649"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "ControlBarrier: Vulkan specification requires non-zero "
+          "Memory Semantics to have one of the following bits set: Acquire, "
+          "Release, AcquireRelease or SequentiallyConsistent"));
+}
+
 TEST_F(ValidateBarriers, OpControlBarrierSubgroupExecutionFragment1p1) {
   const std::string body = R"(
 OpControlBarrier %subgroup %subgroup %acquire_release_workgroup
@@ -687,9 +720,8 @@ OpControlBarrier %subgroup %workgroup %acquire_release_workgroup
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("OpControlBarrier requires one of the following "
-                        "Execution "
-                        "Models: TessellationControl, GLCompute, Kernel, "
-                        "MeshNV or TaskNV"));
+                        "Execution Models: TessellationControl, GLCompute, "
+                        "Kernel, MeshNV or TaskNV"));
 }
 
 TEST_F(ValidateBarriers, OpMemoryBarrierSuccess) {


### PR DESCRIPTION
This commit aligns OpControlBarrier semantics validation with the Vulkan memory model. It disallows combining a relaxed memory order with non-zero storage class semantics in the Vulkan target environment. To my knowledge, this combination is not generated by any compiler.