### PR TITLE
spirv-as: Add OpUnknown pseudo-instruction

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1382,6 +1382,7 @@ if (build_with_chromium && spvtools_build_executables) {
       "test/libspirv_macros_test.cpp",
       "test/name_mapper_test.cpp",
       "test/named_id_test.cpp",
+      "test/op_unknown_test.cpp",
       "test/opcode_make_test.cpp",
       "test/opcode_require_capabilities_test.cpp",
       "test/opcode_split_test.cpp",

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -215,6 +215,48 @@ Note that this has some interesting consequences, including:
   that named ID being output.  This may be valid SPIR-V, contrary to the
   presumed intention of the writer.
 
+## OpUnknown
+<a name="op-unknown"></a>
+
+HLSL has a feature that allows users to specify an exact SPIR-V type using [the
+`SpirvType` template](https://github.com/microsoft/hlsl-specs/blob/main/proposals/0011-inline-spirv.md#types).
+This feature allows the user to specify a type opcode that the compiler does
+not know. In this case, it will be unable to generate assembly using the
+correct mnemonic.
+
+In order to represent unknown opcodes in assembly format, the `OpUnknown`
+pseudo-instruction may be used. The syntax is:
+
+```
+OpUnknown(<enumerant>, <WordCount>) <operand 1> ...
+```
+
+`enumerant` is the opcode enumerant, and `WordCount` is the number of words in
+the instruction. These will be assembled into a single word representing the
+opcode. Operands will be parsed according to the alternate parsing mode
+described in [Arbitrary Integers](#op-unknown).
+
+It must be used at the beginning of a new instruction, and if there is a result
+ID it must explicitly be passed in as an operand. This is because the physical
+layout of a SPIR-V instruction may include a result type operand before the
+result ID operand, but it depends on the opcode and cannot be inferred for an
+unknown operand.
+
+For example, a 32-bit signed integer type could be represented like this:
+
+```
+OpUnknown(21, 4) %int_t 32 1
+```
+
+An OpStore instruction could be represented as:
+
+```
+OpUnknown(62, 3) %9 %12
+```
+
+The enumerant and word count must be decimal integers.
+
+
 ## Notes
 
 * Some enumerants cannot be used by name, because the target instruction

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -234,7 +234,9 @@ OpUnknown(<enumerant>, <WordCount>) <operand 1> ...
 `enumerant` is the opcode enumerant, and `WordCount` is the number of words in
 the instruction. These will be assembled into a single word representing the
 opcode. Operands will be parsed according to the alternate parsing mode
-described in [Arbitrary Integers](#op-unknown).
+described in [Arbitrary Integers](#op-unknown). Named enumerated values cannot
+be handled by this mode and must be represented using the arbitrary integer
+syntax.
 
 It must be used at the beginning of a new instruction, and if there is a result
 ID it must explicitly be passed in as an operand. This is because the physical

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -515,6 +515,125 @@ spv_result_t encodeInstructionStartingWithImmediate(
   return SPV_SUCCESS;
 }
 
+/// @brief Translate an instruction started by OpUnknown and the following
+/// operands to binary form
+///
+/// @param[in] grammar the grammar to use for compilation
+/// @param[in, out] context the dynamic compilation info
+/// @param[in] type of the operand
+/// @param[out] pInst returned binary Opcode
+///
+/// @return result code
+spv_result_t encodeInstructionStartingWithOpUnknown(
+    const spvtools::AssemblyGrammar& grammar,
+    spvtools::AssemblyContext* context, spv_instruction_t* pInst) {
+  spv_position_t nextPosition = {};
+
+  uint16_t opcode;
+  uint16_t wordCount;
+
+  // The '(' character.
+  if (context->advance())
+    return context->diagnostic() << "Expected '(', found end of stream.";
+  if ('(' != context->peek()) {
+    return context->diagnostic() << "'(' expected after OpUnknown but found '"
+                                 << context->peek() << "'.";
+  }
+  context->seekForward(1);
+
+  // The opcode enumerant.
+  if (context->advance())
+    return context->diagnostic()
+           << "Expected opcode enumerant, found end of stream.";
+  std::string opcodeString;
+  spv_result_t error = context->getWord(&opcodeString, &nextPosition);
+  if (error) return context->diagnostic(error) << "Internal Error";
+
+  if (!spvtools::utils::ParseNumber(opcodeString.c_str(), &opcode)) {
+    return context->diagnostic()
+           << "Invalid opcode enumerant: \"" << opcodeString << "\".";
+  }
+
+  context->setPosition(nextPosition);
+
+  // The ',' character.
+  if (context->advance())
+    return context->diagnostic() << "Expected ',', found end of stream.";
+  if (',' != context->peek()) {
+    return context->diagnostic()
+           << "',' expected after opcode enumerant but found '"
+           << context->peek() << "'.";
+  }
+  context->seekForward(1);
+
+  // The number of words.
+  if (context->advance())
+    return context->diagnostic()
+           << "Expected number of words, found end of stream.";
+  std::string wordCountString;
+  error = context->getWord(&wordCountString, &nextPosition);
+  if (error) return context->diagnostic(error) << "Internal Error";
+
+  if (!spvtools::utils::ParseNumber(wordCountString.c_str(), &wordCount)) {
+    return context->diagnostic()
+           << "Invalid number of words: \"" << wordCountString << "\".";
+  }
+
+  if (wordCount == 0) {
+    return context->diagnostic() << "Number of words (which includes the "
+                                    "opcode) must be greater than zero.";
+  }
+
+  context->setPosition(nextPosition);
+
+  // The ')' character.
+  if (context->advance())
+    return context->diagnostic() << "Expected ')', found end of stream.";
+  if (')' != context->peek()) {
+    return context->diagnostic()
+           << "')' expected after number of words but found '"
+           << context->peek() << "'.";
+  }
+  context->seekForward(1);
+
+  pInst->opcode = static_cast<spv::Op>(opcode);
+  context->binaryEncodeU32(spvOpcodeMake(wordCount, pInst->opcode), pInst);
+
+  wordCount--;  // Subtract the opcode from the number of words left to read.
+
+  while (wordCount-- > 0) {
+    if (context->advance() == SPV_END_OF_STREAM) {
+      return context->diagnostic() << "Expected " << wordCount + 1
+                                   << " more operands, found end of stream.";
+    }
+    if (context->isStartOfNewInst()) {
+      std::string invalid;
+      context->getWord(&invalid, &nextPosition);
+      return context->diagnostic()
+             << "Unexpected start of new instruction: \"" << invalid
+             << "\". Expected " << wordCount + 1 << " more operands";
+    }
+
+    std::string operandValue;
+    if ((error = context->getWord(&operandValue, &nextPosition)))
+      return context->diagnostic(error) << "Internal Error";
+
+    if (operandValue == "=")
+      return context->diagnostic() << "OpUnknown not allowed before =.";
+
+    // Needed to pass to spvTextEncodeOpcode(), but it shouldn't ever be
+    // expanded.
+    spv_operand_pattern_t dummyExpectedOperands;
+    error = spvTextEncodeOperand(
+        grammar, context, SPV_OPERAND_TYPE_OPTIONAL_CIV, operandValue.c_str(),
+        pInst, &dummyExpectedOperands);
+    if (error) return error;
+    context->setPosition(nextPosition);
+  }
+
+  return SPV_SUCCESS;
+}
+
 /// @brief Translate single Opcode and operands to binary form
 ///
 /// @param[in] grammar the grammar to use for compilation
@@ -572,6 +691,16 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
       return context->diagnostic()
              << "Invalid Opcode prefix '" << opcodeName << "'.";
     }
+  }
+
+  if (opcodeName == "OpUnknown") {
+    if (!result_id.empty()) {
+      return context->diagnostic()
+             << "OpUnknown not allowed in assignment. Use an explicit result "
+                "id operand instead.";
+    }
+    context->setPosition(nextPosition);
+    return encodeInstructionStartingWithOpUnknown(grammar, context, pInst);
   }
 
   // NOTE: The table contains Opcode names without the "Op" prefix.

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -520,7 +520,6 @@ spv_result_t encodeInstructionStartingWithImmediate(
 ///
 /// @param[in] grammar the grammar to use for compilation
 /// @param[in, out] context the dynamic compilation info
-/// @param[in] type of the operand
 /// @param[out] pInst returned binary Opcode
 ///
 /// @return result code

--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -118,6 +118,9 @@ spv_result_t getWord(spv_text text, spv_position position, std::string* word) {
           break;
         case ' ':
         case ';':
+        case ',':
+        case '(':
+        case ')':
         case '\t':
         case '\n':
         case '\r':

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -116,6 +116,7 @@ set(TEST_SOURCES
   libspirv_macros_test.cpp
   named_id_test.cpp
   name_mapper_test.cpp
+  op_unknown_test.cpp
   opcode_make_test.cpp
   opcode_require_capabilities_test.cpp
   opcode_split_test.cpp

--- a/test/op_unknown_test.cpp
+++ b/test/op_unknown_test.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "source/util/bitutils.h"
+#include "test/test_fixture.h"
+
+namespace spvtools {
+namespace utils {
+namespace {
+
+using spvtest::Concatenate;
+using spvtest::MakeInstruction;
+using spvtest::ScopedContext;
+using spvtest::TextToBinaryTest;
+using ::testing::ElementsAre;
+using ::testing::Eq;
+using ::testing::HasSubstr;
+using ::testing::StrEq;
+
+using OpUnknownTest = TextToBinaryTest;
+
+TEST_F(OpUnknownTest, OpUnknown) {
+  SetText("OpUnknown(255, 1)");
+  ASSERT_EQ(SPV_SUCCESS, spvTextToBinary(ScopedContext().context, text.str,
+                                         text.length, &binary, &diagnostic));
+  EXPECT_EQ(0x000100FFu, binary->code[5]);
+  if (diagnostic) {
+    spvDiagnosticPrint(diagnostic);
+  }
+}
+
+TEST_F(OpUnknownTest, HandlesOperands) {
+  EXPECT_THAT(CompiledInstructions("OpUnknown(24, 4) %a %b %123"),
+              Eq(MakeInstruction(spv::Op::OpTypeMatrix, {1, 2, 3})));
+  EXPECT_THAT(CompiledInstructions("OpUnknown(24, 4) !1 %b %123"),
+              Eq(MakeInstruction(spv::Op::OpTypeMatrix, {1, 1, 2})));
+}
+
+TEST_F(OpUnknownTest, HandlesWhitespace) {
+  EXPECT_THAT(CompiledInstructions("OpUnknown ( 24 , 4 ) %a %b %123"),
+              Eq(MakeInstruction(spv::Op::OpTypeMatrix, {1, 2, 3})));
+  EXPECT_THAT(CompiledInstructions("OpUnknown(24,4) %a %b %123"),
+              Eq(MakeInstruction(spv::Op::OpTypeMatrix, {1, 2, 3})));
+}
+
+TEST_F(OpUnknownTest, MultipleInstructions) {
+  EXPECT_THAT(
+      CompiledInstructions(
+          "%a = OpTypeFunction %b\nOpUnknown(21, 5) %c %d 32 1\nOpNop"),
+      Eq(Concatenate({MakeInstruction(spv::Op::OpTypeFunction, {1, 2}),
+                      MakeInstruction(spv::Op::OpTypeInt, {3, 4, 32, 1}),
+                      MakeInstruction(spv::Op::OpNop, {})})));
+}
+
+TEST_F(OpUnknownTest, OpUnknownInAssignment) {
+  EXPECT_EQ(
+      "OpUnknown not allowed in assignment. Use an explicit result id operand "
+      "instead.",
+      CompileFailure("%2 = OpUnknown(22, 3) 32"));
+  EXPECT_EQ("OpUnknown not allowed before =.",
+            CompileFailure("OpUnknown(22, 3) = OpTypeFloat 32"));
+}
+
+TEST_F(OpUnknownTest, ParsingErrors) {
+  EXPECT_EQ("Expected '(', found end of stream.", CompileFailure("OpUnknown"));
+  EXPECT_EQ("'(' expected after OpUnknown but found 'a'.",
+            CompileFailure("OpUnknown abc"));
+
+  EXPECT_EQ("Expected opcode enumerant, found end of stream.",
+            CompileFailure("OpUnknown("));
+  EXPECT_EQ("Invalid opcode enumerant: \"abc\".",
+            CompileFailure("OpUnknown(abc"));
+  // Opcode enumerant must fit in 16 bits.
+  EXPECT_EQ("Invalid opcode enumerant: \"70000\".",
+            CompileFailure("OpUnknown(70000"));
+
+  EXPECT_EQ("Expected ',', found end of stream.",
+            CompileFailure("OpUnknown(22"));
+  EXPECT_EQ("',' expected after opcode enumerant but found 'a'.",
+            CompileFailure("OpUnknown(22 abc"));
+
+  EXPECT_EQ("Expected number of words, found end of stream.",
+            CompileFailure("OpUnknown(22,"));
+  EXPECT_EQ("Invalid number of words: \"abc\".",
+            CompileFailure("OpUnknown(22, abc"));
+  // Number of words must fit in 16 bits.
+  EXPECT_EQ("Invalid number of words: \"70000\".",
+            CompileFailure("OpUnknown(22, 70000"));
+  EXPECT_EQ(
+      "Number of words (which includes the opcode) must be greater than zero.",
+      CompileFailure("OpUnknown(22, 0"));
+
+  EXPECT_EQ("Expected ')', found end of stream.",
+            CompileFailure("OpUnknown(22, 3"));
+  EXPECT_EQ("')' expected after number of words but found 'a'.",
+            CompileFailure("OpUnknown(22, 3 abc"));
+
+  EXPECT_EQ(
+      "Unexpected start of new instruction: \"OpNop\". Expected 2 more "
+      "operands",
+      CompileFailure("OpUnknown(22, 3) OpNop"));
+  EXPECT_EQ("Expected 2 more operands, found end of stream.",
+            CompileFailure("OpUnknown(22, 3)"));
+
+  EXPECT_EQ(CompileFailure("OpUnknown(21, 4) %c %d 32 1"),
+            "Expected <opcode> or <result-id> at the beginning of an "
+            "instruction, found '1'.");
+}
+
+}  // namespace
+}  // namespace utils
+}  // namespace spvtools


### PR DESCRIPTION
We are adding support for `vk::SpirvType` to HLSL in Clang. This is a language feature that allows users to directly specify the SPIR-V opcode of a type they want to use in HLSL. Knowing the opcode, we can generate a valid binary directly. But LLVM also provides the option for producing text output, which is used for FileCheck tests that match regular expressions against that output. We do not have a way to generate SPIR-V assembly text for instructions with unknown opcodes.

We will also need this when we add support for HLSL’s `vk::ext_instruction`, which allows users to create functions representing arbitrary instructions.