### PR TITLE
Simplify extinst generation

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -201,8 +201,6 @@ SPVTOOLS_OPT_SRC_FILES := \
 # Locations of grammar files.
 #
 SPV_COREUNIFIED1_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/spirv.core.grammar.json
-SPV_GLSL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.glsl.std.450.grammar.json
-SPV_OPENCL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.opencl.std.100.grammar.json
 SPV_DEBUGINFO_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.debuginfo.grammar.json
 SPV_CLDEBUGINFO100_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
 SPV_VKDEBUGINFO100_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
@@ -210,8 +208,6 @@ SPV_VKDEBUGINFO100_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extin
 define gen_spvtools_grammar_tables
 $(call generate-file-dir,$(1)/core.insts-unified1.inc)
 $(1)/core.insts-unified1.inc $(1)/operand.kinds-unified1.inc \
-$(1)/glsl.std.450.insts.inc \
-$(1)/opencl.std.insts.inc \
 : \
         $(LOCAL_PATH)/utils/generate_grammar_tables.py \
         $(SPV_COREUNIFIED1_GRAMMAR) \
@@ -221,20 +217,16 @@ $(1)/opencl.std.insts.inc \
         $(SPV_CLDEBUGINFO100_GRAMMAR)
 		@$(HOST_PYTHON) $(LOCAL_PATH)/utils/generate_grammar_tables.py \
 		                --spirv-core-grammar=$(SPV_COREUNIFIED1_GRAMMAR) \
-		                --extinst-glsl-grammar=$(SPV_GLSL_GRAMMAR) \
-		                --extinst-opencl-grammar=$(SPV_OPENCL_GRAMMAR) \
 		                --extinst-debuginfo-grammar=$(SPV_DEBUGINFO_GRAMMAR) \
 		                --extinst-cldebuginfo100-grammar=$(SPV_CLDEBUGINFO100_GRAMMAR) \
 		                --core-insts-output=$(1)/core.insts-unified1.inc \
-		                --glsl-insts-output=$(1)/glsl.std.450.insts.inc \
-		                --opencl-insts-output=$(1)/opencl.std.insts.inc \
 		                --operand-kinds-output=$(1)/operand.kinds-unified1.inc
 		@echo "[$(TARGET_ARCH_ABI)] Grammar (from unified1)  : instructions & operands <= grammar JSON files"
 $(LOCAL_PATH)/source/opcode.cpp: $(1)/core.insts-unified1.inc
 $(LOCAL_PATH)/source/operand.cpp: $(1)/operand.kinds-unified1.inc
 $(LOCAL_PATH)/source/ext_inst.cpp: \
 	$(1)/glsl.std.450.insts.inc \
-	$(1)/opencl.std.insts.inc \
+	$(1)/opencl.std.100.insts.inc \
 	$(1)/debuginfo.insts.inc \
 	$(1)/opencl.debuginfo.100.insts.inc \
 	$(1)/nonsemantic.shader.debuginfo.100.insts.inc \
@@ -279,10 +271,12 @@ $(1)/$(2).insts.inc : \
 		    --extinst-vendor-grammar=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.$(2).grammar.json \
 		    --vendor-insts-output=$(1)/$(2).insts.inc \
 		    --vendor-operand-kind-prefix=$(3)
-		@echo "[$(TARGET_ARCH_ABI)] Vendor extended instruction set: $(2) tables <= grammar"
+		@echo "[$(TARGET_ARCH_ABI)] Extended instruction set: $(2) tables <= grammar"
 $(LOCAL_PATH)/source/ext_inst.cpp: $(1)/$(2).insts.inc
 endef
