### PR TITLE
Fix invalid layout validation version check

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -2098,7 +2098,7 @@ bool AllowsLayout(ValidationState_t& vstate, const spv::StorageClass sc) {
           spv::Capability::WorkgroupMemoryExplicitLayoutKHR);
     case spv::StorageClass::Function:
     case spv::StorageClass::Private:
-      return vstate.version() < SPV_SPIRV_VERSION_WORD(1, 4);
+      return vstate.version() <= SPV_SPIRV_VERSION_WORD(1, 4);
     case spv::StorageClass::Input:
     case spv::StorageClass::Output:
       // Block is used generally and mesh shaders use Offset.

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10716,8 +10716,8 @@ OpReturn
 OpFunctionEnd
 )";
 
-  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_0);
-  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 
 TEST_F(ValidateDecorations, InvalidLayoutBlockFunctionPost1p4) {
@@ -10739,7 +10739,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_5);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
   EXPECT_THAT(
       getDiagnosticString(),


### PR DESCRIPTION
* Vulkan says versions 1.4 and earlier so change comparison from less than to less than or equal
