### PR TITLE
[opt] Fix bug opt::InstructionBuilder::AddVariable

### DIFF
--- a/source/opt/ir_builder.h
+++ b/source/opt/ir_builder.h
@@ -516,7 +516,7 @@ class InstructionBuilder {
 
   Instruction* AddVariable(uint32_t type_id, uint32_t storage_class) {
     std::vector<Operand> operands;
-    operands.push_back({SPV_OPERAND_TYPE_ID, {storage_class}});
+    operands.push_back({SPV_OPERAND_TYPE_STORAGE_CLASS, {storage_class}});
     std::unique_ptr<Instruction> new_inst(
         new Instruction(GetContext(), spv::Op::OpVariable, type_id,
                         GetContext()->TakeNextId(), operands));


### PR DESCRIPTION
The storage class operand was being added with the wrong operand type.  It was assumed to be an ID.  Then trying to analyze the new variable declaration instruction's defs and uses could get confused and assert out.

Added a test for this.