### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -50,7 +50,7 @@ uint32_t InstructionFolder::UnaryOperate(spv::Op opcode,
       if (s_operand == std::numeric_limits<int32_t>::min()) {
         return s_operand;
       }
-      return -s_operand;
+      return static_cast<uint32_t>(-s_operand);
     }
     case spv::Op::OpNot:
       return ~operand;


### PR DESCRIPTION
Fixes: error: implicit conversion loses integer precision: 'int32_t' (aka 'int') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wimplicit-int-conversion]