### PR TITLE
Fixes for Dawn gn build.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -33,38 +33,35 @@ if (defined(is_fuchsia_tree) && is_fuchsia_tree) {
 spirv_headers = spirv_tools_spirv_headers_dir
 spirv_is_winuwp = is_win && target_os == "winuwp"
 
-template("spvtools_core_tables") {
-  # Generate a compressed table describing SPIR-V core spec instructions and operands.
-  action("spvtools_core_tables_" + target_name) {
-    script = "utils/ggt.py"
+action("spvtools_core_tables") {
+  script = "utils/ggt.py"
 
-    core_json_file =
-        "${spirv_headers}/include/spirv/unified1/spirv.core.grammar.json"
-    debuginfo_insts_file =
-        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
-    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
+  core_json_file =
+      "${spirv_headers}/include/spirv/unified1/spirv.core.grammar.json"
+  debuginfo_insts_file =
+      "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
+  cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
 
-    core_tables_file = "${target_gen_dir}/core_tables.inc"
+  core_tables_file = "${target_gen_dir}/core_tables.inc"
 
-    sources = [
-      cldebuginfo100_insts_file,
-      core_json_file,
-      debuginfo_insts_file,
-    ]
-    outputs = [
-      core_tables_file,
-    ]
-    args = [
-      "--spirv-core-grammar",
-      rebase_path(core_json_file, root_build_dir),
-      "--extinst-debuginfo-grammar",
-      rebase_path(debuginfo_insts_file, root_build_dir),
-      "--extinst-cldebuginfo100-grammar",
-      rebase_path(cldebuginfo100_insts_file, root_build_dir),
-      "--core-tables-output",
-      rebase_path(core_tables_file, root_build_dir)
-    ]
-  }
+  sources = [
+    cldebuginfo100_insts_file,
+    core_json_file,
+    debuginfo_insts_file,
+  ]
+  outputs = [
+    core_tables_file,
+  ]
+  args = [
+    "--spirv-core-grammar",
+    rebase_path(core_json_file, root_build_dir),
+    "--extinst-debuginfo-grammar",
+    rebase_path(debuginfo_insts_file, root_build_dir),
+    "--extinst-cldebuginfo100-grammar",
+    rebase_path(cldebuginfo100_insts_file, root_build_dir),
+    "--core-tables-output",
+    rebase_path(core_tables_file, root_build_dir)
+  ]
 }
 
 template("spvtools_core_enums") {
@@ -105,84 +102,6 @@ template("spvtools_core_enums") {
       extension_enum_file,
       extension_map_file,
     ]
-  }
-}
-
-template("spvtools_glsl_tables") {
-  assert(defined(invoker.version), "Need version in $target_name generation.")
-
-  action("spvtools_glsl_tables_" + target_name) {
-    script = "utils/generate_grammar_tables.py"
-
-    version = invoker.version
-
-    core_json_file =
-        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
-    glsl_json_file = "${spirv_headers}/include/spirv/${version}/extinst.glsl.std.450.grammar.json"
-    debuginfo_insts_file =
-        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
-    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
-
-    glsl_insts_file = "${target_gen_dir}/glsl.std.450.insts.inc"
-
-    args = [
-      "--spirv-core-grammar",
-      rebase_path(core_json_file, root_build_dir),
-      "--extinst-debuginfo-grammar",
-      rebase_path(debuginfo_insts_file, root_build_dir),
-      "--extinst-cldebuginfo100-grammar",
-      rebase_path(cldebuginfo100_insts_file, root_build_dir),
-      "--extinst-glsl-grammar",
-      rebase_path(glsl_json_file, root_build_dir),
-      "--glsl-insts-output",
-      rebase_path(glsl_insts_file, root_build_dir)
-    ]
-    inputs = [
-      core_json_file,
-      glsl_json_file,
-      debuginfo_insts_file,
-      cldebuginfo100_insts_file,
-    ]
-    outputs = [ glsl_insts_file ]
-  }
-}
-
-template("spvtools_opencl_tables") {
-  assert(defined(invoker.version), "Need version in $target_name generation.")
-
-  action("spvtools_opencl_tables_" + target_name) {
-    script = "utils/generate_grammar_tables.py"
-
-    version = invoker.version
-
-    core_json_file =
-        "${spirv_headers}/include/spirv/$version/spirv.core.grammar.json"
-    opencl_json_file = "${spirv_headers}/include/spirv/${version}/extinst.opencl.std.100.grammar.json"
-    debuginfo_insts_file =
-        "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
-    cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
-
-    opencl_insts_file = "${target_gen_dir}/opencl.std.insts.inc"
-
-    args = [
-      "--spirv-core-grammar",
-      rebase_path(core_json_file, root_build_dir),
-      "--extinst-debuginfo-grammar",
-      rebase_path(debuginfo_insts_file, root_build_dir),
-      "--extinst-cldebuginfo100-grammar",
-      rebase_path(cldebuginfo100_insts_file, root_build_dir),
-      "--extinst-opencl-grammar",
-      rebase_path(opencl_json_file, root_build_dir),
-      "--opencl-insts-output",
-      rebase_path(opencl_insts_file, root_build_dir),
-    ]
-    inputs = [
-      core_json_file,
-      opencl_json_file,
-      debuginfo_insts_file,
-      cldebuginfo100_insts_file,
-    ]
-    outputs = [ opencl_insts_file ]
   }
 }
 
@@ -260,16 +179,8 @@ action("spvtools_build_version") {
   ]
 }
 
