### PR TITLE
spirv-val: Label new VUID from 312 headers

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -2282,6 +2282,7 @@ spv_result_t CheckInvalidVulkanExplicitLayout(ValidationState_t& vstate) {
     }
     if (fail_id != 0) {
       return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
+             << vstate.VkErrorID(10684)
              << "Invalid explicit layout decorations on type for operand "
              << vstate.getIdName(fail_id);
     }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2538,6 +2538,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-RuntimeSpirv-Offset-10213);
     case 10583:
       return VUID_WRAP(VUID-StandaloneSpirv-Component-10583);
+    case 10684:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-10684);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10741,6 +10741,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_5);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10790,6 +10792,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10843,6 +10847,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10873,6 +10879,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10901,6 +10909,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10933,6 +10943,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));
@@ -10959,6 +10971,8 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_0);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-10684"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Invalid explicit layout decorations on type for operand"));


### PR DESCRIPTION
Adds new `VUID-StandaloneSpirv-None-10684` VUID label from 1.4.312 headers