### PR TITLE
Fix compile error when compiling with whole program optimization enabled

### DIFF
--- a/source/table.cpp
+++ b/source/table.cpp
@@ -49,9 +49,9 @@ spv_context spvContextCreate(spv_target_env env) {
       return nullptr;
   }
 
-  spv_opcode_table opcode_table;
-  spv_operand_table operand_table;
-  spv_ext_inst_table ext_inst_table;
+  spv_opcode_table opcode_table = nullptr;
+  spv_operand_table operand_table = nullptr;
+  spv_ext_inst_table ext_inst_table = nullptr;
 
   spvOpcodeTableGet(&opcode_table, env);
   spvOperandTableGet(&operand_table, env);


### PR DESCRIPTION
Compiling with `/GL` (Whole program optimization) and `/LTCG` (Link-time code generation) flags on MSVC 2022 causes an error/warning (depends if `/sdl` flag is also used) to be issued:
```
C:\Users\puma\.conan2\p\b\spirv2755296b2b5cb\b\src\source\table.cpp(60): error C4703: potentially uninitialized local pointer variable 'ext_inst_table' used [C:\Users\puma\.conan2\p\b\spirv2755296b2b5cb\b\bui
ld\source\SPIRV-Tools-shared.vcxproj]
LINK : fatal error LNK1257: code generation failed [C:\Users\puma\.conan2\p\b\spirv2755296b2b5cb\b\build\source\SPIRV-Tools-shared.vcxproj]
```

The code should actually be OK, as `spvExtInstTableGet` does check the same set of values for the `env` variable as is in the switch case above the modified code which does an early return.