### PR TITLE
[OPT] Delete decoration for OpPhi when unrolling

### DIFF
--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -560,6 +560,10 @@ void LoopUnrollerUtilsImpl::ReplaceInductionUseWithFinalValue(Loop* loop) {
   loop->GetInductionVariables(inductions);
 
   for (size_t index = 0; index < inductions.size(); ++index) {
+    // We don't want the decorations that applied to the induction variable
+    // to be applied to the value that replace it.
+    context_->KillNamesAndDecorates(state_.previous_phis_[index]);
+
     uint32_t trip_step_id = GetPhiDefID(state_.previous_phis_[index],
                                         state_.previous_latch_block_->id());
     context_->ReplaceAllUsesWith(inductions[index]->result_id(), trip_step_id);


### PR DESCRIPTION
When unrolling, the decorations on an OpPhi in the header of the loop
are treated like any other user outside of the loop. The id of the OpPhi
is replaced by the value in the final iteration. This causes the
decorations to be applied to this other value, which is not
neccessarially correct.

Contributes to https://github.com/microsoft/DirectXShaderCompiler/issues/6914
