### PR TITLE
generate_grammar_tables.py: remove unused option to emit C enums

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -228,8 +228,7 @@ $(1)/opencl.std.insts.inc \
 		                --core-insts-output=$(1)/core.insts-unified1.inc \
 		                --glsl-insts-output=$(1)/glsl.std.450.insts.inc \
 		                --opencl-insts-output=$(1)/opencl.std.insts.inc \
-		                --operand-kinds-output=$(1)/operand.kinds-unified1.inc \
-										--output-language=c++
+		                --operand-kinds-output=$(1)/operand.kinds-unified1.inc
 		@echo "[$(TARGET_ARCH_ABI)] Grammar (from unified1)  : instructions & operands <= grammar JSON files"
 $(LOCAL_PATH)/source/opcode.cpp: $(1)/core.insts-unified1.inc
 $(LOCAL_PATH)/source/operand.cpp: $(1)/operand.kinds-unified1.inc
@@ -304,8 +303,7 @@ $(1)/extension_enum.inc $(1)/enum_string_mapping.inc: \
 		                --extinst-debuginfo-grammar=$(SPV_DEBUGINFO_GRAMMAR) \
 		                --extinst-cldebuginfo100-grammar=$(SPV_CLDEBUGINFO100_GRAMMAR) \
 		                --extension-enum-output=$(1)/extension_enum.inc \
-		                --enum-string-mapping-output=$(1)/enum_string_mapping.inc \
-										--output-language=c++
+		                --enum-string-mapping-output=$(1)/enum_string_mapping.inc
 		@echo "[$(TARGET_ARCH_ABI)] Generate enum<->string mapping <= grammar JSON files"
 # Generated header extension_enum.inc is transitively included by table.h, which is
 # used pervasively.  Capture the pervasive dependency.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -68,9 +68,7 @@ template("spvtools_core_tables") {
       "--extinst-cldebuginfo100-grammar",
       rebase_path(cldebuginfo100_insts_file, root_build_dir),
       "--operand-kinds-output",
-      rebase_path(operand_kinds_file, root_build_dir),
-      "--output-language",
-      "c++"
+      rebase_path(operand_kinds_file, root_build_dir)
     ]
   }
 }
