### PR TITLE
Support optimization of OpCopyLogical

### DIFF
--- a/source/opt/copy_prop_arrays.cpp
+++ b/source/opt/copy_prop_arrays.cpp
@@ -276,6 +276,7 @@ CopyPropagateArrays::GetSourceObjectIfAny(uint32_t result) {
     case spv::Op::OpCompositeConstruct:
       return BuildMemoryObjectFromCompositeConstruct(result_inst);
     case spv::Op::OpCopyObject:
+    case spv::Op::OpCopyLogical:
       return GetSourceObjectIfAny(result_inst->GetSingleWordInOperand(0));
     case spv::Op::OpCompositeInsert:
       return BuildMemoryObjectFromInsert(result_inst);

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -564,6 +564,7 @@ void IRContext::AddCombinatorsForCapability(uint32_t capability) {
          (uint32_t)spv::Op::OpCompositeConstruct,
          (uint32_t)spv::Op::OpCompositeExtract,
          (uint32_t)spv::Op::OpCompositeInsert,
+         (uint32_t)spv::Op::OpCopyLogical,
          (uint32_t)spv::Op::OpCopyObject,
          (uint32_t)spv::Op::OpTranspose,
          (uint32_t)spv::Op::OpSampledImage,

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -8297,6 +8297,185 @@ OpFunctionEnd
       HasSubstr("OpSource HLSL 600 %5 \"#define UBER_TYPE(x) x ## Type"));
 }
 
