### PR TITLE
[OPT] Don't fold n % 1.0

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -2466,7 +2466,7 @@ FoldingRule RedundantFDiv() {
 }
 
 FoldingRule RedundantFMod() {
-  return [](IRContext* context, Instruction* inst,
+  return [](IRContext*, Instruction* inst,
             const std::vector<const analysis::Constant*>& constants) {
     assert(inst->opcode() == spv::Op::OpFMod &&
            "Wrong opcode.  Should be OpFMod.");
@@ -2477,25 +2477,11 @@ FoldingRule RedundantFMod() {
     }
 
     FloatConstantKind kind0 = getFloatConstantKind(constants[0]);
-    FloatConstantKind kind1 = getFloatConstantKind(constants[1]);
 
     if (kind0 == FloatConstantKind::Zero) {
       inst->SetOpcode(spv::Op::OpCopyObject);
       inst->SetInOperands(
           {{SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(0)}}});
-      return true;
-    }
-
-    if (kind1 == FloatConstantKind::One) {
-      auto type = context->get_type_mgr()->GetType(inst->type_id());
-      std::vector<uint32_t> zero_words;
-      zero_words.resize(ElementWidth(type) / 32);
-      auto const_mgr = context->get_constant_mgr();
-      auto zero = const_mgr->GetConstant(type, std::move(zero_words));
-      auto zero_id = const_mgr->GetDefiningInstruction(zero)->result_id();
-
-      inst->SetOpcode(spv::Op::OpCopyObject);
-      inst->SetInOperands({{SPV_OPERAND_TYPE_ID, {zero_id}}});
       return true;
     }
 

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -4609,7 +4609,8 @@ INSTANTIATE_TEST_SUITE_P(FloatRedundantFoldingTest, GeneralInstructionFoldingTes
             "OpReturn\n" +
             "OpFunctionEnd",
         2, 3),
-    // Test case 9: Fold n % 1.0
+    // Test case 9: Don't fold n % 1.0
+    // If `n` is not a whole number, the answer is not 0.
     InstructionFoldingCase<uint32_t>(
         Header() + "%main = OpFunction %void None %void_func\n" +
             "%main_lab = OpLabel\n" +
@@ -4618,7 +4619,7 @@ INSTANTIATE_TEST_SUITE_P(FloatRedundantFoldingTest, GeneralInstructionFoldingTes
             "%2 = OpFMod %float %3 %float_1\n" +
             "OpReturn\n" +
             "OpFunctionEnd",
-        2, FLOAT_0_ID),
+        2, 0),
     // Test case 10: Fold n * 0.0
     InstructionFoldingCase<uint32_t>(
         Header() + "%main = OpFunction %void None %void_func\n" +


### PR DESCRIPTION
If values are not whole number, then the result is not 0. For example,
`(1.5 % 1.0) == 0.5`.

Fixes #6097