@@ -102,9 +100,7 @@ template("spvtools_core_enums") {
       "--extension-enum-output",
       rebase_path(extension_enum_file, root_build_dir),
       "--enum-string-mapping-output",
-      rebase_path(extension_map_file, root_build_dir),
-      "--output-language",
-      "c++"
+      rebase_path(extension_map_file, root_build_dir)
     ]
     inputs = [
       core_json_file,
@@ -145,9 +141,7 @@ template("spvtools_glsl_tables") {
       "--extinst-glsl-grammar",
       rebase_path(glsl_json_file, root_build_dir),
       "--glsl-insts-output",
-      rebase_path(glsl_insts_file, root_build_dir),
-      "--output-language",
-      "c++"
+      rebase_path(glsl_insts_file, root_build_dir)
     ]
     inputs = [
       core_json_file,

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -78,8 +78,7 @@ def generate_core_tables(version):
         " --extinst-debuginfo-grammar=$(location {debuginfo_grammar})" +
         " --extinst-cldebuginfo100-grammar=$(location {cldebuginfo_grammar})" +
         " --core-insts-output=$(location {core_insts_output})" +
-        " --operand-kinds-output=$(location {operand_kinds_output})" +
-        " --output-language=c++"
+        " --operand-kinds-output=$(location {operand_kinds_output})"
     ).format(**_merge_dicts([grammars, outs]))
 
     native.genrule(
@@ -113,8 +112,7 @@ def generate_enum_string_mapping(version):
         " --extinst-debuginfo-grammar=$(location {debuginfo_grammar})" +
         " --extinst-cldebuginfo100-grammar=$(location {cldebuginfo_grammar})" +
         " --extension-enum-output=$(location {extension_enum_ouput})" +
-        " --enum-string-mapping-output=$(location {enum_string_mapping_output})" +
-        " --output-language=c++"
+        " --enum-string-mapping-output=$(location {enum_string_mapping_output})"
     ).format(**_merge_dicts([grammars, outs]))
 
     native.genrule(
@@ -169,8 +167,7 @@ def generate_glsl_tables(version):
     cmd = (
         "$(location :generate_grammar_tables)" +
         " --extinst-glsl-grammar=$(location {gsls_grammar})" +
-        " --glsl-insts-output=$(location {gsls_insts_outs})" +
-        " --output-language=c++"
+        " --glsl-insts-output=$(location {gsls_insts_outs})"
     ).format(**_merge_dicts([grammars, outs]))
 
     native.genrule(

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,7 +37,6 @@ macro(spvtools_core_tables CONFIG_VERSION)
       --extinst-cldebuginfo100-grammar=${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
       --core-insts-output=${GRAMMAR_INSTS_INC_FILE}
       --operand-kinds-output=${GRAMMAR_KINDS_INC_FILE}
-      --output-language=c++
     DEPENDS ${GRAMMAR_PROCESSING_SCRIPT}
             ${GRAMMAR_JSON_FILE}
             ${DEBUGINFO_GRAMMAR_JSON_FILE}
@@ -59,7 +58,6 @@ macro(spvtools_enum_string_mapping CONFIG_VERSION)
       --extinst-cldebuginfo100-grammar=${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
       --extension-enum-output=${GRAMMAR_EXTENSION_ENUM_INC_FILE}
       --enum-string-mapping-output=${GRAMMAR_ENUM_STRING_MAPPING_INC_FILE}
-      --output-language=c++
     DEPENDS ${GRAMMAR_PROCESSING_SCRIPT}
             ${GRAMMAR_JSON_FILE}
             ${DEBUGINFO_GRAMMAR_JSON_FILE}
@@ -94,7 +92,6 @@ macro(spvtools_glsl_tables CONFIG_VERSION)
     COMMAND Python3::Interpreter ${GRAMMAR_PROCESSING_SCRIPT}
       --extinst-glsl-grammar=${GLSL_GRAMMAR_JSON_FILE}
       --glsl-insts-output=${GRAMMAR_INC_FILE}
-      --output-language=c++
     DEPENDS ${GRAMMAR_PROCESSING_SCRIPT} ${CORE_GRAMMAR_JSON_FILE} ${GLSL_GRAMMAR_JSON_FILE}
     COMMENT "Generate info tables for GLSL extended instructions and operands v${CONFIG_VERSION}.")
   list(APPEND EXTINST_CPP_DEPENDS ${GRAMMAR_INC_FILE})

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -34,8 +34,6 @@ SPV_KHR_non_semantic_info
 SPV_EXT_relaxed_printf_string_address_space
 """
 
-OUTPUT_LANGUAGE = 'c'
-
 def make_path_to_file(f):
     """Makes all ancestor directories to the given file, if they don't yet
     exist.
@@ -113,10 +111,7 @@ def compose_capability_list(caps):
     Returns:
       a string containing the braced list of SpvCapability* or spv::Capability:: enums named by caps.
     """
-    base_string = 'SpvCapability'
-    global OUTPUT_LANGUAGE
-    if OUTPUT_LANGUAGE == 'c++':
-        base_string = 'spv::Capability::'
+    base_string = 'spv::Capability::'
 
     return '{' + ', '.join([(base_string + '{}').format(c) for c in caps]) + '}'
 
@@ -139,10 +134,7 @@ def generate_capability_arrays(caps):
       - caps: a sequence of sequence of capability names
     """
     caps = sorted(set([tuple(c) for c in caps if c]))
-    cap_str = 'SpvCapability'
-    global OUTPUT_LANGUAGE
-    if OUTPUT_LANGUAGE == 'c++':
-        cap_str = 'spv::Capability'
+    cap_str = 'spv::Capability'
     arrays = [
         'static const ' + cap_str + ' {}[] = {};'.format(
             get_capability_array_name(c), compose_capability_list(c))
@@ -302,11 +294,7 @@ class InstInitializer(object):
             self.operands.pop()
 
     def __str__(self):
-        global OUTPUT_LANGUAGE
-        base_str = 'SpvOp'
-        if OUTPUT_LANGUAGE == 'c++':
-            base_str = 'spv::Op::Op'
-
+        base_str = 'spv::Op::Op'
         template = ['{{"{opname}"', base_str + '{opname}',
                     '{num_aliases}', '{aliases_mask}',
                     '{num_caps}', '{caps_mask}',
@@ -709,12 +697,8 @@ def generate_capability_to_string_mapping(operand_kinds):
 
     We take care to avoid emitting duplicate values.
     """
-    cap_str = 'SpvCapability'
-    cap_join = ''
-    global OUTPUT_LANGUAGE
-    if OUTPUT_LANGUAGE == 'c++':
-        cap_str = 'spv::Capability'
-        cap_join = '::'
+    cap_str = 'spv::Capability'
+    cap_join = '::'
 
     function = 'const char* CapabilityToString(' + cap_str + ' capability) {\n'
     function += '  switch (capability) {\n'
@@ -816,10 +800,6 @@ def main():
                         type=str, required=False, default=None,
                         help='input JSON grammar file for OpenCL extended '
                         'instruction set')
-    parser.add_argument('--output-language',
-                        type=str, required=False, default='c',
-                        choices=['c','c++'],
-                        help='specify output language type')
 
     parser.add_argument('--core-insts-output', metavar='<path>',
                         type=str, required=False, default=None,
@@ -850,9 +830,6 @@ def main():
                         type=str, required=False, default=None,
                         help='prefix for operand kinds (to disambiguate operand type enums)')
     args = parser.parse_args()
-
-    global OUTPUT_LANGUAGE
-    OUTPUT_LANGUAGE = args.output_language
 
     # The GN build system needs this because it doesn't handle quoting
     # empty string arguments well.


### PR DESCRIPTION
Remove the ability to emit C declarations for core instruction and operand tables.

Non-functional change