+TEST_F(AggressiveDCETest, EliminateCopyLogical) {
+  const std::string before = R"(
+; CHECK: [[float32:%\w+]] = OpTypeFloat 32
+; CHECK: [[v4float:%\w+]] = OpTypeVector [[float32]] 4
+; CHECK-NOT: %10 = OpTypeArray [[v4float]] %9
+; CHECK-NOT: %11 = OpTypeStruct %10 %10
+; CHECK-NOT: %22 = OpTypePointer Uniform %16
+; CHECK-NOT: %38 = OpTypePointer Function [[v4float]]
+; CHECK-NOT: %43 = OpTypePointer Function %10
+; CHECK-NOT: %44 = OpVariable %42 Function
+; CHECK-NOT: %23 = OpAccessChain %22 %19 %21
+; CHECK-NOT: %24 = OpLoad %16 %23
+; CHECK-NOT: %25 = OpCopyLogical %11 %24
+; CHECK-NOT: %46 = OpCompositeExtract %10 %25 0
+; CHECK-NOT:       OpStore %44 %46
+      OpCapability Shader
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint Vertex %4 "main" %19 %30 %32
+      OpSource GLSL 430
+      OpName %4 "main"
+      OpDecorate %14 ArrayStride 16
+      OpDecorate %15 ArrayStride 16
+      OpMemberDecorate %16 0 Offset 0
+      OpMemberDecorate %16 1 Offset 32
+      OpDecorate %17 Block
+      OpMemberDecorate %17 0 Offset 0
+      OpDecorate %19 Binding 0
+      OpDecorate %19 DescriptorSet 0
+      OpDecorate %28 Block
+      OpMemberDecorate %28 0 BuiltIn Position
+      OpMemberDecorate %28 1 BuiltIn PointSize
+      OpMemberDecorate %28 2 BuiltIn ClipDistance
+      OpDecorate %32 Location 0
+ %2 = OpTypeVoid
+ %3 = OpTypeFunction %2
+ %6 = OpTypeFloat 32
+ %7 = OpTypeVector %6 4
+ %8 = OpTypeInt 32 0
+ %9 = OpConstant %8 2
+%10 = OpTypeArray %7 %9
+%11 = OpTypeStruct %10 %10
+%14 = OpTypeArray %7 %9
+%15 = OpTypeArray %7 %9
+%16 = OpTypeStruct %14 %15
+%17 = OpTypeStruct %16
+%18 = OpTypePointer Uniform %17
+%19 = OpVariable %18 Uniform
+%20 = OpTypeInt 32 1
+%21 = OpConstant %20 0
+%22 = OpTypePointer Uniform %16
+%26 = OpConstant %8 1
+%27 = OpTypeArray %6 %26
+%28 = OpTypeStruct %7 %6 %27
+%29 = OpTypePointer Output %28
+%30 = OpVariable %29 Output
+%31 = OpTypePointer Input %7
+%32 = OpVariable %31 Input
+%33 = OpConstant %8 0
+%34 = OpTypePointer Input %6
+%38 = OpTypePointer Function %7
+%41 = OpTypePointer Output %7
+%43 = OpTypePointer Function %10
+%48 = OpTypePointer Uniform %14
+%49 = OpTypePointer Uniform %7
+ %4 = OpFunction %2 None %3
+ %5 = OpLabel
+%44 = OpVariable %43 Function
+%23 = OpAccessChain %22 %19 %21
+%24 = OpLoad %16 %23
+%25 = OpCopyLogical %11 %24
+%46 = OpCompositeExtract %10 %25 0
+%50 = OpAccessChain %48 %19 %21 %33
+      OpStore %44 %46
+%35 = OpAccessChain %34 %32 %33
+%36 = OpLoad %6 %35
+%37 = OpConvertFToS %20 %36
+%47 = OpAccessChain %49 %50 %37
+%40 = OpLoad %7 %47
+%42 = OpAccessChain %41 %30 %21
+      OpStore %42 %40
+      OpReturn
+      OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
+  SinglePassRunAndMatch<AggressiveDCEPass>(before, true);
+}
+
+TEST_F(AggressiveDCETest, KeepCopyLogical) {
+  const std::string before = R"(
+; CHECK: OpCopyLogical
+      OpCapability Shader
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint GLCompute %4 "main" %15 %23 %38
+      OpExecutionMode %4 LocalSize 32 32 1
+      OpSource GLSL 430
+      OpName %4 "main"
+      OpDecorate %10 ArrayStride 16
+      OpDecorate %11 ArrayStride 16
+      OpMemberDecorate %12 0 Offset 0
+      OpMemberDecorate %12 1 Offset 2048
+      OpDecorate %13 Block
+      OpMemberDecorate %13 0 NonReadable
+      OpMemberDecorate %13 0 Offset 0
+      OpDecorate %15 NonReadable
+      OpDecorate %15 Binding 1
+      OpDecorate %15 DescriptorSet 0
+      OpDecorate %18 ArrayStride 16
+      OpDecorate %19 ArrayStride 16
+      OpMemberDecorate %20 0 Offset 0
+      OpMemberDecorate %20 1 Offset 2048
+      OpDecorate %21 Block
+      OpMemberDecorate %21 0 NonWritable
+      OpMemberDecorate %21 0 Offset 0
+      OpDecorate %23 NonWritable
+      OpDecorate %23 Binding 0
+      OpDecorate %23 DescriptorSet 0
+      OpDecorate %30 ArrayStride 16
+      OpDecorate %31 ArrayStride 16
+      OpMemberDecorate %32 0 Offset 0
+      OpMemberDecorate %32 1 Offset 2048
+      OpDecorate %34 ArrayStride 4096
+      OpMemberDecorate %35 0 Offset 0
+      OpDecorate %36 Block
+      OpMemberDecorate %36 0 Offset 0
+      OpDecorate %38 Binding 0
+      OpDecorate %38 DescriptorSet 0
+ %2 = OpTypeVoid
+ %3 = OpTypeFunction %2
+ %6 = OpTypeFloat 32
+ %7 = OpTypeVector %6 4
+ %8 = OpTypeInt 32 0
+ %9 = OpConstant %8 128
+%10 = OpTypeArray %7 %9
+%11 = OpTypeArray %7 %9
+%12 = OpTypeStruct %10 %11
+%13 = OpTypeStruct %12
+%14 = OpTypePointer StorageBuffer %13
+%15 = OpVariable %14 StorageBuffer
+%16 = OpTypeInt 32 1
+%17 = OpConstant %16 0
+%18 = OpTypeArray %7 %9
+%19 = OpTypeArray %7 %9
+%20 = OpTypeStruct %18 %19
+%21 = OpTypeStruct %20
+%22 = OpTypePointer StorageBuffer %21
+%23 = OpVariable %22 StorageBuffer
+%24 = OpTypePointer StorageBuffer %20
+%27 = OpTypePointer StorageBuffer %12
+%30 = OpTypeArray %7 %9
+%31 = OpTypeArray %7 %9
+%32 = OpTypeStruct %30 %31
+%33 = OpConstant %8 8
+%34 = OpTypeArray %32 %33
+%35 = OpTypeStruct %34
+%36 = OpTypeStruct %35
+%37 = OpTypePointer Uniform %36
+%38 = OpVariable %37 Uniform
+ %4 = OpFunction %2 None %3
+ %5 = OpLabel
+%25 = OpAccessChain %24 %23 %17
+%26 = OpLoad %20 %25
+%28 = OpAccessChain %27 %15 %17
+%29 = OpCopyLogical %12 %26
+      OpStore %28 %29
+      OpReturn
+      OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
+  SinglePassRunAndMatch<AggressiveDCEPass>(before, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/copy_prop_array_test.cpp
+++ b/test/opt/copy_prop_array_test.cpp
@@ -2146,6 +2146,86 @@ OpFunctionEnd
   SetTargetEnv(SPV_ENV_UNIVERSAL_1_4);
   SinglePassRunAndMatch<CopyPropagateArrays>(before, true);
 }
+
+TEST_F(CopyPropArrayPassTest, PropCopyLogical) {
+  const std::string before = R"(
+; CHECK: [[v4array_ptr:%\w+]] = OpTypePointer Uniform %14
+; CHECK: [[v4_ptr:%\w+]] = OpTypePointer Uniform %7
+; CHECK: [[ac:%\w+]] = OpAccessChain [[v4array_ptr]] %19 %21 %33
+; CHECK: %47 = OpAccessChain [[v4_ptr]] [[ac]] %37
+      OpCapability Shader
+ %1 = OpExtInstImport "GLSL.std.450"
+      OpMemoryModel Logical GLSL450
+      OpEntryPoint Vertex %4 "main" %19 %30 %32
+      OpSource GLSL 430
+      OpName %4 "main"
+      OpDecorate %14 ArrayStride 16
+      OpDecorate %15 ArrayStride 16
+      OpMemberDecorate %16 0 Offset 0
+      OpMemberDecorate %16 1 Offset 32
+      OpDecorate %17 Block
+      OpMemberDecorate %17 0 Offset 0
+      OpDecorate %19 Binding 0
+      OpDecorate %19 DescriptorSet 0
+      OpDecorate %28 Block
+      OpMemberDecorate %28 0 BuiltIn Position
+      OpMemberDecorate %28 1 BuiltIn PointSize
+      OpMemberDecorate %28 2 BuiltIn ClipDistance
+      OpDecorate %32 Location 0
+ %2 = OpTypeVoid
+ %3 = OpTypeFunction %2
+ %6 = OpTypeFloat 32
+ %7 = OpTypeVector %6 4
+ %8 = OpTypeInt 32 0
+ %9 = OpConstant %8 2
+%10 = OpTypeArray %7 %9
+%11 = OpTypeStruct %10 %10
+%14 = OpTypeArray %7 %9
+%15 = OpTypeArray %7 %9
+%16 = OpTypeStruct %14 %15
+%17 = OpTypeStruct %16
+%18 = OpTypePointer Uniform %17
+%19 = OpVariable %18 Uniform
+%20 = OpTypeInt 32 1
+%21 = OpConstant %20 0
+%22 = OpTypePointer Uniform %16
+%26 = OpConstant %8 1
+%27 = OpTypeArray %6 %26
+%28 = OpTypeStruct %7 %6 %27
+%29 = OpTypePointer Output %28
+%30 = OpVariable %29 Output
+%31 = OpTypePointer Input %7
+%32 = OpVariable %31 Input
+%33 = OpConstant %8 0
+%34 = OpTypePointer Input %6
+%38 = OpTypePointer Function %7
+%41 = OpTypePointer Output %7
+%43 = OpTypePointer Function %10
+ %4 = OpFunction %2 None %3
+ %5 = OpLabel
+%44 = OpVariable %43 Function
+%23 = OpAccessChain %22 %19 %21
+%24 = OpLoad %16 %23
+%25 = OpCopyLogical %11 %24
+%46 = OpCompositeExtract %10 %25 0
+      OpStore %44 %46
+%35 = OpAccessChain %34 %32 %33
+%36 = OpLoad %6 %35
+%37 = OpConvertFToS %20 %36
+%47 = OpAccessChain %38 %44 %37
+%40 = OpLoad %7 %47
+%42 = OpAccessChain %41 %30 %21
+      OpStore %42 %40
+      OpReturn
+      OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
+  SinglePassRunAndMatch<CopyPropagateArrays>(before, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
This PR fixes an issue where redundant OpCopyLogical copies are not removed by SPIRV-Tools-opt. OpCopyLogical is generated by default by glslang for conversions between types with potentially differing layouts in SPIR-V 1.4 and later, such as when reading uniform/storage buffers into local and/or function parameter variables.

When the following GLSL is compiled using glslang targeting SPIR-V 1.4 or later and then optimized by SPIRV-Tools-opt, the entire contents of the uniform buffer are copied into local memory even though only a small subset of the uniform buffer is actually read from. With the improvements in this PR, the unnecessary copy of the entire uniform buffer into local memory is removed, and the data is instead read directly from the uniform buffer itself.

````
#version 430

struct S1 {
    vec4 a1[128];
    vec4 a2[128];
};

uniform UBO1 {
    S1 s1;
};

in int in0;

void main() {
    S1 s = s1;
    gl_Position = s.a1[in0];
}
````

The lack of optimization is caused by missing support for OpCopyLogical in the CopyPropagateArrays and AggressiveDeadCodeElimination passes, support for which seems to have not been implemented in any of SPIRV-Tools-opt since the release of SPIR-V 1.4. The inability to optimize OpCopyLogical can lead to a large number of unnecessary loads to local memory not being optimized away when they could and should be, which can have catastrophic performance consequences on some drivers/GPUs whenever a large amount of data is read from such uniform and/or storage buffers. This PR implements support for OpCopyLogical in these passes, allowing them to properly optimize such unused copies away.

This PR incorporates two parts to enable optimization of OpCopyLogical:

First, because OpCopyLogical is not a known combinator opcode, whenever AggressiveDeadCodeElimination first builds its list of live variables it unconditionally marks all OpCopyLogical accesses as live. The consequence of this is that until now OpCopyLogical instructions were not being removed even when they weren't live. This PR adds OpCopyLogical to the list of known combinator opcodes in order to allow the AggressiveDeadCodeElimination pass to eliminate it.

Second, this PR adds support for OpCopyLogical to the CopyPropagateArrays pass by making use of existing logic for handling OpCopyObject, which (in this context) is already suitable for processing OpCopyLogical as well.

Since OpCopyLogical is only available in SPIR-V 1.4 and later, shaders using SPIR-V 1.3 and earlier are unaffected by these changes. An unrelated but similar-consequence issue exists with optimization of SPIR-V 1.3 and earlier shaders, but this is out of scope for this PR.