### PR TITLE
[Kokoro] Add dxc-smoketest

### DIFF
--- a/kokoro/dxc-smoketest/build.sh
+++ b/kokoro/dxc-smoketest/build.sh
@@ -19,4 +19,4 @@ set -e
 set -x
 
 SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc cmake-shaderc-smoketest
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc cmake-dxc-smoketest

--- a/kokoro/dxc-smoketest/continuous.cfg
+++ b/kokoro/dxc-smoketest/continuous.cfg
@@ -1,11 +1,10 @@
-#!/bin/bash
 # Copyright (c) 2018 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fail on any error.
-set -e
-# Display commands being run.
-set -x
+# Continuous build configuration.
+build_file: "SPIRV-Tools/kokoro/dxc-smoketest/build.sh"
 
-SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc cmake-shaderc-smoketest

--- a/kokoro/dxc-smoketest/presubmit.cfg
+++ b/kokoro/dxc-smoketest/presubmit.cfg
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 # Presubmit build configuration.
-build_file: "SPIRV-Tools/kokoro/shaderc-smoketest/build.sh"
+build_file: "SPIRV-Tools/kokoro/dxc-smoketest/build.sh"
 

--- a/kokoro/dxc-smoketest/presubmit.cfg
+++ b/kokoro/dxc-smoketest/presubmit.cfg
@@ -1,11 +1,10 @@
-#!/bin/bash
 # Copyright (c) 2018 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Fail on any error.
-set -e
-# Display commands being run.
-set -x
+# Presubmit build configuration.
+build_file: "SPIRV-Tools/kokoro/shaderc-smoketest/build.sh"
 
-SCRIPT_DIR=`dirname "$BASH_SOURCE"`
-source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gcc cmake-shaderc-smoketest

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -188,7 +188,7 @@ elif [ $TOOL = "cmake-dxc-smoketest" ]; then
   ninja ClangSPIRVTests
 
   echo $(date): Testing ClangSPIRVTests...
-  build/tools/clang/unittests/SPIRV/ClangSPIRVTests
+  tools/clang/unittests/SPIRV/ClangSPIRVTests
 
   echo $(date): Testing check-clang-codegenspirv...
   ninja check-clang-codegenspirv

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -45,7 +45,7 @@ function clean_dir() {
   mkdir "$dir"
 }
 
-if [ $TOOL != "cmake-smoketest" ]; then
+if [ $TOOL != "cmake-shaderc-smoketest" && $TOOL != "cmake-dxc-smoketest" ]; then
   # Get source for dependencies, as specified in the DEPS file
   /usr/bin/python3 utils/git-sync-deps --treeless
 fi
@@ -115,7 +115,7 @@ if [ $TOOL = "cmake" ]; then
   ninja install
   cd $KOKORO_ARTIFACTS_DIR
   tar czf install.tgz install
-elif [ $TOOL = "cmake-smoketest" ]; then
+elif [ $TOOL = "cmake-shaderc-smoketest" ]; then
   using cmake-3.31.2
   using ninja-1.10.0
 
@@ -156,6 +156,43 @@ elif [ $TOOL = "cmake-smoketest" ]; then
   echo $(date): Starting ctest...
   ctest --output-on-failure -j4
   echo $(date): ctest completed.
+elif [ $TOOL = "cmake-dxc-smoketest" ]; then
+  using cmake-3.31.2
+  using ninja-1.10.0
+
+  # Get shaderc.
+  DXC_DIR=/tmp/dxc
+  clean_dir "$DXC_DIR"
+  cd $DXC_DIR
+  git clone https://github.com/microsoft/DirectXShaderCompiler.git .
+  cd $DXC_DIR/external
+
+  # Get DXC dependencies. Link the appropriate SPIRV-Tools.
+  git clone https://github.com/microsoft/DirectX-Headers.git
+  rm -rf SPIRV-Tools
+  ln -s $ROOT_DIR SPIRV-Tools
+  git clone https://github.com/KhronosGroup/SPIRV-Headers.git SPIRV-Headers
+
+  cd $DXC_DIR
+  mkdir build
+  cd $DXC_DIR/build
+
+  # Invoke the build.
+  echo $(date): Configuring build...
+  cmake $DXC_DIR \
+  -C $DXC_DIR/cmake/caches/PredefinedParams.cmake \
+  -DCMAKE_BUILD_TYPE="Release" \
+  -G Ninja
+
+  echo $(date): Building ClangSPIRVTests...
+  ninja ClangSPIRVTests
+
+  echo $(date): Testing ClangSPIRVTests...
+  build/tools/clang/unittests/SPIRV/ClangSPIRVTests
+
+  echo $(date): Testing check-clang-codegenspirv...
+  ninja check-clang-codegenspirv
+
 elif [ $TOOL = "cmake-android-ndk" ]; then
   using cmake-3.31.2
   using ndk-r27c

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -45,7 +45,7 @@ function clean_dir() {
   mkdir "$dir"
 }
 
-if [ $TOOL != "cmake-shaderc-smoketest" && $TOOL != "cmake-dxc-smoketest" ]; then
+if [ $TOOL != "cmake-shaderc-smoketest" ] && [ $TOOL != "cmake-dxc-smoketest" ]; then
   # Get source for dependencies, as specified in the DEPS file
   /usr/bin/python3 utils/git-sync-deps --treeless
 fi

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -168,7 +168,7 @@ elif [ $TOOL = "cmake-dxc-smoketest" ]; then
   cd $DXC_DIR/external
 
   # Get DXC dependencies. Link the appropriate SPIRV-Tools.
-  git clone https://github.com/microsoft/DirectX-Headers.git
+  git submodule update --init DirectX-Headers
   rm -rf SPIRV-Tools
   ln -s $ROOT_DIR SPIRV-Tools
   git clone https://github.com/KhronosGroup/SPIRV-Headers.git SPIRV-Headers


### PR DESCRIPTION
New validation check in spir-val can identify invalid code generated by DXC.
This will generally only be caught when DXC or SPIR-V tools is imported into
Google3. This can take a while. Adding the smoke test will enable us to get an
early warning that DXC needs to be updated.
