### PR TITLE
spirv-val: Add Vulkan Aligned PowerOfTwo check

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -380,6 +380,16 @@ spv_result_t CheckMemoryAccess(ValidationState_t& _, const Instruction* inst,
              << _.VkErrorID(4708)
              << "Memory accesses with PhysicalStorageBuffer must use Aligned.";
     }
+  } else {
+    // even if there are other masks, the Aligned operand will be next
+    const uint32_t aligned_value = inst->GetOperandAs<uint32_t>(index + 1);
+    const bool is_power_of_two =
+        aligned_value && !(aligned_value & (aligned_value - 1));
+    if (!is_power_of_two) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << "Memory accesses Aligned operand value " << aligned_value
+             << " is not a power of two.";
+    }
   }
 
   return SPV_SUCCESS;

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -5764,7 +5764,7 @@ TEST_P(ValidateIdWithMessage,
  %2 = OpFunction %8 None %11
  %4 = OpFunctionParameter %10
 %15 = OpLabel
-%16 = OpLoad %6 %3 Aligned 0
+%16 = OpLoad %6 %3 Aligned 1
 %17 = OpCompositeExtract %5 %16 0
 %18 = OpInBoundsPtrAccessChain %13 %4 %17 %12
       OpStore %18 %14 Aligned 4
@@ -5798,7 +5798,7 @@ TEST_P(ValidateIdWithMessage, OpPtrAccessChainGood) {
  %2 = OpFunction %8 None %12
  %4 = OpFunctionParameter %11
 %17 = OpLabel
-%18 = OpLoad %6 %3 Aligned 0
+%18 = OpLoad %6 %3 Aligned 1
 %19 = OpCompositeExtract %5 %18 0
 %20 = OpBitwiseAnd %5 %19 %13
 %21 = OpPtrAccessChain %15 %4 %20 %14


### PR DESCRIPTION
hit in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9531 and creating spec VU in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7210

The `Aligned` literal value should be allowed to be things like `0` or `3`

(related Glslang issue https://github.com/KhronosGroup/glslang/issues/3893)