### PR TITLE
fix clang-20 build issue

### DIFF
--- a/tools/diff/diff.cpp
+++ b/tools/diff/diff.cpp
@@ -87,7 +87,8 @@ std::unique_ptr<spvtools::opt::IRContext> load_module(const char* path) {
     return spvtools::BuildModule(
         kDefaultEnvironment, spvtools::utils::CLIMessageConsumer,
         std::string(contents.begin(), contents.end()),
-        spvtools::SpirvTools::kDefaultAssembleOption |
+        static_cast<spv_text_to_binary_options_t>(
+            spvtools::SpirvTools::kDefaultAssembleOption) |
             SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
   }
 


### PR DESCRIPTION
Trying to build SpirV with Clang-20 I have the following error which I find interesting.

```
[328/373] Building CXX object tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o
FAILED: tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o
/usr/bin/clang++-20 -DSPIRV_COLOR_TERMINAL -DSPIRV_TIMER_ENABLED -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/build/Release -I/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/include -I/home/elvisdukaj/.conan2/p/spirva7c686f153c5c/p/include -m64 -stdlib=libc++ -O3 -DNDEBUG -std=c++26 -fPIE -Wextra-semi -Wall -Wextra -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-self-assign -Wno-long-long -Wshadow -Wundef -Wconversion -Wno-sign-conversion -fno-exceptions -ftemplate-depth=1024 -MD -MT tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o -MF tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o.d -o tools/CMakeFiles/spirv-diff.dir/diff/diff.cpp.o -c /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/tools/diff/diff.cpp
/home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/tools/diff/diff.cpp:90:54: error: invalid bitwise operation between different enumeration types ('spvtools::SpirvTools::(unnamed enum at /home/elvisdukaj/.conan2/p/b/spirv6b92024eb0385/b/src/include/spirv-tools/libspirv.hpp:299:3)' and 'spv_text_to_binary_options_t')
   90 |         spvtools::SpirvTools::kDefaultAssembleOption |
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
   91 |             SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
[351/373] Building CXX object source/diff/CMakeFiles/SPIRV-Tools-diff.dir/diff.cpp.o
ninja: build stopped: subcommand failed.
```

`kDefaultAssembleOption` is defined as following:

```C++
class SPIRV_TOOLS_EXPORT SpirvTools {
 public:
  enum {
    // Default assembling option used by assemble():
    kDefaultAssembleOption = SPV_TEXT_TO_BINARY_OPTION_NONE,

    // Default disassembling option used by Disassemble():
    // * Avoid prefix comments from decoding the SPIR-V module header, and
    // * Use friendly names for variables.
    kDefaultDisassembleOption = SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
                                SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES
  };
```

but it's type is an anonymous enum insteaf of a `spv_text_to_binary_options_t` despite the assignment.

A simple cast solve the build issue.