### PR TITLE
Add instruction printingClass value to InstructionDesc

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -207,8 +207,9 @@ SPV_CLDEBUGINFO100_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extin
 SPV_VKDEBUGINFO100_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
 
 define gen_spvtools_grammar_tables
-$(call generate-file-dir,$(1)/core_tables.inc)
-$(1)/core_tables.inc \
+$(call generate-file-dir,$(1)/core_tables_body.inc)
+$(1)/core_tables_body.inc \
+$(1)/core_tables_header.inc \
 : \
         $(LOCAL_PATH)/utils/generate_grammar_tables.py \
         $(SPV_COREUNIFIED1_GRAMMAR) \
@@ -218,9 +219,13 @@ $(1)/core_tables.inc \
 		                --spirv-core-grammar=$(SPV_COREUNIFIED1_GRAMMAR) \
 		                --extinst-debuginfo-grammar=$(SPV_DEBUGINFO_GRAMMAR) \
 		                --extinst-cldebuginfo100-grammar=$(SPV_CLDEBUGINFO100_GRAMMAR) \
-		                --core-tables-output=$(1)/core_tables.inc
-		@echo "[$(TARGET_ARCH_ABI)] Grammar (from unified1)  : instructions & operands <= grammar JSON files"
-$(LOCAL_PATH)/source/table2.cpp: $(1)/core_tables.inc
+		                --core-tables-body-output=$(1)/core_tables_body.inc \
+		                --core-tables-header-output=$(1)/core_tables_header.inc
+		@echo "[$(TARGET_ARCH_ABI)] Grammar from unified1)  : instructions & operands <= grammar JSON files"
+# Make all source files depend on the generated core tables
+$(foreach F,$(SPVTOOLS_SRC_FILES) $(SPVTOOLS_OPT_SRC_FILES),$(LOCAL_PATH)/$F ) \
+  : $(1)/core_tables_body.inc \
+    $(1)/core_tables_header.inc
 $(LOCAL_PATH)/source/ext_inst.cpp: \
 	$(1)/glsl.std.450.insts.inc \
 	$(1)/opencl.std.100.insts.inc \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -42,7 +42,8 @@ action("spvtools_core_tables") {
       "${spirv_headers}/include/spirv/unified1/extinst.debuginfo.grammar.json"
   cldebuginfo100_insts_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
 
-  core_tables_file = "${target_gen_dir}/core_tables.inc"
+  core_tables_body_file = "${target_gen_dir}/core_tables_body.inc"
+  core_tables_header_file = "${target_gen_dir}/core_tables_header.inc"
 
   sources = [
     cldebuginfo100_insts_file,
@@ -50,7 +51,8 @@ action("spvtools_core_tables") {
     debuginfo_insts_file,
   ]
   outputs = [
-    core_tables_file,
+    core_tables_body_file,
+    core_tables_header_file,
   ]
   args = [
     "--spirv-core-grammar",
@@ -59,8 +61,10 @@ action("spvtools_core_tables") {
     rebase_path(debuginfo_insts_file, root_build_dir),
     "--extinst-cldebuginfo100-grammar",
     rebase_path(cldebuginfo100_insts_file, root_build_dir),
-    "--core-tables-output",
-    rebase_path(core_tables_file, root_build_dir)
+    "--core-tables-body-output",
+    rebase_path(core_tables_body_file, root_build_dir),
+    "--core-tables-header-output",
+    rebase_path(core_tables_header_file, root_build_dir)
   ]
 }
 

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -101,7 +101,8 @@ def generate_compressed_tables():
     )
 
     outs = dict(
-        core_tables_output = "core_tables.inc",
+        core_tables_header_output = "core_tables_header.inc",
+        core_tables_body_output = "core_tables_body.inc",
     )
 
     cmd = (
@@ -109,7 +110,8 @@ def generate_compressed_tables():
         " --spirv-core-grammar=$(location {core_grammar})" +
         " --extinst-debuginfo-grammar=$(location {debuginfo_grammar})" +
         " --extinst-cldebuginfo100-grammar=$(location {cldebuginfo_grammar})" +
-        " --core-tables-output=$(location {core_tables_output})"
+        " --core-tables-body-output=$(location {core_tables_body_output})" +
+        " --core-tables-header-output=$(location {core_tables_header_output})"
     ).format(**_merge_dicts([grammars, outs]))
 
     native.genrule(

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -24,19 +24,21 @@ set(DEBUGINFO_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/unified1/exti
 set(CLDEBUGINFO100_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json")
 set(VKDEBUGINFO100_GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json")
 
-set(CORE_TABLES_INC_FILE ${spirv-tools_BINARY_DIR}/core_tables.inc)
-add_custom_command(OUTPUT ${CORE_TABLES_INC_FILE}
+set(CORE_TABLES_BODY_INC_FILE ${spirv-tools_BINARY_DIR}/core_tables_body.inc)
+set(CORE_TABLES_HEADER_INC_FILE ${spirv-tools_BINARY_DIR}/core_tables_header.inc)
+add_custom_command(OUTPUT ${CORE_TABLES_BODY_INC_FILE} ${CORE_TABLES_HEADER_INC_FILE}
     COMMAND Python3::Interpreter ${GGT_SCRIPT}
       --spirv-core-grammar=${SPIRV_CORE_GRAMMAR_JSON_FILE}
       --extinst-debuginfo-grammar=${DEBUGINFO_GRAMMAR_JSON_FILE}
       --extinst-cldebuginfo100-grammar=${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
-      --core-tables-output=${CORE_TABLES_INC_FILE}
+      --core-tables-body-output=${CORE_TABLES_BODY_INC_FILE}
+      --core-tables-header-output=${CORE_TABLES_HEADER_INC_FILE}
     DEPENDS ${GGT_SCRIPT}
             ${SPIRV_CORE_GRAMMAR_JSON_FILE}
             ${DEBUGINFO_GRAMMAR_JSON_FILE}
             ${CLDEBUGINFO100_GRAMMAR_JSON_FILE}
     COMMENT "Generate core tables")
-add_custom_target(spirv-tools-tables DEPENDS ${CORE_TABLES_INC_FILE})
+add_custom_target(spirv-tools-tables DEPENDS ${CORE_TABLES_BODY_INC_FILE} ${CORE_TABLES_HEADER_INC_FILE})
 
 macro(spvtools_enum_string_mapping CONFIG_VERSION)
   set(GRAMMAR_JSON_FILE "${SPIRV_HEADER_INCLUDE_DIR}/spirv/${CONFIG_VERSION}/spirv.core.grammar.json")
@@ -144,7 +146,10 @@ list(APPEND OPCODE_CPP_DEPENDS ${GENERATOR_INC_FILE})
 # We need to wrap the .inc files with a custom target to avoid problems when
 # multiple targets depend on the same custom command.
 add_custom_target(core_tables
-  DEPENDS ${OPCODE_CPP_DEPENDS} ${OPERAND_CPP_DEPENDS} ${CORE_TABLES_INC_FILE})
+	DEPENDS ${OPCODE_CPP_DEPENDS}
+	        ${OPERAND_CPP_DEPENDS}
+		${CORE_TABLES_BODY_INC_FILE}
+		${CORE_TABLES_HEADER_INC_FILE})
 add_custom_target(enum_string_mapping
   DEPENDS ${EXTENSION_H_DEPENDS} ${ENUM_STRING_MAPPING_CPP_DEPENDS})
 add_custom_target(extinst_tables

--- a/source/table2.cpp
+++ b/source/table2.cpp
@@ -94,7 +94,7 @@ IndexRange OperandByValueRangeForKind(spv_operand_type_t type);
 // Returns the name of an extension, as an index into kStrings
 IndexRange ExtensionToIndexRange(Extension extension);
 
-#include "core_tables.inc"
+#include "core_tables_body.inc"
 
 // Returns a pointer to the null-terminated C-style string in the global
 // strings table, as referenced by 'ir'.  Assumes the given range is valid.

--- a/source/table2.h
+++ b/source/table2.h
@@ -58,6 +58,7 @@
 //      -  a spv::Op opcode
 //      -  a bool hasResult
 //      -  a bool hasType
+//      -  a printing class
 //
 // The arrays are represented by spans into a global static array, with one
 // array for each of:
@@ -82,6 +83,8 @@
 
 namespace spvtools {
 
+#include "core_tables_header.inc"
+
 using IndexRange = utils::IndexRange<uint32_t, uint32_t>;
 
 // Describes a SPIR-V operand.
@@ -100,8 +103,8 @@ struct OperandDesc {
   // Minimal core SPIR-V version required for this feature, if without
   // extensions. ~0u means reserved for future use. ~0u and non-empty
   // extension lists means only available in extensions.
-  const uint32_t minVersion;
-  const uint32_t lastVersion;
+  const uint32_t minVersion = 0xFFFFFFFFu;
+  const uint32_t lastVersion = 0xFFFFFFFFu;
   utils::Span<const spv_operand_type_t> operands() const;
   utils::Span<const char> name() const;
   utils::Span<const IndexRange> aliases() const;
@@ -119,15 +122,7 @@ struct OperandDesc {
         minVersion(mv),
         lastVersion(lv) {}
 
-  OperandDesc(uint32_t v)
-      : value(v),
-        operands_range(),
-        name_range(),
-        aliases_range(),
-        capabilities_range(),
-        extensions_range(),
-        minVersion(0u),
-        lastVersion(0u) {}
+  OperandDesc(uint32_t v) : value(v) {}
 
   OperandDesc(const OperandDesc&) = delete;
   OperandDesc(OperandDesc&&) = delete;
@@ -136,8 +131,8 @@ struct OperandDesc {
 // Describes an Instruction
 struct InstructionDesc {
   const spv::Op opcode;
-  const bool hasResult;
-  const bool hasType;
+  const bool hasResult = false;
+  const bool hasType = false;
 
   const IndexRange operands_range;      // Indexes kOperandSpans
   const IndexRange name_range;          // Indexes kStrings
@@ -151,8 +146,11 @@ struct InstructionDesc {
   // Minimal core SPIR-V version required for this feature, if without
   // extensions. ~0u means reserved for future use. ~0u and non-empty
   // extension lists means only available in extensions.
-  const uint32_t minVersion;
-  const uint32_t lastVersion;
+  const uint32_t minVersion = 0xFFFFFFFFu;
+  const uint32_t lastVersion = 0xFFFFFFFFu;
+  // The printing class specifies what kind of instruction it is, e.g. what
+  // section of the SPIR-V spec. E.g. kImage, kComposite
+  const PrintingClass printingClass = PrintingClass::kReserved;
   // Returns the span of elements in the global grammar tables corresponding
   // to the privately-stored index ranges
   utils::Span<const spv_operand_type_t> operands() const;
@@ -163,7 +161,7 @@ struct InstructionDesc {
 
   InstructionDesc(spv::Op oc, bool hr, bool ht, IndexRange o, IndexRange n,
                   IndexRange a, IndexRange c, IndexRange e, uint32_t mv,
-                  uint32_t lv)
+                  uint32_t lv, PrintingClass pc)
       : opcode(oc),
         hasResult(hr),
         hasType(ht),
@@ -173,19 +171,10 @@ struct InstructionDesc {
         capabilities_range(c),
         extensions_range(e),
         minVersion(mv),
-        lastVersion(lv) {}
+        lastVersion(lv),
+        printingClass(pc) {}
 
-  InstructionDesc(spv::Op oc)
-      : opcode(oc),
-        hasResult(false),
-        hasType(false),
-        operands_range(),
-        name_range(),
-        aliases_range(),
-        capabilities_range(),
-        extensions_range(),
-        minVersion(0u),
-        lastVersion(0u) {}
+  InstructionDesc(spv::Op oc) : opcode(oc) {}
 
   InstructionDesc(const InstructionDesc&) = delete;
   InstructionDesc(InstructionDesc&&) = delete;

--- a/test/opcode_lookup_test.cpp
+++ b/test/opcode_lookup_test.cpp
@@ -174,5 +174,59 @@ TEST(OpcodeLookupExtInstTest, Operands) {
                         SPV_OPERAND_TYPE_EXTENSION_INSTRUCTION_NUMBER}));
 }
 
+// Test printingClass
+
+struct OpcodePrintingClassCase {
+  std::string name;
+  PrintingClass expected;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         const OpcodePrintingClassCase& opcc) {
+  os << "OPCC('" << opcc.name << "', " << static_cast<int>(opcc.expected)
+     << ")";
+  return os;
+}
+
+using OpcodePrintingClassTest =
+    ::testing::TestWithParam<OpcodePrintingClassCase>;
+
+TEST_P(OpcodePrintingClassTest, OpcodeLookup_ByName) {
+  InstructionDesc* desc = nullptr;
+  auto status = LookupOpcode(GetParam().name.data(), &desc);
+  EXPECT_EQ(status, SPV_SUCCESS);
+  ASSERT_NE(desc, nullptr);
+  EXPECT_EQ(desc->printingClass, GetParam().expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Samples, OpcodePrintingClassTest,
+    ValuesIn(std::vector<OpcodePrintingClassCase>{
+        {"ConstantFunctionPointerINTEL", PrintingClass::k_exclude},
+        {"Nop", PrintingClass::kMiscellaneous},
+        {"SourceContinued", PrintingClass::kDebug},
+        {"Decorate", PrintingClass::kAnnotation},
+        {"Extension", PrintingClass::kExtension},
+        {"MemoryModel", PrintingClass::kMode_Setting},
+        {"Variable", PrintingClass::kMemory},
+        {"CooperativeMatrixPerElementOpNV", PrintingClass::kFunction},
+        {"SampledImage", PrintingClass::kImage},
+        {"ConvertFToU", PrintingClass::kConversion},
+        {"VectorExtractDynamic", PrintingClass::kComposite},
+        {"IAdd", PrintingClass::kArithmetic},
+        {"ShiftRightLogical", PrintingClass::kBit},
+        {"Any", PrintingClass::kRelational_and_Logical},
+        {"DPdx", PrintingClass::kDerivative},
+        {"Branch", PrintingClass::kControl_Flow},
+        {"AtomicLoad", PrintingClass::kAtomic},
+        {"ControlBarrier", PrintingClass::kBarrier},
+        {"GroupAll", PrintingClass::kGroup},
+        {"EnqueueMarker", PrintingClass::kDevice_Side_Enqueue},
+        {"ReadPipe", PrintingClass::kPipe},
+        {"GroupNonUniformElect", PrintingClass::kNon_Uniform},
+        // Skipping "Reserved" because it's probably an
+        // unstable class.
+    }));
+
 }  // namespace
 }  // namespace spvtools


### PR DESCRIPTION
The compressed tables content now goes to:

  core_tables_headers.h, included by table2.h
  core_tables_body.h, included by table2.cpp

Fixes: #6067