### PR TITLE
opt: add resolve-binding-conflicts pass

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -172,6 +172,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/remove_unused_interface_variables_pass.cpp \
 		source/opt/replace_desc_array_access_using_var_index.cpp \
 		source/opt/replace_invalid_opc.cpp \
+		source/opt/resolve_binding_conflicts_pass.cpp \
 		source/opt/scalar_analysis.cpp \
 		source/opt/scalar_analysis_simplification.cpp \
 		source/opt/scalar_replacement_pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -771,6 +771,8 @@ static_library("spvtools_opt") {
     "source/opt/replace_desc_array_access_using_var_index.h",
     "source/opt/replace_invalid_opc.cpp",
     "source/opt/replace_invalid_opc.h",
+    "source/opt/resolve_binding_conflicts_pass.cpp",
+    "source/opt/resolve_binding_conflicts_pass.h",
     "source/opt/scalar_analysis.cpp",
     "source/opt/scalar_analysis.h",
     "source/opt/scalar_analysis_nodes.h",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -973,6 +973,55 @@ Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add);
 // parameters into separate image and sampler parts. Binding numbers and
 // other decorations are copied.
 Optimizer::PassToken CreateSplitCombinedImageSamplerPass();
+
+// Creates a pass to remap bindings to avoid conflicts, assuming the module
+// is valid for Vulkan.  A conflict exits when an entry point uses two distinct
+// variables with the same descriptor set and binding.  Vulkan allows one kind
+// of conflict: when one varible is an image (or array of images), and the
+// other is a sampler (or an array of samplers).
+
+// Conflicts are eliminated by incrementing the binding number of the sampler
+// part, and then propagating that increment through variables with
+// higher-numbered bindings until no conflict remains. This handles the case
+// when multiple shaders may share the same resource variables; this can
+// introduce holes in binding slots.
+//
+// Here's an example where shaders Alpha, Beta, Gamma, Delta collectively use
+// resource variables %100, %101, %102, %103, %104 all with the same
+// DescriptorSet and with Bindings as in the following table:
+//
+// Before:
+//
+//   Binding:   0          1        2        3
+//   Alpha:    %100,%101
+//   Beta:     %100       %102
+//   Gamma:               %102     %103
+//   Delta:                        %103     %104
+//
+// The Alpha shader has a conflict where variables %100, %101 have the same
+// descriptor set and binding.  If %100 is a sampler resource variable, then
+// the conflict is resolved by incrementing the binding number on %100 from 0
+// to 1.  But this causes a new confict for shader Beta because it now uses
+// both %100 and %102 with binding number 1.  That conflict is resolved by
+// incrementing the binding number on its variable that originally appeared
+// second (i.e. %102), so %102 gets binding 2. This now produces a conflict
+// for Gamma between %102 and %103 using binding number 2. Since %103 originally
+// appeared second (in the view from Gamma), the algorithm bumps %103 to binding
+// number %103. Now Delta has a conflict between %103 and %104, resulting in
+// %104 getting the next binding number, 4.  The picture afterward is:
+//
+// After:
+//
+//   Binding:   0          1        2        3        4
+//   Alpha:    %101       %100
+//   Beta:                %100     %102
+//   Gamma:                        %102     %103
+//   Delta:                                 %103     %104
+//
+//
+// This pass assumes binding numbers are not applid via decoration groups
+// (OpDecorationGroup).
+Optimizer::PassToken CreateResolveBindingConflictsPass();
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   remove_unused_interface_variables_pass.h
   replace_desc_array_access_using_var_index.h
   replace_invalid_opc.h
+  resolve_binding_conflicts_pass.h
   scalar_analysis.h
   scalar_analysis_nodes.h
   scalar_replacement_pass.h
@@ -226,6 +227,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   remove_unused_interface_variables_pass.cpp
   replace_desc_array_access_using_var_index.cpp
   replace_invalid_opc.cpp
+  resolve_binding_conflicts_pass.cpp
   scalar_analysis.cpp
   scalar_analysis_simplification.cpp
   scalar_replacement_pass.cpp

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -639,6 +639,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag,
     RegisterPass(CreateTrimCapabilitiesPass());
   } else if (pass_name == "split-combined-image-sampler") {
     RegisterPass(CreateSplitCombinedImageSamplerPass());
+  } else if (pass_name == "resolve-binding-conflicts") {
+    RegisterPass(CreateResolveBindingConflictsPass());
   } else {
     Errorf(consumer(), nullptr, {},
            "Unknown flag '--%s'. Use --help for a list of valid flags",
@@ -1193,6 +1195,11 @@ Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass() {
 Optimizer::PassToken CreateSplitCombinedImageSamplerPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::SplitCombinedImageSamplerPass>());
+}
+
+Optimizer::PassToken CreateResolveBindingConflictsPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::ResolveBindingConflictsPass>());
 }
 
 }  // namespace spvtools

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -74,6 +74,7 @@
 #include "source/opt/remove_unused_interface_variables_pass.h"
 #include "source/opt/replace_desc_array_access_using_var_index.h"
 #include "source/opt/replace_invalid_opc.h"
