### PR TITLE
Fix explicit layout validation on ptr type

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -2138,8 +2138,8 @@ bool UsesExplicitLayout(ValidationState_t& vstate, uint32_t type_id,
         allowLayoutDecorations = AllowsLayout(vstate, sc);
       }
       if (!allowLayoutDecorations) {
-        res = std::any_of(iter->second.begin(), iter->second.end(),
-            [](const Decoration& d) {
+        res = std::any_of(
+          iter->second.begin(), iter->second.end(), [](const Decoration& d) {
               return d.dec_type() == spv::Decoration::Block ||
                      d.dec_type() == spv::Decoration::BufferBlock ||
                      d.dec_type() == spv::Decoration::Offset ||

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1014,7 +1014,7 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
         }
         if (num_workgroup_variables_with_block > 1 &&
             num_workgroup_variables_with_block !=
-                num_workgroup_variables_with_aliased) {
+            num_workgroup_variables_with_aliased) {
           return vstate.diag(SPV_ERROR_INVALID_BINARY,
                              vstate.FindDef(entry_point))
                  << "When declaring WorkgroupMemoryExplicitLayoutKHR, "

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -2139,7 +2139,7 @@ bool UsesExplicitLayout(ValidationState_t& vstate, uint32_t type_id,
       }
       if (!allowLayoutDecorations) {
         res = std::any_of(
-          iter->second.begin(), iter->second.end(), [](const Decoration& d) {
+            iter->second.begin(), iter->second.end(), [](const Decoration& d) {
               return d.dec_type() == spv::Decoration::Block ||
                      d.dec_type() == spv::Decoration::BufferBlock ||
                      d.dec_type() == spv::Decoration::Offset ||

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10994,7 +10994,7 @@ OpReturn
 OpFunctionEnd
 )";
 
-  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_5);
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 


### PR DESCRIPTION
Closes #6028.

Layout decorations on ptr types of allowed storage class shouldn't be as explicit layout decorations of struct types that uses it.