### PR TITLE
spirv-val: fix validation of BFloat16 FP types

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -112,6 +112,7 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
   // Int8, Int16, and Int64 capabilities allow using 8-bit, 16-bit, and 64-bit
   // integers, respectively.
   auto num_bits = inst->GetOperandAs<const uint32_t>(1);
+  const bool has_encoding = inst->operands().size() > 2;
   if (num_bits == 32) {
     return SPV_SUCCESS;
   }
@@ -125,7 +126,9 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
   }
 
   if (num_bits == 16) {
-    if (_.features().declare_float16_type) {
+    // An absence of FP encoding implies IEEE 754. The Float16 and Float16Buffer
+    // capabilities only enable IEEE 754 binary 16
+    if (has_encoding || _.features().declare_float16_type) {
       return SPV_SUCCESS;
     }
     return _.diag(SPV_ERROR_INVALID_DATA, inst)

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -416,6 +416,12 @@ TEST_F(ValidateData, dot_bfloat16_bad) {
               HasSubstr("requires BFloat16DotProductKHR be declared."));
 }
 
+TEST_F(ValidateData, bfloat16_without_float16_capability_good) {
+  std::string str = header_with_bfloat16 + "%2 = OpTypeFloat 16 BFloat16KHR";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateData, float64_good) {
   std::string str = header_with_float64 + "%2 = OpTypeFloat 64";
 


### PR DESCRIPTION
These should not require the Float16/Float16Buffer capabilities.


Change-Id: I3b50260ba634502befb36b6a67dac5961f102fa3