+#include "source/opt/resolve_binding_conflicts_pass.h"
 #include "source/opt/scalar_replacement_pass.h"
 #include "source/opt/set_spec_constant_default_value_pass.h"
 #include "source/opt/simplification_pass.h"

--- a/source/opt/resolve_binding_conflicts_pass.cpp
+++ b/source/opt/resolve_binding_conflicts_pass.cpp
@@ -1,0 +1,328 @@
+// Copyright (c) 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/resolve_binding_conflicts_pass.h"
+
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "source/opt/decoration_manager.h"
+#include "source/opt/def_use_manager.h"
+#include "source/opt/instruction.h"
+#include "source/opt/ir_builder.h"
+#include "source/opt/ir_context.h"
+#include "spirv/unified1/spirv.h"
+
+namespace spvtools {
+namespace opt {
+
+// A VarBindingInfo contains the binding information for a single resource
+// variable.
+//
+// Exactly one such object is created per resource variable in the
+// module. In particular, when a resource variable is statically used by
+// more than one entry point, those entry points share the same VarBindingInfo
+// object for that variable.
+struct VarBindingInfo {
+  const Instruction* const var;
+  const uint32_t descriptor_set;
+  Instruction* const binding_decoration;
+
+  // Returns the binding number.
+  uint32_t binding() const {
+    return binding_decoration->GetSingleWordInOperand(2);
+  }
+  // Sets the binding number to 'b'.
+  void updateBinding(uint32_t b) { binding_decoration->SetOperand(2, {b}); }
+};
+
+// The bindings in the same descriptor set that are used by an entry point.
+using BindingList = std::vector<VarBindingInfo*>;
+// A map from descriptor set number to the list of bindings in that descriptor
+// set, as used by a particular entry point.
+using DescriptorSets = std::unordered_map<uint32_t, BindingList>;
+
+IRContext::Analysis ResolveBindingConflictsPass::GetPreservedAnalyses() {
+  // All analyses are kept up to date.
+  // At most this modifies the Binding numbers on variables.
+  return IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping |
+         IRContext::kAnalysisDecorations | IRContext::kAnalysisCombinators |
+         IRContext::kAnalysisCFG | IRContext::kAnalysisDominatorAnalysis |
+         IRContext::kAnalysisLoopAnalysis | IRContext::kAnalysisNameMap |
+         IRContext::kAnalysisScalarEvolution |
+         IRContext::kAnalysisRegisterPressure |
+         IRContext::kAnalysisValueNumberTable |
+         IRContext::kAnalysisStructuredCFG | IRContext::kAnalysisBuiltinVarId |
+         IRContext::kAnalysisIdToFuncMapping | IRContext::kAnalysisConstants |
+         IRContext::kAnalysisTypes | IRContext::kAnalysisDebugInfo |
+         IRContext::kAnalysisLiveness;
+}
+
+// Orders variable binding info objects.
+// * The binding number is most signficant;
+// * Then a sampler-like object compares greater than non-sampler like object.
+// * Otherwise compare based on variable ID.
+// This provides a total order among bindings in a descriptor set for a valid
+// Vulkan module.
+bool Less(const VarBindingInfo* const lhs, const VarBindingInfo* const rhs) {
+  if (lhs->binding() < rhs->binding()) return true;
+  if (lhs->binding() > rhs->binding()) return false;
+
+  // Examine types.
+  // In valid Vulkan the only conflict can occur between
+  // images and samplers.  We only care about a specific
+  // comparison when one is a image-like thing and the other
+  // is a sampler-like thing of the same shape.  So unwrap
+  // types until we hit one of those two.
+
+  auto* def_use_mgr = lhs->var->context()->get_def_use_mgr();
+
+  // Returns the type found by iteratively following pointer pointee type,
+  // or array element type.
+  auto unwrap = [&def_use_mgr](Instruction* ty) {
+    bool keep_going = true;
+    do {
+      switch (ty->opcode()) {
+        case spv::Op::OpTypePointer:
+          ty = def_use_mgr->GetDef(ty->GetSingleWordInOperand(1));
+          break;
+        case spv::Op::OpTypeArray:
+        case spv::Op::OpTypeRuntimeArray:
+          ty = def_use_mgr->GetDef(ty->GetSingleWordInOperand(0));
+          break;
+        default:
+          keep_going = false;
+          break;
+      }
+    } while (keep_going);
+    return ty;
+  };
+
+  auto* lhs_ty = unwrap(def_use_mgr->GetDef(lhs->var->type_id()));
+  auto* rhs_ty = unwrap(def_use_mgr->GetDef(rhs->var->type_id()));
+  if (lhs_ty->opcode() == rhs_ty->opcode()) {
+    // Pick based on variable ID.
+    return lhs->var->result_id() < rhs->var->result_id();
+  }
+  // A sampler is always greater than an image.
+  if (lhs_ty->opcode() == spv::Op::OpTypeSampler) {
+    return false;
+  }
+  if (rhs_ty->opcode() == spv::Op::OpTypeSampler) {
+    return true;
+  }
+  // Pick based on variable ID.
+  return lhs->var->result_id() < rhs->var->result_id();
+}
+
+// Summarizes the caller-callee relationships between functions in a module.
+class CallGraph {
+ public:
+  // Returns the list of all functions statically reachable from entry points,
+  // where callees precede callers.
+  const std::vector<uint32_t>& CalleesBeforeCallers() const {
+    return visit_order_;
+  }
+  // Returns the list functions called from a given function.
+  const std::unordered_set<uint32_t>& Callees(uint32_t caller) {
+    return calls_[caller];
+  }
+
+  CallGraph(IRContext& context) {
+    // Populate calls_.
+    std::queue<uint32_t> callee_queue;
+    for (const auto& fn : *context.module()) {
+      auto& callees = calls_[fn.result_id()];
+      context.AddCalls(&fn, &callee_queue);
+      while (!callee_queue.empty()) {
+        callees.insert(callee_queue.front());
+        callee_queue.pop();
+      }
+    }
+
+    // Perform depth-first search, starting from each entry point.
+    // Populates visit_order_.
+    for (const auto& ep : context.module()->entry_points()) {
+      Visit(ep.GetSingleWordInOperand(1));
+    }
+  }
+
+ private:
+  // Visits a function, recursively visiting its callees. Adds this ID
+  // to the visit_order after all callees have been visited.
+  void Visit(uint32_t func_id) {
+    if (visited_.count(func_id)) {
+      return;
+    }
+    visited_.insert(func_id);
+    for (auto callee_id : calls_[func_id]) {
+      Visit(callee_id);
+    }
+    visit_order_.push_back(func_id);
+  }
+
+  // Maps the ID of a function to the IDs of functions it calls.
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>> calls_;
+
+  // IDs of visited functions;
+  std::unordered_set<uint32_t> visited_;
+  // IDs of functions, where callees precede callers.
+  std::vector<uint32_t> visit_order_;
+};
+
+// Returns vector binding info for all resource variables in the module.
+auto GetVarBindings(IRContext& context) {
+  std::vector<VarBindingInfo> vars;
+  auto* deco_mgr = context.get_decoration_mgr();
+  for (auto& inst : context.module()->types_values()) {
+    if (inst.opcode() == spv::Op::OpVariable) {
+      Instruction* descriptor_set_deco = nullptr;
+      Instruction* binding_deco = nullptr;
+      for (auto* deco : deco_mgr->GetDecorationsFor(inst.result_id(), false)) {
+        switch (static_cast<spv::Decoration>(deco->GetSingleWordInOperand(1))) {
+          case spv::Decoration::DescriptorSet:
+            assert(!descriptor_set_deco);
+            descriptor_set_deco = deco;
+            break;
+          case spv::Decoration::Binding:
+            assert(!binding_deco);
+            binding_deco = deco;
+            break;
+          default:
+            break;
+        }
+      }
+      if (descriptor_set_deco && binding_deco) {
+        vars.push_back({&inst, descriptor_set_deco->GetSingleWordInOperand(2),
+                        binding_deco});
+      }
+    }
+  }
+  return vars;
+}
+
+// Merges the bindings from source into sink. Maintains order and uniqueness
+// within a list of bindings.
+void Merge(DescriptorSets& sink, const DescriptorSets& source) {
+  for (auto index_and_bindings : source) {
+    const uint32_t index = index_and_bindings.first;
+    const BindingList& src1 = index_and_bindings.second;
+    const BindingList& src2 = sink[index];
+    BindingList merged;
+    merged.resize(src1.size() + src2.size());
+    auto merged_end = std::merge(src1.begin(), src1.end(), src2.begin(),
+                                 src2.end(), merged.begin(), Less);
+    auto unique_end = std::unique(merged.begin(), merged_end);
+    merged.resize(unique_end - merged.begin());
+    sink[index] = std::move(merged);
+  }
+}
+
+// Resolves conflicts within this binding list, so the binding number on an
+// item is at least one more than the binding number on the previous item.
+// When this does not yet hold, increase the binding number on the second
+// item in the pair. Returns true if any changes were applied.
+bool ResolveConflicts(BindingList& bl) {
+  bool changed = false;
+  for (size_t i = 1; i < bl.size(); i++) {
+    const auto prev_num = bl[i - 1]->binding();
+    if (prev_num >= bl[i]->binding()) {
+      bl[i]->updateBinding(prev_num + 1);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+Pass::Status ResolveBindingConflictsPass::Process() {
+  // Assumes the descriptor set and binding decorations are not provided
+  // via decoration groups.  Decoration groups were deprecated in SPIR-V 1.3
+  // Revision 6.  I have not seen any compiler generate them. --dneto
+
+  auto vars = GetVarBindings(*context());
+
+  // Maps a function ID to the variables used directly or indirectly by the
+  // function, organized into descriptor sets. Each descriptor set
+  // consists of a BindingList of distinct variables.
+  std::unordered_map<uint32_t, DescriptorSets> used_vars;
+
+  // Determine variables directly used by functions.
+  auto* def_use_mgr = context()->get_def_use_mgr();
+  for (auto& var : vars) {
+    std::unordered_set<uint32_t> visited_functions_for_var;
+    def_use_mgr->ForEachUser(var.var, [&](Instruction* user) {
+      if (auto* block = context()->get_instr_block(user)) {
+        auto* fn = block->GetParent();
+        assert(fn);
+        const auto fn_id = fn->result_id();
+        if (visited_functions_for_var.insert(fn_id).second) {
+          used_vars[fn_id][var.descriptor_set].push_back(&var);
+        }
+      }
+    });
+  }
+
+  // Sort within a descriptor set by binding number.
+  for (auto& sets_for_fn : used_vars) {
+    for (auto& ds : sets_for_fn.second) {
+      BindingList& bindings = ds.second;
+      std::stable_sort(bindings.begin(), bindings.end(), Less);
+    }
+  }
+
+  // Propagate from callees to callers.
+  CallGraph call_graph(*context());
+  for (const uint32_t caller : call_graph.CalleesBeforeCallers()) {
+    DescriptorSets& caller_ds = used_vars[caller];
+    for (const uint32_t callee : call_graph.Callees(caller)) {
+      Merge(caller_ds, used_vars[callee]);
+    }
+  }
+
+  // At this point, the descriptor sets associated with each entry point
+  // capture exactly the set of resource variables statically used
+  // by the static call tree of that entry point.
+
+  // Resolve conflicts.
+  // VarBindingInfo objects may be shared between the bindings lists.
+  // Updating a binding in one list can require updating another list later.
+  // So repeat updates until settling.
+
+  // The union of BindingLists across all entry points.
+  std::vector<BindingList*> ep_bindings;
+
+  for (auto& ep : context()->module()->entry_points()) {
+    for (auto& ds : used_vars[ep.GetSingleWordInOperand(1)]) {
+      BindingList& bindings = ds.second;
+      ep_bindings.push_back(&bindings);
+    }
+  }
+  bool modified = false;
+  bool found_conflict;
+  do {
+    found_conflict = false;
+    for (BindingList* bl : ep_bindings) {
+      found_conflict |= ResolveConflicts(*bl);
+    }
+    modified |= found_conflict;
+  } while (found_conflict);
+
+  return modified ? Pass::Status::SuccessWithChange
+                  : Pass::Status::SuccessWithoutChange;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/resolve_binding_conflicts_pass.h
+++ b/source/opt/resolve_binding_conflicts_pass.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_RESOLVE_BINDING_CONFLICTS_PASS_H_
+#define LIBSPIRV_OPT_RESOLVE_BINDING_CONFLICTS_PASS_H_
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "source/diagnostic.h"
+#include "source/opt/pass.h"
+#include "source/util/small_vector.h"
+
+namespace spvtools {
+namespace opt {
+class ResolveBindingConflictsPass : public Pass {
+ public:
+  virtual ~ResolveBindingConflictsPass() override = default;
+  const char* name() const override { return "resolve-binding-conflicts"; }
+  IRContext::Analysis GetPreservedAnalyses() override;
+  Status Process() override;
+};
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_RESOLVE_BINDING_CONFLICTS_PASS_H_

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -94,6 +94,7 @@ add_spvtools_unittest(TARGET opt
        relax_float_ops_test.cpp
        replace_desc_array_access_using_var_index_test.cpp
        replace_invalid_opc_test.cpp
+       resolve_binding_conflicts_pass_test.cpp
        scalar_analysis.cpp
        scalar_replacement_test.cpp
        set_spec_const_default_value_test.cpp

--- a/test/opt/resolve_binding_conflicts_pass_test.cpp
+++ b/test/opt/resolve_binding_conflicts_pass_test.cpp
@@ -1,0 +1,864 @@
+// Copyright (c) 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <ostream>
+
+#include "spirv-tools/optimizer.hpp"
+#include "test/opt/pass_fixture.h"
+#include "test/opt/pass_utils.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+
+struct ResolveBindingConflictsTest : public PassTest<::testing::Test> {
+  virtual void SetUp() override {
+    SetTargetEnv(SPV_ENV_VULKAN_1_1);  // allow storage buffer storage class
+                                       // without extension.
+    SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+    SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES |
+                          SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                          SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
+  }
+};
+
+using StringList = std::vector<std::string>;
+std::string EntryPointDecls(const StringList& names) {
+  std::ostringstream os;
+  for (auto& name : names) {
+    os << "               OpEntryPoint GLCompute %" + name + " \"" + name +
+              "\"\n";
+  }
+  for (auto& name : names) {
+    os << "               OpExecutionMode %" + name + " LocalSize 1 1 1\n";
+  }
+  for (auto& name : names) {
+    os << "               OpName %" + name + " \"" + name + "\"\n";
+  }
+  return os.str();
+}
+
+std::string Preamble(const StringList& names = {"main"}) {
+  return R"(               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+)" + EntryPointDecls(names) +
+         R"(               OpName %voidfn "voidfn"
+               OpName %s_ty "s_ty"
+               OpName %i_ty "i_ty"
+               OpName %si_ty "si_ty"
+               OpName %p_s_ty "p_s_ty"
+               OpName %p_i_ty "p_i_ty"
+               OpName %p_si_ty "p_si_ty"
+               OpName %st_ty "st_ty"
+               OpName %pu_st_ty "pu_st_ty"
+               OpName %pb_st_ty "pb_st_ty"
+)";
+}
+
+std::string BasicTypes() {
+  return R"(               OpDecorate %st_ty Block
+               OpMemberDecorate %st_ty 0 Offset 0
+      %float = OpTypeFloat 32
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_3 = OpConstant %uint 3
+       %void = OpTypeVoid
+     %voidfn = OpTypeFunction %void
+       %s_ty = OpTypeSampler
+       %i_ty = OpTypeImage %float 2D 0 0 0 1 Unknown
+      %si_ty = OpTypeSampledImage %i_ty
+     %p_i_ty = OpTypePointer UniformConstant %i_ty
+     %p_s_ty = OpTypePointer UniformConstant %s_ty
+    %p_si_ty = OpTypePointer UniformConstant %si_ty
+      %st_ty = OpTypeStruct %uint
+   %pu_st_ty = OpTypePointer Uniform %st_ty
+   %pb_st_ty = OpTypePointer StorageBuffer %st_ty
+)";
+}
+std::string NoCheck() { return "; CHECK-NOT: nothing to see"; }
+
+TEST_F(ResolveBindingConflictsTest, NoBindings_NoChange) {
+  const std::string kTest = Preamble() + BasicTypes() +
+                            R"(       %main = OpFunction %void None %voidfn
+        %100 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest + NoCheck(), /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithoutChange);
+  EXPECT_EQ(kTest, disasm);
+}
+
+TEST_F(ResolveBindingConflictsTest, NoConflict_UnusedVars_NoChange) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 0
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 0
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 0
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 0
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 0
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 0
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 0
+
+)" + BasicTypes() + R"(
+
+ ; Unused variables
+
+        %100 = OpVariable %p_i_ty UniformConstant  ; image
+        %101 = OpVariable %p_s_ty UniformConstant  ; sampler
+        %102 = OpVariable %pu_st_ty Uniform        ; UBO
+        %103 = OpVariable %pb_st_ty StorageBuffer  ; SSBO
+        %104 = OpVariable %p_si_ty UniformConstant ; combined sampled image
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithoutChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest, NoConflict_UsedVars_NoChange) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 1
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 2
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 3
+               OpDecorate %110 DescriptorSet 1
+               OpDecorate %110 Binding 0
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 0
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 1
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %110 DescriptorSet 1
+      ; CHECK: OpDecorate %110 Binding 0
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_i_ty UniformConstant  ; image
+        %101 = OpVariable %p_s_ty UniformConstant  ; sampler
+        %102 = OpVariable %pu_st_ty Uniform        ; UBO
+        %103 = OpVariable %pb_st_ty StorageBuffer  ; SSBO
+        %110 = OpVariable %p_si_ty UniformConstant ; combined sampled image
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_i_ty %100
+         %12 = OpCopyObject %p_s_ty %101
+         %13 = OpCopyObject %pu_st_ty %102
+         %14 = OpCopyObject %pb_st_ty %103
+         %15 = OpCopyObject %p_si_ty %110
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithoutChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       OneEntryPoint_SamplerFirstConflict_Resolves) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+
+      ; The sampler's binding number is incremented, even when listed first.
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; sampler listed first
+        %101 = OpVariable %p_i_ty UniformConstant
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_s_ty %100
+         %12 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       OneEntryPoint_SamplerSecondConflict_Resolves) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+
+      ; The sampler's binding number is incremented, even when listed second.
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 0
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 1
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_i_ty UniformConstant
+        %101 = OpVariable %p_s_ty UniformConstant ; sampler listed second
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_i_ty %100
+         %12 = OpCopyObject %p_s_ty %101
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest, OneEntryPoint_Conflict_Ripples) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 2
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 3
+
+      ; The sampler's binding number is incremented, and later
+      ; bindings move out of the way.
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; sampler comes first
+        %101 = OpVariable %p_i_ty UniformConstant
+        %102 = OpVariable %pu_st_ty Uniform
+        %103 = OpVariable %pb_st_ty StorageBuffer
+        %104 = OpVariable %p_si_ty UniformConstant
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_s_ty %100
+         %12 = OpCopyObject %p_i_ty %101
+         %13 = OpCopyObject %pu_st_ty %102
+         %14 = OpCopyObject %pb_st_ty %103
+         %15 = OpCopyObject %p_si_ty %104
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       OneEntryPoint_Conflict_RippleStopsAtFirstHole) {
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               ; Leave a hole at (0, 2)
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 3
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 4
+
+      ; There was a hole at binding 2.  The ripple stops there.
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; sampler comes first
+        %101 = OpVariable %p_i_ty UniformConstant
+        %102 = OpVariable %pu_st_ty Uniform
+        %103 = OpVariable %pb_st_ty StorageBuffer
+        %104 = OpVariable %p_si_ty UniformConstant
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_s_ty %100
+         %12 = OpCopyObject %p_i_ty %101
+         %13 = OpCopyObject %pu_st_ty %102
+         %14 = OpCopyObject %pb_st_ty %103
+         %15 = OpCopyObject %p_si_ty %104
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest, OneEntryPoint_MultiConflict_Resolves) {
+  const std::string kTest = Preamble() +
+                            R"(
+      ; Two conflicts: at Bindings 0, and 1
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 1
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 2
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; sampler first
+        %101 = OpVariable %p_i_ty UniformConstant
+        %102 = OpVariable %p_i_ty UniformConstant
+        %103 = OpVariable %p_s_ty UniformConstant ; sampler second
+        %104 = OpVariable %pu_st_ty Uniform
+
+       %main = OpFunction %void None %voidfn
+         %10 = OpLabel
+         %11 = OpCopyObject %p_s_ty %100
+         %12 = OpCopyObject %p_i_ty %101
+         %13 = OpCopyObject %p_i_ty %102
+         %14 = OpCopyObject %p_s_ty %103
+         %15 = OpCopyObject %pu_st_ty %104
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       OneEntryPoint_MultiConflict_ComplexCallGraph_Resolves) {
+  // Check that uses are seen even when used at various points in a complex call
+  // graph.
+  const std::string kTest = Preamble() +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 1
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 2
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; used in %200
+        %101 = OpVariable %p_i_ty UniformConstant ; used in %300, %400
+        %102 = OpVariable %p_i_ty UniformConstant ; used in %500
+        %103 = OpVariable %p_s_ty UniformConstant ; used in %400 twice
+        %104 = OpVariable %pu_st_ty Uniform       ; used in %600
+
+        %200 = OpFunction %void None %voidfn
+        %201 = OpLabel
+        %202 = OpCopyObject %p_s_ty %100
+               OpReturn
+               OpFunctionEnd
+
+        %300 = OpFunction %void None %voidfn
+        %301 = OpLabel
+        %302 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+
+        %400 = OpFunction %void None %voidfn
+        %401 = OpLabel
+        %402 = OpFunctionCall %void %200
+        %403 = OpCopyObject %p_s_ty %103
+        %404 = OpCopyObject %p_i_ty %101
+        %405 = OpCopyObject %p_s_ty %103
+        %406 = OpFunctionCall %void %300
+               OpReturn
+               OpFunctionEnd
+
+        %500 = OpFunction %void None %voidfn
+        %501 = OpLabel
+        %502 = OpFunctionCall %void %400
+        %503 = OpCopyObject %p_i_ty %102
+        %504 = OpFunctionCall %void %300
+               OpReturn
+               OpFunctionEnd
+
+        %600 = OpFunction %void None %voidfn
+        %601 = OpLabel
+        %602 = OpFunctionCall %void %300
+        %603 = OpFunctionCall %void %500
+        %604 = OpCopyObject %pu_st_ty %104
+               OpReturn
+               OpFunctionEnd
+
+       %main = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpFunctionCall %void %600
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       MultiEntryPoint_DuplicatConflicts_ResolvesOnlyOnce) {
+  // Before:
+  //
+  //   Binding:   0          1
+  //   Alpha:    %100,%101
+  //   Beta:     %100,%101
+  //
+  // After:
+  //
+  //   Binding:   0          1
+  //   Alpha:    %101       %100
+  //   Beta:     %101       %100
+  const std::string kTest = Preamble({"alpha", "beta"}) +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant
+        %101 = OpVariable %p_i_ty UniformConstant
+
+      %alpha = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpCopyObject %p_s_ty %100
+       %1002 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+
+       %beta = OpFunction %void None %voidfn
+       %2000 = OpLabel
+       %2001 = OpCopyObject %p_s_ty %100
+       %2002 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       MultiEntryPoint_IndependentConflicts_Resolves) {
+  // Before:
+  //
+  //   Binding:   0          1
+  //   Alpha:    %100,%101
+  //   Beta:     %102,%103
+  //
+  // After:
+  //
+  //   Binding:   0          1
+  //   Alpha:    %101       %100
+  //   Beta:     %102       %103
+  const std::string kTest = Preamble({"alpha", "beta"}) +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 0
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 0
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 0
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 1
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant
+        %101 = OpVariable %p_i_ty UniformConstant
+        %102 = OpVariable %p_i_ty UniformConstant
+        %103 = OpVariable %p_s_ty UniformConstant
+
+      %alpha = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpCopyObject %p_s_ty %100
+       %1002 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+
+       %beta = OpFunction %void None %voidfn
+       %2000 = OpLabel
+       %2001 = OpCopyObject %p_i_ty %102
+       %2002 = OpCopyObject %p_s_ty %103
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       MultiEntryPoint_SameVarConflictsAcrossMultiEntryPoints_Resolves) {
+  // A sampler variable is bumped, causing potential conflicts in other shaders.
+  //
+  // Before:
+  //
+  //   Binding:   0          1        2
+  //   Alpha:    %100,%101
+  //   Beta:     %100       %102
+  //   Gamma:    %100                %103
+  //
+  // After:
+  //
+  //   Binding:   0          1        2
+  //   Alpha:    %101       %100
+  //   Beta:                %100     %102
+  //   Gamma:    %100                %103
+  //
+  const std::string kTest = Preamble({"alpha", "beta", "gamma"}) +
+                            R"(
+               OpDecorate %100 DescriptorSet 0  ; The sampler
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 2
+
+      ; bumped once
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+
+      ; pushed back from bump of %100
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+
+      ; does not need to be bumped
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 2
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant ; used in alpha, beta, gamma
+        %101 = OpVariable %p_i_ty UniformConstant ; used in alpha
+        %102 = OpVariable %pu_st_ty Uniform       ; used in beta
+        %103 = OpVariable %pb_st_ty StorageBuffer ; used in gamma
+
+      %alpha = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpCopyObject %p_s_ty %100
+       %1002 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+
+       %beta = OpFunction %void None %voidfn
+       %2000 = OpLabel
+       %2001 = OpCopyObject %p_s_ty %100
+       %2002 = OpCopyObject %pu_st_ty %102
+               OpReturn
+               OpFunctionEnd
+
+      %gamma = OpFunction %void None %voidfn
+       %3000 = OpLabel
+       %3001 = OpCopyObject %p_s_ty %100
+       %3002 = OpCopyObject %pb_st_ty %103
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest, MultiEntryPoint_ConflictCascade_Resolves) {
+  // Before:
+  //
+  //   Binding:   0          1        2        3
+  //   Alpha:    %100,%101
+  //   Beta:     %100       %102
+  //   Gamma:               %102     %103
+  //   Delta:                        %103     %104
+  //
+  // After:
+  //
+  //   Binding:   0          1        2        3        4
+  //   Alpha:    %101       %100
+  //   Beta:                %100     %102
+  //   Gamma:                        %102     %103
+  //   Delta:                                 %103     %104
+  //
+  const std::string kTest = Preamble({"alpha", "beta", "gamma", "delta"}) +
+                            R"(
+               OpDecorate %100 DescriptorSet 0  ; The sampler
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 2
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 3
+
+      ; %100 is bumped once:
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 1
+
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 0
+
+      ; pushed back from bump of %100
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+
+      ; pushed back from bump of %102
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+
+      ; pushed back from bump of %103
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_s_ty UniformConstant  ; used in alpha, beta
+        %101 = OpVariable %p_i_ty UniformConstant  ; used in alpha
+        %102 = OpVariable %pu_st_ty Uniform        ; used in beta, gamma
+        %103 = OpVariable %pb_st_ty StorageBuffer  ; used in gamma, delta
+        %104 = OpVariable %p_si_ty UniformConstant ; used delta
+
+      %alpha = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpCopyObject %p_s_ty %100
+       %1002 = OpCopyObject %p_i_ty %101
+               OpReturn
+               OpFunctionEnd
+
+       %beta = OpFunction %void None %voidfn
+       %2000 = OpLabel
+       %2001 = OpCopyObject %p_s_ty %100
+       %2002 = OpCopyObject %pu_st_ty %102
+               OpReturn
+               OpFunctionEnd
+
+      %gamma = OpFunction %void None %voidfn
+       %3000 = OpLabel
+       %3001 = OpCopyObject %pu_st_ty %102
+       %3002 = OpCopyObject %pb_st_ty %103
+               OpReturn
+               OpFunctionEnd
+
+      %delta = OpFunction %void None %voidfn
+       %4000 = OpLabel
+       %4001 = OpCopyObject %pb_st_ty %103
+       %4002 = OpCopyObject %p_si_ty %104
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+TEST_F(ResolveBindingConflictsTest,
+       MultiEntryPoint_ConflictCascade_RevisitEntryPoint) {
+  // Prove that the settling algorithm knows to revisit entry points that
+  // already had all their own conflicts resolved.
+  //
+  // Before:
+  //
+  //   Binding:   0          1       2        3       4
+  //   Alpha:    %100,%101          %103     %104    %105
+  //   Beta:          %101  %102    %103             %105
+  //
+  // After:
+  //
+  //   Binding:    0         1       2        3       4       5
+  //   Alpha:    %100       %101             %103    %104    %105
+  //   Beta:                %101    %102     %103            %105
+  const std::string kTest = Preamble({"alpha", "beta"}) +
+                            R"(
+               OpDecorate %100 DescriptorSet 0
+               OpDecorate %100 Binding 0
+               OpDecorate %101 DescriptorSet 0 ; the sampler
+               OpDecorate %101 Binding 0
+               OpDecorate %102 DescriptorSet 0
+               OpDecorate %102 Binding 1
+               OpDecorate %103 DescriptorSet 0
+               OpDecorate %103 Binding 2
+               OpDecorate %104 DescriptorSet 0
+               OpDecorate %104 Binding 3
+               OpDecorate %105 DescriptorSet 0
+               OpDecorate %105 Binding 4
+
+      ; CHECK: OpDecorate %100 DescriptorSet 0
+      ; CHECK: OpDecorate %100 Binding 0
+      ; CHECK: OpDecorate %101 DescriptorSet 0
+      ; CHECK: OpDecorate %101 Binding 1
+      ; CHECK: OpDecorate %102 DescriptorSet 0
+      ; CHECK: OpDecorate %102 Binding 2
+      ; CHECK: OpDecorate %103 DescriptorSet 0
+      ; CHECK: OpDecorate %103 Binding 3
+      ; CHECK: OpDecorate %104 DescriptorSet 0
+      ; CHECK: OpDecorate %104 Binding 4
+      ; CHECK: OpDecorate %105 DescriptorSet 0
+      ; CHECK: OpDecorate %105 Binding 5
+
+)" + BasicTypes() + R"(
+
+        %100 = OpVariable %p_i_ty UniformConstant
+        %101 = OpVariable %p_s_ty UniformConstant
+        %102 = OpVariable %pu_st_ty Uniform
+        %103 = OpVariable %pb_st_ty StorageBuffer
+        %104 = OpVariable %p_si_ty UniformConstant
+        %105 = OpVariable %p_s_ty UniformConstant
+
+      %alpha = OpFunction %void None %voidfn
+       %1000 = OpLabel
+       %1001 = OpCopyObject %p_i_ty %100
+       %1002 = OpCopyObject %p_s_ty %101
+       %1003 = OpCopyObject %pb_st_ty %103
+       %1004 = OpCopyObject %p_si_ty %104
+       %1005 = OpCopyObject %p_s_ty %105
+               OpReturn
+               OpFunctionEnd
+
+       %beta = OpFunction %void None %voidfn
+       %2000 = OpLabel
+       %2001 = OpCopyObject %p_s_ty %101
+       %2002 = OpCopyObject %pu_st_ty %102
+       %2003 = OpCopyObject %pb_st_ty %103
+       %2004 = OpCopyObject %p_s_ty %105
+               OpReturn
+               OpFunctionEnd
+)";
+
+  auto [disasm, status] = SinglePassRunAndMatch<ResolveBindingConflictsPass>(
+      kTest, /* do_validation= */ true);
+  EXPECT_EQ(status, Pass::Status::SuccessWithChange) << disasm;
+}
+
+}  // namespace
+}  // namespace opt
+}  // namespace spvtools

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -455,15 +455,21 @@ Options (in lexicographical order):)",
                instructions.)");
   printf(R"(
   --remove-unused-interface-variables
-               Removes variables referenced on the |OpEntryPoint| instruction 
-               that are not referenced in the entry point function or any function 
-               in its call tree.  Note that this could cause the shader interface 
+               Removes variables referenced on the |OpEntryPoint| instruction
+               that are not referenced in the entry point function or any function
+               in its call tree.  Note that this could cause the shader interface
                to no longer match other shader stages.)");
   printf(R"(
   --replace-invalid-opcode
                Replaces instructions whose opcode is valid for shader modules,
                but not for the current shader stage.  To have an effect, all
                entry points must have the same execution model.)");
+  printf(R"(
+  --resolve-binding-conflicts
+               Renumber bindings to avoid conflicts.
+               When an image and sampler share the same desriptor set and binding,
+               increment the binding number of the sampler. Recursively ripple
+               to higher-numbered bindings until all conflicts resolved resolved.)");
   printf(R"(
   --ssa-rewrite
                Replace loads and stores to function local variables with


### PR DESCRIPTION
Assumes the input is a valid Vulkan module.

A conflict exists when an entry point uses two variables with the same descriptor set and binding. Vulkan allows one kind of conflict: where the two variables are an image (array of images) variable and a sampler (array of samplers) variable.

The sampler variable's binding is incremented, and that increment ripples up through higher numbered bindings until no more conflicts remain.

Bug: crbug.com/398231475