-# Vendor and debug extended instruction sets, with grammars from SPIRV-Tools source tree.
+# Vendor and debug extended instruction sets, with grammars from SPIRV-Headers source tree.
+$(eval $(call gen_spvtools_vendor_tables,$(SPVTOOLS_OUT_PATH),glsl.std.450,""))
+$(eval $(call gen_spvtools_vendor_tables,$(SPVTOOLS_OUT_PATH),opencl.std.100,""))
 $(eval $(call gen_spvtools_vendor_tables,$(SPVTOOLS_OUT_PATH),debuginfo,""))
 $(eval $(call gen_spvtools_vendor_tables,$(SPVTOOLS_OUT_PATH),opencl.debuginfo.100,"CLDEBUG100_"))
 $(eval $(call gen_spvtools_vendor_tables,$(SPVTOOLS_OUT_PATH),nonsemantic.shader.debuginfo.100,"SHDEBUG100_"))

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,8 +8,6 @@ load(
     "generate_core_tables",
     "generate_enum_string_mapping",
     "generate_extinst_lang_headers",
-    "generate_glsl_tables",
-    "generate_opencl_tables",
     "generate_vendor_tables",
     "incompatible_with",
 )
@@ -42,9 +40,15 @@ generate_core_tables(version = "unified1")
 
 generate_enum_string_mapping(version = "unified1")
 
-generate_opencl_tables(version = "unified1")
+generate_vendor_tables(
+   extension = "glsl.std.450",
+   target = "spirv_glsl_grammar_unified1"
+)
 
-generate_glsl_tables(version = "unified1")
+generate_vendor_tables(
+   extension = "opencl.std.100",
+   target = "spirv_opencl_grammar_unified1"
+)
 
 generate_vendor_tables(extension = "spv-amd-shader-explicit-vertex-parameter")
 
@@ -143,8 +147,8 @@ cc_library(
         ":gen_extinst_lang_headers_DebugInfo",
         ":gen_extinst_lang_headers_NonSemanticShaderDebugInfo100",
         ":gen_extinst_lang_headers_OpenCLDebugInfo100",
-        ":gen_glsl_tables_unified1",
-        ":gen_opencl_tables_unified1",
+        ":gen_vendor_tables_spirv_glsl_grammar_unified1",
+        ":gen_vendor_tables_spirv_opencl_grammar_unified1",
         ":gen_vendor_tables_debuginfo",
         ":gen_vendor_tables_nonsemantic_clspvreflection",
         ":gen_vendor_tables_nonsemantic_vkspreflection",

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -125,69 +125,20 @@ def generate_enum_string_mapping(version):
         visibility = ["//visibility:private"],
     )
 
-def generate_opencl_tables(version):
-    if not version:
-        fail("Must specify version", "version")
-
-    grammars = dict(
-        opencl_grammar = "@spirv_headers//:spirv_opencl_grammar_{}".format(version),
-    )
-
-    outs = dict(
-        opencl_insts_output = "opencl.std.insts.inc",
-    )
-
-    cmd = (
-        "$(location :generate_grammar_tables)" +
-        " --extinst-opencl-grammar=$(location {opencl_grammar})" +
-        " --opencl-insts-output=$(location {opencl_insts_output})"
-    ).format(**_merge_dicts([grammars, outs]))
-
-    native.genrule(
-        name = "gen_opencl_tables_" + version,
-        srcs = grammars.values(),
-        outs = outs.values(),
-        cmd = cmd,
-        cmd_bat = cmd,
-        tools = [":generate_grammar_tables"],
-        visibility = ["//visibility:private"],
-    )
-
-def generate_glsl_tables(version):
-    if not version:
-        fail("Must specify version", "version")
-
-    grammars = dict(
-        gsls_grammar = "@spirv_headers//:spirv_glsl_grammar_{}".format(version),
-    )
-    outs = dict(
-        gsls_insts_outs = "glsl.std.450.insts.inc",
-    )
-
-    cmd = (
-        "$(location :generate_grammar_tables)" +
-        " --extinst-glsl-grammar=$(location {gsls_grammar})" +
-        " --glsl-insts-output=$(location {gsls_insts_outs})"
-    ).format(**_merge_dicts([grammars, outs]))
-
-    native.genrule(
-        name = "gen_glsl_tables_" + version,
-        srcs = grammars.values(),
-        outs = outs.values(),
-        cmd = cmd,
-        cmd_bat = cmd,
-        tools = [":generate_grammar_tables"],
-        visibility = ["//visibility:private"],
-    )
-
-def generate_vendor_tables(extension, operand_kind_prefix = ""):
+def generate_vendor_tables(extension, target = "", operand_kind_prefix = ""):
     if not extension:
         fail("Must specify extension", "extension")
 
