### PR TITLE
opt: value numbering: preserve loads of image, sampler, sampled image

### DIFF
--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -45,26 +45,41 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
     return value;
   }
 
+  auto assign_new_number = [this](Instruction* i) {
+    const auto value = TakeNextValueNumber();
+    id_to_value_[i->result_id()] = value;
+    return value;
+  };
+
   // If the instruction has other side effects, then it must
   // have its own value number.
-  // OpSampledImage and OpImage must remain in the same basic block in which
-  // they are used, because of this we will assign each one it own value number.
   if (!context()->IsCombinatorInstruction(inst) &&
       !inst->IsCommonDebugInstr()) {
-    value = TakeNextValueNumber();
-    id_to_value_[inst->result_id()] = value;
-    return value;
+    return assign_new_number(inst);
   }
 
+  // OpSampledImage and OpImage must remain in the same basic block in which
+  // they are used, because of this we will assign each one it own value number.
   switch (inst->opcode()) {
     case spv::Op::OpSampledImage:
     case spv::Op::OpImage:
     case spv::Op::OpVariable:
-      value = TakeNextValueNumber();
-      id_to_value_[inst->result_id()] = value;
-      return value;
+      return assign_new_number(inst);
     default:
       break;
+  }
+
+  // A load that yields an image, sampler, or sampled image must remain in
+  // the same basic block.  So assign it its own value number.
+  if (inst->IsLoad()) {
+    switch (context()->get_def_use_mgr()->GetDef(inst->type_id())->opcode()) {
+      case spv::Op::OpTypeSampledImage:
+      case spv::Op::OpTypeImage:
+      case spv::Op::OpTypeSampler:
+        return assign_new_number(inst);
+      default:
+        break;
+    }
   }
 
   // If it is a load from memory that can be modified, we have to assume the
@@ -74,9 +89,7 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
   // read only.  However, if this is ever relaxed because we analyze stores, we
   // will have to add a new case for volatile loads.
   if (inst->IsLoad() && !inst->IsReadOnlyLoad()) {
-    value = TakeNextValueNumber();
-    id_to_value_[inst->result_id()] = value;
-    return value;
+    return assign_new_number(inst);
   }
 
   analysis::DecorationManager* dec_mgr = context()->get_decoration_mgr();

--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -46,9 +46,9 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
   }
 
   auto assign_new_number = [this](Instruction* i) {
-    const auto value = TakeNextValueNumber();
-    id_to_value_[i->result_id()] = value;
-    return value;
+    const auto new_value = TakeNextValueNumber();
+    id_to_value_[i->result_id()] = new_value;
+    return new_value;
   };
 
   // If the instruction has other side effects, then it must

--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -278,6 +278,23 @@ class PassTest : public TestT {
     }
   }
 
+  // Returns the disassembly of the current module. This is useful for
+  // debugging.
+  std::unique_ptr<opt::IRContext> AssembleModule(const std::string& text) {
+    return spvtools::BuildModule(env_, consumer_, text, assemble_options_);
+  }
+
+  // Returns the disassembly of the current module. This is useful for
+  // debugging.
+  std::string Disassemble(opt::Module* m) {
+    std::vector<uint32_t> binary;
+    m->ToBinary(&binary, /* skip_nop = */ false);
+    std::string disassembly;
+    SpirvTools tools(env_);
+    tools.Disassemble(binary, &disassembly, disassemble_options_);
+    return disassembly;
+  }
+
   void SetAssembleOptions(uint32_t assemble_options) {
     assemble_options_ = assemble_options;
   }

--- a/test/opt/redundancy_elimination_test.cpp
+++ b/test/opt/redundancy_elimination_test.cpp
@@ -359,6 +359,93 @@ OpFunctionEnd
   SinglePassRunAndCheck<RedundancyEliminationPass>(text, text, false);
 }
 
+TEST_F(RedundancyEliminationTest, PreserveLoadYieldingImage) {
+  // This is more strict than needed.
+  // This is sufficient to ensure that the load of an image
+  // occurs in the same basic block as its use.
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpName %main "main"
+               OpName %load_ty "load_ty"
+               OpDecorate %var DescriptorSet 0
+               OpDecorate %var Binding 0
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %load_ty = OpTypeImage %float 2D 0 0 0 2 Rgba32f
+%ptr_load_ty = OpTypePointer UniformConstant %load_ty
+        %var = OpVariable %ptr_load_ty UniformConstant
+       %main = OpFunction %void None %6
+       ; CHECK: OpLoad %load_ty
+       ; CHECK: OpLoad %load_ty
+         %15 = OpLabel
+         %16 = OpLoad %load_ty %var
+         %17 = OpLoad %load_ty %var
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<RedundancyEliminationPass>(text, false);
+}
+
+TEST_F(RedundancyEliminationTest, PreserveLoadYieldingSampler) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpName %main "main"
+               OpName %load_ty "load_ty"
+               OpDecorate %var DescriptorSet 0
+               OpDecorate %var Binding 0
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+    %load_ty = OpTypeSampler
+%ptr_load_ty = OpTypePointer UniformConstant %load_ty
+        %var = OpVariable %ptr_load_ty UniformConstant
+       %main = OpFunction %void None %6
+       ; CHECK: OpLoad %load_ty
+       ; CHECK: OpLoad %load_ty
+         %15 = OpLabel
+         %16 = OpLoad %load_ty %var
+         %17 = OpLoad %load_ty %var
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<RedundancyEliminationPass>(text, false);
+}
+
+TEST_F(RedundancyEliminationTest, PreserveLoadYieldingSampledImage) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginLowerLeft
+               OpName %main "main"
+               OpName %load_ty "load_ty"
+               OpDecorate %var DescriptorSet 0
+               OpDecorate %var Binding 0
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+       %i_ty = OpTypeImage %float 2D 0 0 0 2 Rgba32f
+    %load_ty = OpTypeSampledImage %i_ty
+%ptr_load_ty = OpTypePointer UniformConstant %load_ty
+        %var = OpVariable %ptr_load_ty UniformConstant
+       %main = OpFunction %void None %6
+       ; CHECK: OpLoad %load_ty
+       ; CHECK: OpLoad %load_ty
+         %15 = OpLabel
+         %16 = OpLoad %load_ty %var
+         %17 = OpLoad %load_ty %var
+               OpReturn
+               OpFunctionEnd
+  )";
+  SinglePassRunAndMatch<RedundancyEliminationPass>(text, false);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
Consider load yielding an image, sampler, or sampled image, to always have distinct value numbers.

This causes redundancy elimination avoid violating the 'single-block' rule:

	All OpSampledImage instructions, or instructions that load an
	image or sampler reference, must be in the same block in which
	their Result <id> are consumed.

Note that this is strictly more than necessary: it would be ok to eliminate loads when they occur in the same basic block. This patch follows precedent where different OpSampledImage instructions are always given different value numbers.

Fixed: #6054