### PR TITLE
spirv-val: Add AllowNon32bitBase option

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -740,6 +740,10 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowLocalSizeId(
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowOffsetTextureOperand(
     spv_validator_options options, bool val);
 
+// Allow base operands of some bit operations to be non-32-bit wide.
+SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowNon32BitBases(
+    spv_validator_options options, bool val);
+
 // Whether friendly names should be used in validation error messages.
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetFriendlyNames(
     spv_validator_options options, bool val);

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -132,6 +132,11 @@ class SPIRV_TOOLS_EXPORT ValidatorOptions {
     spvValidatorOptionsSetAllowOffsetTextureOperand(options_, val);
   }
 
+  // Allow base operands of some bit operations to be non-32-bit wide.
+  void SetAllowNon32BitBases(bool val) {
+    spvValidatorOptionsSetAllowNon32BitBases(options_, val);
+  }
+
   // Records whether or not the validator should relax the rules on pointer
   // usage in logical addressing mode.
   //

--- a/source/spirv_validator_options.cpp
+++ b/source/spirv_validator_options.cpp
@@ -131,6 +131,11 @@ void spvValidatorOptionsSetAllowOffsetTextureOperand(
   options->allow_offset_texture_operand = val;
 }
 
+void spvValidatorOptionsSetAllowNon32BitBases(spv_validator_options options,
+                                              bool val) {
+  options->allow_non_32_bit_bases = val;
+}
+
 void spvValidatorOptionsSetFriendlyNames(spv_validator_options options,
                                          bool val) {
   options->use_friendly_names = val;

--- a/source/spirv_validator_options.h
+++ b/source/spirv_validator_options.h
@@ -49,6 +49,7 @@ struct spv_validator_options_t {
         skip_block_layout(false),
         allow_localsizeid(false),
         allow_offset_texture_operand(false),
+        allow_non_32_bit_bases(false),
         before_hlsl_legalization(false),
         use_friendly_names(true) {}
 
@@ -62,6 +63,7 @@ struct spv_validator_options_t {
   bool skip_block_layout;
   bool allow_localsizeid;
   bool allow_offset_texture_operand;
+  bool allow_non_32_bit_bases;
   bool before_hlsl_legalization;
   bool use_friendly_names;
 };

--- a/source/val/validate_bitwise.cpp
+++ b/source/val/validate_bitwise.cpp
@@ -30,14 +30,14 @@ spv_result_t ValidateBaseType(ValidationState_t& _, const Instruction* inst,
 
   if (!_.IsIntScalarType(base_type) && !_.IsIntVectorType(base_type)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << _.VkErrorID(4781)
            << "Expected int scalar or vector type for Base operand: "
            << spvOpcodeString(opcode);
   }
 
   // Vulkan has a restriction to 32 bit for base
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    if (_.GetBitWidth(base_type) != 32) {
+    if (_.GetBitWidth(base_type) != 32 &&
+        !_.options()->allow_non_32_bit_bases) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << _.VkErrorID(4781)
              << "Expected 32-bit int type for Base operand: "

--- a/test/val/val_bitwise_test.cpp
+++ b/test/val/val_bitwise_test.cpp
@@ -427,6 +427,16 @@ TEST_F(ValidateBitwise, OpBitFieldInsertNot32Vulkan) {
       HasSubstr("Expected 32-bit int type for Base operand: BitFieldInsert"));
 }
 
+TEST_F(ValidateBitwise, OpBitFieldInsertNot32Allow) {
+  const std::string body = R"(
+  %val1 = OpBitFieldInsert %u64 %u64_1 %u64_2 %s32_1 %s32_2
+  )";
+
+  CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
+  spvValidatorOptionsSetAllowNon32BitBases(getValidatorOptions(), true);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+}
+
 TEST_F(ValidateBitwise, OpBitFieldSExtractSuccess) {
   const std::string body = R"(
 %val1 = OpBitFieldSExtract %u64 %u64_1 %s32_1 %s32_2
@@ -607,10 +617,8 @@ TEST_F(ValidateBitwise, OpBitCountBaseNotInt) {
 %val1 = OpBitCount %u32 %f64_1
 )";
 
-  CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Base-04781"));
+  CompileSuccessfully(GenerateShaderCode(body).c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -68,6 +68,8 @@ Options:
                                    be allowed by the target environment.
   --allow-offset-texture-operand   Allow use of the Offset texture operands where it would otherwise not
                                    be allowed by the target environment.
+  --allow-non-32-bit-bases         Allow use of non-32 bit for the Base operand where it would otherwise
+                                   not be allowed by the target environment.
   --before-hlsl-legalization       Allows code patterns that are intended to be
                                    fixed by spirv-opt's legalization passes.
   --version                        Display validator version information.
@@ -165,6 +167,8 @@ int main(int argc, char** argv) {
         options.SetAllowLocalSizeId(true);
       } else if (0 == strcmp(cur_arg, "--allow-offset-texture-operand")) {
         options.SetAllowOffsetTextureOperand(true);
+      } else if (0 == strcmp(cur_arg, "--allow-non-32-bit-bases")) {
+        options.SetAllowNon32BitBases(true);
       } else if (0 == strcmp(cur_arg, "--relax-struct-store")) {
         options.SetRelaxStructStore(true);
       } else if (0 == cur_arg[1]) {


### PR DESCRIPTION
Adds ` --allow-non-32-bit-bases` for future upcoming Vulkan Extension