### PR TITLE
spirv-val: Validate PhysicalStorageBuffer Stage Interface

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2523,6 +2523,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpEntryPoint-08722);
     case 8973:
       return VUID_WRAP(VUID-StandaloneSpirv-Pointer-08973);
+    case 9557:
+    return VUID_WRAP(VUID-StandaloneSpirv-Input-09557);
     case 9638:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-09638);
     case 9658:

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -1668,7 +1668,7 @@ TEST_F(ValidateInterfacesTest, InvalidLocationTypePointer) {
               HasSubstr("Invalid type to assign a location"));
 }
 
-TEST_F(ValidateInterfacesTest, ValidLocationTypePhysicalStorageBufferPointer) {
+TEST_F(ValidateInterfacesTest, PhysicalStorageBufferPointer) {
   const std::string text = R"(
 OpCapability Shader
 OpCapability PhysicalStorageBufferAddresses
@@ -1677,10 +1677,10 @@ OpEntryPoint Vertex %main "main" %var
 OpDecorate %var Location 0
 OpDecorate %var RestrictPointer
 %void = OpTypeVoid
-%int = OpTypeInt 32 0
-%ptr = OpTypePointer PhysicalStorageBuffer %int
-%ptr2 = OpTypePointer Input %ptr
-%var = OpVariable %ptr2 Input
+%uint = OpTypeInt 32 0
+%psb_ptr = OpTypePointer PhysicalStorageBuffer %uint
+%in_ptr = OpTypePointer Input %psb_ptr
+%var = OpVariable %in_ptr Input
 %void_fn = OpTypeFunction %void
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
@@ -1688,7 +1688,139 @@ OpReturn
 OpFunctionEnd
 )";
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-09557"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input/Output interface variable id <2> contains a "
+                        "PhysicalStorageBuffer pointer, which is not allowed"));
+}
+
+TEST_F(ValidateInterfacesTest, PhysicalStorageBufferPointerArray) {
+  const std::string text = R"(
+  OpCapability Shader
+  OpCapability PhysicalStorageBufferAddresses
+  OpMemoryModel PhysicalStorageBuffer64 GLSL450
+  OpEntryPoint Vertex %main "main" %var
+  OpDecorate %var Location 0
+  OpDecorate %var RestrictPointer
+  %void = OpTypeVoid
+  %uint = OpTypeInt 32 0
+  %uint_3 = OpConstant %uint 3
+  %psb_ptr = OpTypePointer PhysicalStorageBuffer %uint
+  %array = OpTypeArray %psb_ptr %uint_3
+  %in_ptr = OpTypePointer Input %array
+  %var = OpVariable %in_ptr Input
+  %void_fn = OpTypeFunction %void
+  %main = OpFunction %void None %void_fn
+  %entry = OpLabel
+  OpReturn
+  OpFunctionEnd
+  )";
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-09557"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input/Output interface variable id <2> contains a "
+                        "PhysicalStorageBuffer pointer, which is not allowed"));
+}
+TEST_F(ValidateInterfacesTest, PhysicalStorageBufferPointerStruct) {
+  const std::string text = R"(
+  OpCapability Shader
+  OpCapability PhysicalStorageBufferAddresses
+  OpMemoryModel PhysicalStorageBuffer64 GLSL450
+  OpEntryPoint Vertex %main "main" %var
+  OpDecorate %var Location 0
+  OpDecorate %var RestrictPointer
+  %void = OpTypeVoid
+  %int = OpTypeInt 32 1
+  OpTypeForwardPointer %psb_ptr PhysicalStorageBuffer
+  %struct_0 = OpTypeStruct %int %psb_ptr
+  %struct_1 = OpTypeStruct %int %int
+  %psb_ptr = OpTypePointer PhysicalStorageBuffer %struct_1
+  %in_ptr = OpTypePointer Input %struct_0
+  %var = OpVariable %in_ptr Input
+  %void_fn = OpTypeFunction %void
+  %main = OpFunction %void None %void_fn
+  %entry = OpLabel
+  OpReturn
+  OpFunctionEnd
+  )";
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-09557"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input/Output interface variable id <2> contains a "
+                        "PhysicalStorageBuffer pointer, which is not allowed"));
+}
+
+TEST_F(ValidateInterfacesTest, PhysicalStorageBufferPointerArrayOfStruct) {
+  const std::string text = R"(
+  OpCapability Shader
+  OpCapability PhysicalStorageBufferAddresses
+  OpMemoryModel PhysicalStorageBuffer64 GLSL450
+  OpEntryPoint Vertex %main "main" %var
+  OpDecorate %var Location 0
+  OpDecorate %var RestrictPointer
+  %void = OpTypeVoid
+  %int = OpTypeInt 32 1
+  %uint = OpTypeInt 32 0
+  %uint_3 = OpConstant %uint 3
+  OpTypeForwardPointer %psb_ptr PhysicalStorageBuffer
+  %array_1 = OpTypeArray %psb_ptr %uint_3
+  %struct_0 = OpTypeStruct %int %array_1
+   %struct_1 = OpTypeStruct %int %int
+  %psb_ptr = OpTypePointer PhysicalStorageBuffer %struct_1
+  %array_0 = OpTypeArray %struct_0 %uint_3
+  %in_ptr = OpTypePointer Input %array_0
+  %var = OpVariable %in_ptr Input
+  %void_fn = OpTypeFunction %void
+  %main = OpFunction %void None %void_fn
+  %entry = OpLabel
+  OpReturn
+  OpFunctionEnd
+  )";
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-09557"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input/Output interface variable id <2> contains a "
+                        "PhysicalStorageBuffer pointer, which is not allowed"));
+}
+
+TEST_F(ValidateInterfacesTest, PhysicalStorageBufferPointerNestedStruct) {
+  const std::string text = R"(
+  OpCapability Shader
+  OpCapability PhysicalStorageBufferAddresses
+  OpMemoryModel PhysicalStorageBuffer64 GLSL450
+  OpEntryPoint Vertex %main "main" %var
+  OpDecorate %var Location 0
+  OpDecorate %var RestrictPointer
+  %void = OpTypeVoid
+  %int = OpTypeInt 32 1
+  OpTypeForwardPointer %psb_ptr PhysicalStorageBuffer
+  %struct_0 = OpTypeStruct %int %psb_ptr
+  %struct_1 = OpTypeStruct %int %int
+  %psb_ptr = OpTypePointer PhysicalStorageBuffer %struct_1
+  %struct_2 = OpTypeStruct %int %struct_0
+  %in_ptr = OpTypePointer Input %struct_2
+  %var = OpVariable %in_ptr Input
+  %void_fn = OpTypeFunction %void
+  %main = OpFunction %void None %void_fn
+  %entry = OpLabel
+  OpReturn
+  OpFunctionEnd
+  )";
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Input-09557"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Input/Output interface variable id <2> contains a "
+                        "PhysicalStorageBuffer pointer, which is not allowed"));
 }
 
 TEST_F(ValidateInterfacesTest, UntypedVariableInputMissing) {


### PR DESCRIPTION
re-attempt at https://github.com/KhronosGroup/SPIRV-Tools/pull/5539 (which was reverted in https://github.com/KhronosGroup/SPIRV-Tools/pull/5575)

Going to first fix GLSL to not generate invalid SPIR-V