-spvtools_core_tables("unified1") {
-}
 spvtools_core_enums("unified1") {
   version = "unified1"
-}
-spvtools_glsl_tables("glsl1-0") {
-  version = "1.0"
-}
-spvtools_opencl_tables("opencl1-0") {
-  version = "1.0"
 }
 spvtools_language_header("debuginfo") {
   name = "DebugInfo"
@@ -286,6 +197,14 @@ spvtools_language_header("vkdebuginfo100") {
 }
 
 spvtools_vendor_tables = [
+  [
+    "glsl.std.450",
+    "...nil...",
+  ],
+  [
+    "opencl.std.100",
+    "...nil...",
+  ],
   [
     "spv-amd-shader-explicit-vertex-parameter",
     "...nil...",
@@ -394,13 +313,11 @@ group("spvtools_language_headers") {
 
 static_library("spvtools") {
   deps = [
-    ":spvtools_core_tables_unified1",
+    ":spvtools_core_tables",
     ":spvtools_generators_inc",
-    ":spvtools_glsl_tables_glsl1-0",
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
     ":spvtools_language_header_vkdebuginfo100",
-    ":spvtools_opencl_tables_opencl1-0",
   ]
   foreach(table_def, spvtools_vendor_tables) {
     target_name = table_def[0]
@@ -457,6 +374,8 @@ static_library("spvtools") {
     "source/spirv_validator_options.h",
     "source/table.cpp",
     "source/table.h",
+    "source/table2.cpp",
+    "source/table2.h",
     "source/text.cpp",
     "source/text.h",
     "source/text_handler.cpp",

--- a/source/table2.cpp
+++ b/source/table2.cpp
@@ -139,8 +139,7 @@ utils::Span<const spvtools::Extension> InstructionDesc::extensions() const {
 
 spv_result_t LookupOpcode(spv::Op opcode, InstructionDesc** desc) {
   // Metaphor: Look for the needle in the haystack.
-  // The operand value is the first member.
-  const InstructionDesc needle{opcode};
+  const InstructionDesc needle(opcode);
   auto where = std::lower_bound(
       kInstructionDesc.begin(), kInstructionDesc.end(), needle,
       [&](const InstructionDesc& lhs, const InstructionDesc& rhs) {

--- a/source/table2.h
+++ b/source/table2.h
@@ -108,6 +108,27 @@ struct OperandDesc {
   utils::Span<const spv::Capability> capabilities() const;
   utils::Span<const spvtools::Extension> extensions() const;
 
+  OperandDesc(uint32_t v, IndexRange o, IndexRange n, IndexRange a,
+              IndexRange c, IndexRange e, uint32_t mv, uint32_t lv)
+      : value(v),
+        operands_range(o),
+        name_range(n),
+        aliases_range(a),
+        capabilities_range(c),
+        extensions_range(e),
+        minVersion(mv),
+        lastVersion(lv) {}
+
+  OperandDesc(uint32_t v)
+      : value(v),
+        operands_range(),
+        name_range(),
+        aliases_range(),
+        capabilities_range(),
+        extensions_range(),
+        minVersion(0u),
+        lastVersion(0u) {}
+
   OperandDesc(const OperandDesc&) = delete;
   OperandDesc(OperandDesc&&) = delete;
 };
@@ -139,6 +160,32 @@ struct InstructionDesc {
   utils::Span<const IndexRange> aliases() const;
   utils::Span<const spv::Capability> capabilities() const;
   utils::Span<const spvtools::Extension> extensions() const;
+
+  InstructionDesc(spv::Op oc, bool hr, bool ht, IndexRange o, IndexRange n,
+                  IndexRange a, IndexRange c, IndexRange e, uint32_t mv,
+                  uint32_t lv)
+      : opcode(oc),
+        hasResult(hr),
+        hasType(ht),
+        operands_range(o),
+        name_range(n),
+        aliases_range(a),
+        capabilities_range(c),
+        extensions_range(e),
+        minVersion(mv),
+        lastVersion(lv) {}
+
+  InstructionDesc(spv::Op oc)
+      : opcode(oc),
+        hasResult(false),
+        hasType(false),
+        operands_range(),
+        name_range(),
+        aliases_range(),
+        capabilities_range(),
+        extensions_range(),
+        minVersion(0u),
+        lastVersion(0u) {}
 
   InstructionDesc(const InstructionDesc&) = delete;
   InstructionDesc(InstructionDesc&&) = delete;


### PR DESCRIPTION
- Fix build.gn for recent updates in table generation

- GLSL and OpenCL extended instructions are generated like other vendor extended instruction sets

- Core table generation was reworked.  We don't need a GN template.

- Add more constructors for InstructionDesc and OperandDesc. The compiler didn't like the brace-initialization without a matching constructor with exactly the same parameters.