-    extension_rule = extension.replace("-", "_").replace(".", "_")
-    grammars = dict(
-        vendor_grammar = "@spirv_headers//:spirv_ext_inst_{}_grammar_unified1".format(extension_rule),
-    )
+    if target == "":
+        extension_rule = extension.replace("-", "_").replace(".", "_")
+        grammars = dict(
+            vendor_grammar = "@spirv_headers//:spirv_ext_inst_{}_grammar_unified1".format(extension_rule),
+        )
+    else:
+        grammars = dict(
+            vendor_grammar = "@spirv_headers//:{}".format(target),
+        )
+        extension_rule = target
     outs = dict(
         vendor_insts_output = "{}.insts.inc".format(extension),
     )

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -41,7 +41,7 @@ macro(spvtools_core_tables CONFIG_VERSION)
             ${GRAMMAR_JSON_FILE}
             ${DEBUGINFO_GRAMMAR_JSON_FILE}
             ${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
-    COMMENT "Generate info tables for SPIR-V v${CONFIG_VERSION} core instructions and operands.")
+    COMMENT "Generate info tables for SPIR-V ${CONFIG_VERSION} core instructions and operands.")
   list(APPEND OPCODE_CPP_DEPENDS ${GRAMMAR_INSTS_INC_FILE})
   list(APPEND OPERAND_CPP_DEPENDS ${GRAMMAR_KINDS_INC_FILE})
 endmacro(spvtools_core_tables)
@@ -62,7 +62,7 @@ macro(spvtools_enum_string_mapping CONFIG_VERSION)
             ${GRAMMAR_JSON_FILE}
             ${DEBUGINFO_GRAMMAR_JSON_FILE}
             ${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
-    COMMENT "Generate enum-string mapping for SPIR-V v${CONFIG_VERSION}.")
+    COMMENT "Generate enum-string mapping for SPIR-V ${CONFIG_VERSION}.")
   list(APPEND EXTENSION_H_DEPENDS ${GRAMMAR_EXTENSION_ENUM_INC_FILE})
   list(APPEND ENUM_STRING_MAPPING_CPP_DEPENDS ${GRAMMAR_ENUM_STRING_MAPPING_INC_FILE})
 endmacro(spvtools_enum_string_mapping)
@@ -83,32 +83,6 @@ macro(spvtools_vimsyntax CONFIG_VERSION CLVERSION)
             ${GLSL_GRAMMAR_JSON_FILE} ${OPENCL_GRAMMAR_JSON_FILE} ${DEBUGINFO_GRAMMAR_JSON_FILE}
     COMMENT "Generate spvasm.vim: Vim syntax file for SPIR-V assembly.")
 endmacro(spvtools_vimsyntax)
