### PR TITLE
spirv-val: Update 1.4.312 VUID churn

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -284,6 +284,7 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
     }
   }
 
+  // TODO - Need to add TileShadingRateQCOM support
   if (spvIsVulkanEnv(_.context()->target_env)) {
     switch (execution_model) {
       case spv::ExecutionModel::GLCompute:
@@ -312,7 +313,7 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
           }
           if (!ok) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << _.VkErrorID(6426)
+                   << _.VkErrorID(10685)
                    << "In the Vulkan environment, GLCompute execution model "
                       "entry points require either the LocalSize or "
                       "LocalSizeId execution mode or an object decorated with "

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2349,8 +2349,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeRuntimeArray-04680);
     case 4682:
       return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04682);
-    case 6426:
-      return VUID_WRAP(VUID-StandaloneSpirv-LocalSize-06426); // formally 04683
+    case 10685:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-10685); // formally 04683 and 06426
     case 4685:
       return VUID_WRAP(VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685);
     case 4686:

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -64,7 +64,7 @@ OpEntryPoint GLCompute %main "main"
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-LocalSize-06426"));
+              AnyVUID("VUID-StandaloneSpirv-None-10685"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(


### PR DESCRIPTION
I noticed this VUID was altered, but I have zero idea how `TileShadingRateQCOM` work and leaving that up to the vendor if they wish to actually add tooling support for their vendor extensions