### PR TITLE
spirv-val: Restrict VUID 09557 to Vulkan environments

### DIFF
--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -130,10 +130,12 @@ spv_result_t check_interface_variable(ValidationState_t& _,
     }
   }
 
-  if (var->GetOperandAs<spv::StorageClass>(2) == spv::StorageClass::Input ||
-      var->GetOperandAs<spv::StorageClass>(2) == spv::StorageClass::Output) {
-    if (auto error = ValidateInputOutputInterfaceVariables(_, var))
-      return error;
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    if (var->GetOperandAs<spv::StorageClass>(2) == spv::StorageClass::Input ||
+        var->GetOperandAs<spv::StorageClass>(2) == spv::StorageClass::Output) {
+      if (auto error = ValidateInputOutputInterfaceVariables(_, var))
+        return error;
+    }
   }
 
   return SPV_SUCCESS;


### PR DESCRIPTION
The validation added in #6000 seems specific to Vulkan environments. Ensure it only runs for Vulkan environments.