-
-macro(spvtools_glsl_tables CONFIG_VERSION)
-  set(CORE_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/${CONFIG_VERSION}/spirv.core.grammar.json")
-  set(GLSL_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/${CONFIG_VERSION}/extinst.glsl.std.450.grammar.json")
-  set(GRAMMAR_INC_FILE "${spirv-tools_BINARY_DIR}/glsl.std.450.insts.inc")
-  add_custom_command(OUTPUT ${GRAMMAR_INC_FILE}
-    COMMAND Python3::Interpreter ${GRAMMAR_PROCESSING_SCRIPT}
-      --extinst-glsl-grammar=${GLSL_GRAMMAR_JSON_FILE}
-      --glsl-insts-output=${GRAMMAR_INC_FILE}
-    DEPENDS ${GRAMMAR_PROCESSING_SCRIPT} ${CORE_GRAMMAR_JSON_FILE} ${GLSL_GRAMMAR_JSON_FILE}
-    COMMENT "Generate info tables for GLSL extended instructions and operands v${CONFIG_VERSION}.")
-  list(APPEND EXTINST_CPP_DEPENDS ${GRAMMAR_INC_FILE})
-endmacro(spvtools_glsl_tables)
-
-macro(spvtools_opencl_tables CONFIG_VERSION)
-  set(CORE_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/${CONFIG_VERSION}/spirv.core.grammar.json")
-  set(OPENCL_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/${CONFIG_VERSION}/extinst.opencl.std.100.grammar.json")
-  set(GRAMMAR_INC_FILE "${spirv-tools_BINARY_DIR}/opencl.std.insts.inc")
-  add_custom_command(OUTPUT ${GRAMMAR_INC_FILE}
-    COMMAND Python3::Interpreter ${GRAMMAR_PROCESSING_SCRIPT}
-      --extinst-opencl-grammar=${OPENCL_GRAMMAR_JSON_FILE}
-      --opencl-insts-output=${GRAMMAR_INC_FILE}
-    DEPENDS ${GRAMMAR_PROCESSING_SCRIPT} ${CORE_GRAMMAR_JSON_FILE} ${OPENCL_GRAMMAR_JSON_FILE}
-    COMMENT "Generate info tables for OpenCL extended instructions and operands v${CONFIG_VERSION}.")
-  list(APPEND EXTINST_CPP_DEPENDS ${GRAMMAR_INC_FILE})
-endmacro(spvtools_opencl_tables)
 
 macro(spvtools_vendor_tables VENDOR_TABLE SHORT_NAME OPERAND_KIND_PREFIX)
   set(INSTS_FILE "${spirv-tools_BINARY_DIR}/${VENDOR_TABLE}.insts.inc")
@@ -143,8 +117,8 @@ endmacro(spvtools_extinst_lang_headers)
 
 spvtools_core_tables("unified1")
 spvtools_enum_string_mapping("unified1")
-spvtools_opencl_tables("unified1")
-spvtools_glsl_tables("unified1")
+spvtools_vendor_tables("glsl.std.450" "glsl" "")
+spvtools_vendor_tables("opencl.std.100" "opencl" "")
 spvtools_vendor_tables("spv-amd-shader-explicit-vertex-parameter" "spv-amd-sevp" "")
 spvtools_vendor_tables("spv-amd-shader-trinary-minmax" "spv-amd-stm" "")
 spvtools_vendor_tables("spv-amd-gcn-shader" "spv-amd-gs" "")

--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -20,20 +20,17 @@
 // See https://www.khronos.org/registry/spir-v/specs/1.0/DebugInfo.html
 // TODO(dneto): DebugInfo.h should probably move to SPIRV-Headers.
 #include "DebugInfo.h"
-
-#include "source/latest_version_glsl_std_450_header.h"
-#include "source/latest_version_opencl_std_header.h"
-#include "source/macro.h"
-#include "source/spirv_definition.h"
-
 #include "debuginfo.insts.inc"
 #include "glsl.std.450.insts.inc"
 #include "nonsemantic.clspvreflection.insts.inc"
 #include "nonsemantic.shader.debuginfo.100.insts.inc"
 #include "nonsemantic.vkspreflection.insts.inc"
 #include "opencl.debuginfo.100.insts.inc"
-#include "opencl.std.insts.inc"
-
+#include "opencl.std.100.insts.inc"
+#include "source/latest_version_glsl_std_450_header.h"
+#include "source/latest_version_opencl_std_header.h"
+#include "source/macro.h"
+#include "source/spirv_definition.h"
 #include "spirv-tools/libspirv.h"
 #include "spv-amd-gcn-shader.insts.inc"
 #include "spv-amd-shader-ballot.insts.inc"
@@ -41,8 +38,10 @@
 #include "spv-amd-shader-trinary-minmax.insts.inc"
 
 static const spv_ext_inst_group_t kGroups_1_0[] = {
-    {SPV_EXT_INST_TYPE_GLSL_STD_450, ARRAY_SIZE(glsl_entries), glsl_entries},
-    {SPV_EXT_INST_TYPE_OPENCL_STD, ARRAY_SIZE(opencl_entries), opencl_entries},
+    {SPV_EXT_INST_TYPE_GLSL_STD_450, ARRAY_SIZE(glsl_std_450_entries),
+     glsl_std_450_entries},
+    {SPV_EXT_INST_TYPE_OPENCL_STD, ARRAY_SIZE(opencl_std_100_entries),
+     opencl_std_100_entries},
     {SPV_EXT_INST_TYPE_SPV_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER,
      ARRAY_SIZE(spv_amd_shader_explicit_vertex_parameter_entries),
      spv_amd_shader_explicit_vertex_parameter_entries},

--- a/utils/generate_grammar_tables.py
+++ b/utils/generate_grammar_tables.py
@@ -763,7 +763,7 @@ def prefix_operand_kind_names(prefix, json_dict):
     """
 
     old_to_new = {}
-    for operand_kind in json_dict["operand_kinds"]:
+    for operand_kind in json_dict.get("operand_kinds", []):
         old_name = operand_kind["kind"]
         new_name = prefix + old_name
         operand_kind["kind"] = new_name
@@ -792,24 +792,10 @@ def main():
                         type=str, required=False, default=None,
                         help='input JSON grammar file for OpenCL.DebugInfo.100 '
                         'extended instruction set')
-    parser.add_argument('--extinst-glsl-grammar', metavar='<path>',
-                        type=str, required=False, default=None,
-                        help='input JSON grammar file for GLSL extended '
-                        'instruction set')
-    parser.add_argument('--extinst-opencl-grammar', metavar='<path>',
-                        type=str, required=False, default=None,
-                        help='input JSON grammar file for OpenCL extended '
-                        'instruction set')
 
     parser.add_argument('--core-insts-output', metavar='<path>',
                         type=str, required=False, default=None,
                         help='output file for core SPIR-V instructions')
-    parser.add_argument('--glsl-insts-output', metavar='<path>',
-                        type=str, required=False, default=None,
-                        help='output file for GLSL extended instruction set')
-    parser.add_argument('--opencl-insts-output', metavar='<path>',
-                        type=str, required=False, default=None,
-                        help='output file for OpenCL extended instruction set')
     parser.add_argument('--operand-kinds-output', metavar='<path>',
                         type=str, required=False, default=None,
                         help='output file for operand kinds')
@@ -848,24 +834,12 @@ def main():
               'and --extinst-debuginfo-grammar '
               'and --extinst-cldebuginfo100-grammar')
         exit(1)
-    if (args.glsl_insts_output is None) != \
-            (args.extinst_glsl_grammar is None):
-        print('error: --glsl-insts-output and --extinst-glsl-grammar '
-              'should be specified together.')
-        exit(1)
-    if (args.opencl_insts_output is None) != \
-            (args.extinst_opencl_grammar is None):
-        print('error: --opencl-insts-output and --extinst-opencl-grammar '
-              'should be specified together.')
-        exit(1)
     if (args.vendor_insts_output is None) != \
             (args.extinst_vendor_grammar is None):
         print('error: --vendor-insts-output and '
               '--extinst-vendor-grammar should be specified together.')
         exit(1)
     if all([args.core_insts_output is None,
-            args.glsl_insts_output is None,
-            args.opencl_insts_output is None,
             args.vendor_insts_output is None,
             args.extension_enum_output is None,
             args.enum_string_mapping_output is None]):
@@ -907,22 +881,6 @@ def main():
             with open(args.enum_string_mapping_output, 'w') as f:
                 f.write(generate_all_string_enum_mappings(
                     extensions, operand_kinds))
-
-    if args.extinst_glsl_grammar is not None:
-        with open(args.extinst_glsl_grammar) as json_file:
-            grammar = json.loads(json_file.read())
-            make_path_to_file(args.glsl_insts_output)
-            with open(args.glsl_insts_output, 'w') as f:
-                f.write(generate_extended_instruction_table(
-                    grammar, 'glsl'))
-
-    if args.extinst_opencl_grammar is not None:
-        with open(args.extinst_opencl_grammar) as json_file:
-            grammar = json.loads(json_file.read())
-            make_path_to_file(args.opencl_insts_output)
-            with open(args.opencl_insts_output, 'w') as f:
-                f.write(generate_extended_instruction_table(
-                    grammar, 'opencl'))
 
     if args.extinst_vendor_grammar is not None:
         with open(args.extinst_vendor_grammar) as json_file:


### PR DESCRIPTION

    Simplify ext inst table generation
    
    Generate glsl.std.450 and opencl.std.100 extended instruction tables
    the same way other vendor extended instruction tables are generated.
    
    Also:
    - Don't always assume operand_kinds exists