### PR TITLE
Add missing include headers

### DIFF
--- a/tools/util/flags.cpp
+++ b/tools/util/flags.cpp
@@ -15,6 +15,7 @@
 #include "flags.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
This is for C++ modules build in chromium.