### PR TITLE
split-combined-image-sampler: synthesize names

### DIFF
--- a/source/opt/split_combined_image_sampler_pass.h
+++ b/source/opt/split_combined_image_sampler_pass.h
@@ -87,6 +87,11 @@ class SplitCombinedImageSamplerPass : public Pass {
     return ptr_ty->GetSingleWordInOperand(1);
   }
 
+  // Creates a new OpName instruction mapping the given name to the given
+  // string, and adds it to the module at the end of the OpName and OpMemberName
+  // section.
+  void AddOpName(uint32_t id, const std::string& name);
+
   // Cached from the IRContext. Valid while Process() is running.
   analysis::DefUseManager* def_use_mgr_ = nullptr;
   // Cached from the IRContext. Valid while Process() is running.

--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -43,6 +43,7 @@ namespace utils {
 template <class T, size_t small_size>
 class SmallVector {
  public:
+  using value_type = T;
   using iterator = T*;
   using const_iterator = const T*;
 

--- a/source/util/string_utils.h
+++ b/source/util/string_utils.h
@@ -17,12 +17,11 @@
 
 #include <assert.h>
 
+#include <cstdint>
 #include <cstring>
 #include <sstream>
 #include <string>
 #include <vector>
-
-#include "source/util/string_utils.h"
 
 namespace spvtools {
 namespace utils {
@@ -48,8 +47,9 @@ std::pair<std::string, std::string> SplitFlagArgs(const std::string& flag);
 
 // Encodes a string as a sequence of words, using the SPIR-V encoding, appending
 // to an existing vector.
-inline void AppendToVector(const std::string& input,
-                           std::vector<uint32_t>* result) {
+template <class VectorType = std::vector<uint32_t>>
+inline void AppendToVector(const std::string& input, VectorType* result) {
+  static_assert(std::is_same<uint32_t, typename VectorType::value_type>::value);
   uint32_t word = 0;
   size_t num_bytes = input.size();
   // SPIR-V strings are null-terminated.  The byte_index == num_bytes
@@ -70,8 +70,10 @@ inline void AppendToVector(const std::string& input,
 }
 
 // Encodes a string as a sequence of words, using the SPIR-V encoding.
-inline std::vector<uint32_t> MakeVector(const std::string& input) {
-  std::vector<uint32_t> result;
+template <class VectorType = std::vector<uint32_t>>
+inline VectorType MakeVector(const std::string& input) {
+  static_assert(std::is_same<uint32_t, typename VectorType::value_type>::value);
+  VectorType result;
   AppendToVector(input, &result);
   return result;
 }


### PR DESCRIPTION
If the original combined value has an OpName, then create names for the image and sampler parts by appending "_image" or "_sampler", respectively.

Bug: crbug.com/398231475