### PR TITLE
no static initializers

### DIFF
--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -60,7 +60,7 @@ spv_result_t spvTextParseMaskOperand(const spv_operand_type_t type,
   do {
     end = std::find(begin, text_end, separator);
 
-    spvtools::OperandDesc* entry = nullptr;
+    const spvtools::OperandDesc* entry = nullptr;
     if (auto error =
             spvtools::LookupOperand(type, begin, end - begin, &entry)) {
       return error;
@@ -175,7 +175,7 @@ CapabilitySet AssemblyGrammar::filterCapsAgainstTargetEnv(
   CapabilitySet cap_set;
   const auto version = spvVersionForTargetEnv(target_env_);
   for (uint32_t i = 0; i < count; ++i) {
-    spvtools::OperandDesc* entry = nullptr;
+    const spvtools::OperandDesc* entry = nullptr;
     if (SPV_SUCCESS ==
         spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                 static_cast<uint32_t>(cap_array[i]), &entry)) {
@@ -193,7 +193,7 @@ CapabilitySet AssemblyGrammar::filterCapsAgainstTargetEnv(
 
 const char* AssemblyGrammar::lookupOperandName(spv_operand_type_t type,
                                                uint32_t operand) const {
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   if (spvtools::LookupOperand(type, operand, &desc) != SPV_SUCCESS || !desc) {
     return "Unknown";
   }

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -318,7 +318,7 @@ spv_result_t Parser::parseInstruction() {
     return diagnostic() << "Invalid instruction word count: "
                         << inst_word_count;
   }
-  spvtools::InstructionDesc* opcode_desc = nullptr;
+  const spvtools::InstructionDesc* opcode_desc = nullptr;
   if (spvtools::LookupOpcode(static_cast<spv::Op>(inst.opcode), &opcode_desc))
     return diagnostic() << "Invalid opcode: " << inst.opcode;
 
@@ -522,7 +522,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
         return diagnostic()
                << "Invalid " << spvOperandTypeStr(type) << ": " << word;
       }
-      spvtools::InstructionDesc* opcode_entry = nullptr;
+      const spvtools::InstructionDesc* opcode_entry = nullptr;
       if (spvtools::LookupOpcode(spv::Op(word), &opcode_entry)) {
         return diagnostic(SPV_ERROR_INTERNAL)
                << "OpSpecConstant opcode table out of sync";
@@ -688,7 +688,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
       if (type == SPV_OPERAND_TYPE_OPTIONAL_FPENCODING)
         parsed_operand.type = SPV_OPERAND_TYPE_FPENCODING;
 
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (spvtools::LookupOperand(type, word, &entry)) {
         return diagnostic()
                << "Invalid " << spvOperandTypeStr(parsed_operand.type)
@@ -699,7 +699,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     } break;
 
     case SPV_OPERAND_TYPE_SOURCE_LANGUAGE: {
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (spvtools::LookupOperand(type, word, &entry)) {
         return diagnostic()
                << "Invalid " << spvOperandTypeStr(parsed_operand.type)
@@ -754,7 +754,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
       uint32_t remaining_word = word;
       for (uint32_t mask = (1u << 31); remaining_word; mask >>= 1) {
         if (remaining_word & mask) {
-          spvtools::OperandDesc* entry = nullptr;
+          const spvtools::OperandDesc* entry = nullptr;
           if (spvtools::LookupOperand(type, mask, &entry)) {
             return diagnostic()
                    << "Invalid " << spvOperandTypeStr(parsed_operand.type)
@@ -767,7 +767,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
       }
       if (word == 0) {
         // An all-zeroes mask *might* also be valid.
-        spvtools::OperandDesc* entry = nullptr;
+        const spvtools::OperandDesc* entry = nullptr;
         if (SPV_SUCCESS == spvtools::LookupOperand(type, 0, &entry)) {
           // Prepare for its operands, if any.
           spvPushOperandTypes(entry->operands(), expected_operands);

--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -886,7 +886,7 @@ void InstructionDisassembler::EmitOperand(std::ostream& stream,
       }
     } break;
     case SPV_OPERAND_TYPE_SPEC_CONSTANT_OP_NUMBER: {
-      spvtools::InstructionDesc* opcodeEntry = nullptr;
+      const spvtools::InstructionDesc* opcodeEntry = nullptr;
       if (LookupOpcode(spv::Op(word), &opcodeEntry))
         assert(false && "should have caught this earlier");
       SetRed(stream);
@@ -949,7 +949,7 @@ void InstructionDisassembler::EmitOperand(std::ostream& stream,
     case SPV_OPERAND_TYPE_QUANTIZATION_MODES:
     case SPV_OPERAND_TYPE_FPENCODING:
     case SPV_OPERAND_TYPE_OVERFLOW_MODES: {
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (spvtools::LookupOperand(operand.type, word, &entry))
         assert(false && "should have caught this earlier");
       stream << entry->name().data();
@@ -969,7 +969,7 @@ void InstructionDisassembler::EmitOperand(std::ostream& stream,
       if (spvOperandIsConcreteMask(operand.type)) {
         EmitMaskOperand(stream, operand.type, word);
       } else if (spvOperandIsConcrete(operand.type)) {
-        spvtools::OperandDesc* entry = nullptr;
+        const spvtools::OperandDesc* entry = nullptr;
         if (spvtools::LookupOperand(operand.type, word, &entry))
           assert(false && "should have caught this earlier");
         stream << entry->name().data();
@@ -992,7 +992,7 @@ void InstructionDisassembler::EmitMaskOperand(std::ostream& stream,
   for (mask = 1; remaining_word; mask <<= 1) {
     if (remaining_word & mask) {
       remaining_word ^= mask;
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (spvtools::LookupOperand(type, mask, &entry))
         assert(false && "should have caught this earlier");
       if (num_emitted) stream << "|";
@@ -1003,7 +1003,7 @@ void InstructionDisassembler::EmitMaskOperand(std::ostream& stream,
   if (!num_emitted) {
     // An operand value of 0 was provided, so represent it by the name
     // of the 0 value. In many cases, that's "None".
-    spvtools::OperandDesc* entry = nullptr;
+    const spvtools::OperandDesc* entry = nullptr;
     if (SPV_SUCCESS == spvtools::LookupOperand(type, 0, &entry))
       stream << entry->name().data();
   }

--- a/source/link/linker.cpp
+++ b/source/link/linker.cpp
@@ -292,8 +292,8 @@ spv_result_t MergeModules(const MessageConsumer& consumer,
     const uint32_t module_addressing_model =
         memory_model_inst->GetSingleWordOperand(0u);
     if (module_addressing_model != linked_addressing_model) {
-      spvtools::OperandDesc* linked_desc = nullptr;
-      spvtools::OperandDesc* module_desc = nullptr;
+      const spvtools::OperandDesc* linked_desc = nullptr;
+      const spvtools::OperandDesc* module_desc = nullptr;
       spvtools::LookupOperand(SPV_OPERAND_TYPE_ADDRESSING_MODEL,
                               linked_addressing_model, &linked_desc);
       spvtools::LookupOperand(SPV_OPERAND_TYPE_ADDRESSING_MODEL,
@@ -308,8 +308,8 @@ spv_result_t MergeModules(const MessageConsumer& consumer,
     const uint32_t module_memory_model =
         memory_model_inst->GetSingleWordOperand(1u);
     if (module_memory_model != linked_memory_model) {
-      spvtools::OperandDesc* linked_desc = nullptr;
-      spvtools::OperandDesc* module_desc = nullptr;
+      const spvtools::OperandDesc* linked_desc = nullptr;
+      const spvtools::OperandDesc* module_desc = nullptr;
       spvtools::LookupOperand(SPV_OPERAND_TYPE_MEMORY_MODEL,
                               linked_memory_model, &linked_desc);
       spvtools::LookupOperand(SPV_OPERAND_TYPE_MEMORY_MODEL,
@@ -335,7 +335,7 @@ spv_result_t MergeModules(const MessageConsumer& consumer,
             return v.first == model && v.second == name;
           });
       if (i != entry_points.end()) {
-        spvtools::OperandDesc* desc = nullptr;
+        const spvtools::OperandDesc* desc = nullptr;
         spvtools::LookupOperand(SPV_OPERAND_TYPE_EXECUTION_MODEL, model, &desc);
         return DiagnosticStream(position, consumer, "", SPV_ERROR_INTERNAL)
                << "The entry point \"" << name << "\", with execution model "

--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -328,7 +328,7 @@ spv_result_t FriendlyNameMapper::ParseInstruction(
 
 std::string FriendlyNameMapper::NameForEnumOperand(spv_operand_type_t type,
                                                    uint32_t word) {
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   if (SPV_SUCCESS == spvtools::LookupOperand(type, word, &desc)) {
     return desc->name().data();
   } else {

--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -88,7 +88,7 @@ void spvInstructionCopy(const uint32_t* words, const spv::Op opcode,
 }
 
 const char* spvOpcodeString(const uint32_t opcode) {
-  spvtools::InstructionDesc* desc = nullptr;
+  const spvtools::InstructionDesc* desc = nullptr;
   if (SPV_SUCCESS !=
       spvtools::LookupOpcode(static_cast<spv::Op>(opcode), &desc)) {
     assert(0 && "Unreachable!");

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -247,7 +247,7 @@ void spvPushOperandTypesForMask(const spv_operand_type_t type,
   for (uint32_t candidate_bit = (1u << 31u); candidate_bit;
        candidate_bit >>= 1) {
     if (candidate_bit & mask) {
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (SPV_SUCCESS == spvtools::LookupOperand(type, candidate_bit, &entry)) {
         spvPushOperandTypes(entry->operands(), pattern);
       }

--- a/source/opt/feature_manager.cpp
+++ b/source/opt/feature_manager.cpp
@@ -54,7 +54,7 @@ void FeatureManager::AddCapability(spv::Capability cap) {
 
   capabilities_.insert(cap);
 
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   if (SPV_SUCCESS == spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                              uint32_t(cap), &desc)) {
     for (auto capability :

--- a/source/opt/replace_invalid_opc.cpp
+++ b/source/opt/replace_invalid_opc.cpp
@@ -209,7 +209,7 @@ uint32_t ReplaceInvalidOpcodePass::GetSpecialConstant(uint32_t type_id) {
 }
 
 std::string ReplaceInvalidOpcodePass::BuildWarningMessage(spv::Op opcode) {
-  spvtools::InstructionDesc* opcode_desc = nullptr;
+  const spvtools::InstructionDesc* opcode_desc = nullptr;
   spvtools::LookupOpcode(opcode, &opcode_desc);
   std::string message = "Removing ";
   message += opcode_desc->name().data();

--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -449,7 +449,7 @@ constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 14> kOpcodeHandlers{{
 namespace {
 ExtensionSet getExtensionsRelatedTo(const CapabilitySet& capabilities) {
   ExtensionSet output;
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   for (auto capability : capabilities) {
     if (SPV_SUCCESS !=
         spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
@@ -512,7 +512,7 @@ void TrimCapabilitiesPass::addInstructionRequirementsForOpcode(
     return;
   }
 
-  spvtools::InstructionDesc* desc;
+  const spvtools::InstructionDesc* desc;
   auto result = spvtools::LookupOpcode(opcode, &desc);
   if (result != SPV_SUCCESS) {
     return;
@@ -550,7 +550,7 @@ void TrimCapabilitiesPass::addInstructionRequirementsForOperand(
 
   // case 1: Operand is a single value, can directly lookup.
   if (!spvOperandIsConcreteMask(operand.type)) {
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     auto result =
         spvtools::LookupOperand(operand.type, operand.words[0], &desc);
     if (result != SPV_SUCCESS) {
@@ -568,7 +568,7 @@ void TrimCapabilitiesPass::addInstructionRequirementsForOperand(
       continue;
     }
 
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     auto result = spvtools::LookupOperand(operand.type, mask, &desc);
     if (result != SPV_SUCCESS) {
       continue;
@@ -647,7 +647,7 @@ void TrimCapabilitiesPass::addInstructionRequirements(
 void TrimCapabilitiesPass::AddExtensionsForOperand(
     const spv_operand_type_t type, const uint32_t value,
     ExtensionSet* extensions) const {
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   spv_result_t result = spvtools::LookupOperand(type, value, &desc);
   if (result != SPV_SUCCESS) {
     return;

--- a/source/table2.h
+++ b/source/table2.h
@@ -181,10 +181,10 @@ struct InstructionDesc {
 
 // Finds the instruction description by opcode name. The name should not
 // have the "Op" prefix. On success, returns SPV_SUCCESS and updates *desc.
-spv_result_t LookupOpcode(const char* name, InstructionDesc** desc);
+spv_result_t LookupOpcode(const char* name, const InstructionDesc** desc);
 // Finds the instruction description by opcode value.
 // On success, returns SPV_SUCCESS and updates *desc.
-spv_result_t LookupOpcode(spv::Op opcode, InstructionDesc** desc);
+spv_result_t LookupOpcode(spv::Op opcode, const InstructionDesc** desc);
 
 // Finds the instruction description by opcode name, without the "Op" prefix.
 // A lookup will succeed if:
@@ -195,7 +195,7 @@ spv_result_t LookupOpcode(spv::Op opcode, InstructionDesc** desc);
 //   or the instruction is enabled by at least one capability.,
 // On success, returns SPV_SUCCESS and updates *desc.
 spv_result_t LookupOpcodeForEnv(spv_target_env env, const char* name,
-                                InstructionDesc** desc);
+                                const InstructionDesc** desc);
 
 // Finds the instruction description by opcode value.
 // A lookup will succeed if:
@@ -206,12 +206,12 @@ spv_result_t LookupOpcodeForEnv(spv_target_env env, const char* name,
 //   or the instruction is enabled by at least one capability.,
 // On success, returns SPV_SUCCESS and updates *desc.
 spv_result_t LookupOpcodeForEnv(spv_target_env env, spv::Op,
-                                InstructionDesc** desc);
+                                const InstructionDesc** desc);
 
 spv_result_t LookupOperand(spv_operand_type_t type, const char* name,
-                           size_t name_len, OperandDesc** desc);
+                           size_t name_len, const OperandDesc** desc);
 spv_result_t LookupOperand(spv_operand_type_t type, uint32_t operand,
-                           OperandDesc** desc);
+                           const OperandDesc** desc);
 
 // Finds Extension enum corresponding to |str|. Returns false if not found.
 bool GetExtensionFromString(const char* str, Extension* extension);

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -285,7 +285,7 @@ spv_result_t spvTextEncodeOperand(const spvtools::AssemblyGrammar& grammar,
         return context->diagnostic() << "Invalid " << spvOperandTypeStr(type)
                                      << " '" << textValue << "'.";
       }
-      spvtools::InstructionDesc* opcodeEntry = nullptr;
+      const spvtools::InstructionDesc* opcodeEntry = nullptr;
       if (LookupOpcodeForEnv(grammar.target_env(), opcode, &opcodeEntry)) {
         return context->diagnostic(SPV_ERROR_INTERNAL)
                << "OpSpecConstant opcode table out of sync";
@@ -348,7 +348,7 @@ spv_result_t spvTextEncodeOperand(const spvtools::AssemblyGrammar& grammar,
             context->getTypeOfTypeGeneratingValue(pInst->resultTypeId);
         if (!spvtools::isScalarFloating(expected_type) &&
             !spvtools::isScalarIntegral(expected_type)) {
-          spvtools::InstructionDesc* opcodeEntry = nullptr;
+          const spvtools::InstructionDesc* opcodeEntry = nullptr;
           const char* opcode_name = "opcode";
           if (SPV_SUCCESS == LookupOpcode(pInst->opcode, &opcodeEntry)) {
             opcode_name =
@@ -458,7 +458,7 @@ spv_result_t spvTextEncodeOperand(const spvtools::AssemblyGrammar& grammar,
     default: {
       // NOTE: All non literal operands are handled here using the operand
       // table.
-      spvtools::OperandDesc* entry = nullptr;
+      const spvtools::OperandDesc* entry = nullptr;
       if (spvtools::LookupOperand(type, textValue, strlen(textValue), &entry)) {
         return context->diagnostic() << "Invalid " << spvOperandTypeStr(type)
                                      << " '" << textValue << "'.";
@@ -708,7 +708,7 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
   // NOTE: The table contains Opcode names without the "Op" prefix.
   const char* pInstName = opcodeName.data() + 2;
 
-  spvtools::InstructionDesc* opcodeEntry = nullptr;
+  const spvtools::InstructionDesc* opcodeEntry = nullptr;
   error = LookupOpcodeForEnv(grammar.target_env(), pInstName, &opcodeEntry);
   if (error) {
     return context->diagnostic(error)

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -287,7 +287,7 @@ bool IsSupportOptionalOpenCL_1_2(uint32_t capability) {
 
 // Checks if |capability| was enabled by extension.
 bool IsEnabledByExtension(ValidationState_t& _, uint32_t capability) {
-  spvtools::OperandDesc* operand_desc = nullptr;
+  const spvtools::OperandDesc* operand_desc = nullptr;
   spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY, capability,
                           &operand_desc);
 
@@ -355,7 +355,7 @@ spv_result_t CapabilityPass(ValidationState_t& _, const Instruction* inst) {
 
   const uint32_t capability = inst->word(operand.offset);
   const auto capability_str = [capability]() {
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     if (spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY, capability,
                                 &desc) != SPV_SUCCESS ||
         !desc) {

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -93,7 +93,7 @@ spv_result_t ValidateOperandForDebugInfo(
     const std::function<std::string()>& ext_inst_name) {
   auto* operand = _.FindDef(inst->word(word_index));
   if (operand->opcode() != expected_opcode) {
-    spvtools::InstructionDesc* desc = nullptr;
+    const spvtools::InstructionDesc* desc = nullptr;
     if (spvtools::LookupOpcodeForEnv(_.context()->target_env, expected_opcode,
                                      &desc) != SPV_SUCCESS ||
         !desc) {

--- a/source/val/validate_instruction.cpp
+++ b/source/val/validate_instruction.cpp
@@ -38,7 +38,7 @@ namespace {
 std::string ToString(const CapabilitySet& capabilities) {
   std::stringstream ss;
   for (auto capability : capabilities) {
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     if (SPV_SUCCESS == spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                                uint32_t(capability), &desc))
       ss << desc->name().data() << " ";
@@ -71,7 +71,7 @@ CapabilitySet EnablingCapabilitiesForOp(const ValidationState_t& state,
       break;
   }
   // Look it up in the grammar
-  spvtools::InstructionDesc* opcode_desc = nullptr;
+  const spvtools::InstructionDesc* opcode_desc = nullptr;
   if (SPV_SUCCESS ==
       LookupOpcodeForEnv(state.context()->target_env, opcode, &opcode_desc)) {
     return state.grammar().filterCapsAgainstTargetEnv(
@@ -168,7 +168,7 @@ spv_result_t CheckRequiredCapabilities(ValidationState_t& state,
   }
 
   CapabilitySet enabling_capabilities;
-  spvtools::OperandDesc* operand_desc = nullptr;
+  const spvtools::OperandDesc* operand_desc = nullptr;
   const auto lookup_result =
       spvtools::LookupOperand(operand.type, word, &operand_desc);
   if (lookup_result == SPV_SUCCESS) {
@@ -224,7 +224,7 @@ spv_result_t ReservedCheck(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpImageSparseSampleProjExplicitLod:
     case spv::Op::OpImageSparseSampleProjDrefImplicitLod:
     case spv::Op::OpImageSparseSampleProjDrefExplicitLod: {
-      spvtools::InstructionDesc* inst_desc = nullptr;
+      const spvtools::InstructionDesc* inst_desc = nullptr;
       spvtools::LookupOpcode(opcode, &inst_desc);
       return _.diag(SPV_ERROR_INVALID_BINARY, inst)
              << "Invalid Opcode name 'Op" << inst_desc->name().data() << "'";
@@ -277,7 +277,7 @@ spv_result_t CapabilityCheck(ValidationState_t& _, const Instruction* inst) {
 // dependencies for the opcode.
 spv_result_t VersionCheck(ValidationState_t& _, const Instruction* inst) {
   const auto opcode = inst->opcode();
-  spvtools::InstructionDesc* inst_desc;
+  const spvtools::InstructionDesc* inst_desc = nullptr;
   const spv_result_t r = spvtools::LookupOpcode(opcode, &inst_desc);
   assert(r == SPV_SUCCESS);
   (void)r;

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -927,7 +927,7 @@ spv_result_t ValidateDuplicateExecutionModes(ValidationState_t& _) {
   std::set<PerOperandKey> seen_per_operand;
 
   const auto lookupMode = [](spv::ExecutionMode mode) -> std::string {
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     if (spvtools::LookupOperand(SPV_OPERAND_TYPE_EXECUTION_MODE,
                                 static_cast<uint32_t>(mode),
                                 &desc) == SPV_SUCCESS) {

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -368,7 +368,7 @@ void ValidationState_t::RegisterCapability(spv::Capability cap) {
   if (module_capabilities_.contains(cap)) return;
 
   module_capabilities_.insert(cap);
-  spvtools::OperandDesc* desc = nullptr;
+  const spvtools::OperandDesc* desc = nullptr;
   if (SPV_SUCCESS == spvtools::LookupOperand(SPV_OPERAND_TYPE_CAPABILITY,
                                              uint32_t(cap), &desc)) {
     for (auto capability : CapabilitySet(desc->capabilities_range.count(),

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -789,7 +789,7 @@ class ValidationState_t {
 
   // Returns the string name for |decoration|.
   std::string SpvDecorationString(uint32_t decoration) {
-    spvtools::OperandDesc* desc = nullptr;
+    const spvtools::OperandDesc* desc = nullptr;
     if (spvtools::LookupOperand(SPV_OPERAND_TYPE_DECORATION, decoration,
                                 &desc) != SPV_SUCCESS) {
       return std::string("Unknown");

--- a/test/opcode_lookup_test.cpp
+++ b/test/opcode_lookup_test.cpp
@@ -41,7 +41,7 @@ std::ostream& operator<<(std::ostream& os, const OpcodeLookupCase& olc) {
 using OpcodeLookupTest = ::testing::TestWithParam<OpcodeLookupCase>;
 
 TEST_P(OpcodeLookupTest, OpcodeLookup_ByName) {
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   auto status = LookupOpcode(GetParam().name.data(), &desc);
   if (GetParam().expect_pass) {
     EXPECT_EQ(status, SPV_SUCCESS);
@@ -54,7 +54,7 @@ TEST_P(OpcodeLookupTest, OpcodeLookup_ByName) {
 }
 
 TEST_P(OpcodeLookupTest, OpcodeLookup_ByOpcode_Success) {
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   if (GetParam().expect_pass) {
     spv::Op opcode = static_cast<spv::Op>(GetParam().opcode);
     auto status = LookupOpcode(opcode, &desc);
@@ -80,7 +80,7 @@ TEST(OpcodeLookupSingleTest, OpcodeLookup_ByOpcode_Fails) {
   // This list may need adjusting over time.
   std::array<uint32_t, 3> bad_opcodes = {{99999, 37737, 110101}};
   for (auto bad_opcode : bad_opcodes) {
-    InstructionDesc* desc = nullptr;
+    const InstructionDesc* desc = nullptr;
     spv::Op opcode = static_cast<spv::Op>(bad_opcode);
     auto status = LookupOpcode(opcode, &desc);
     EXPECT_NE(status, SPV_SUCCESS);
@@ -105,7 +105,7 @@ std::ostream& operator<<(std::ostream& os, const OpcodeLookupEnvCase& olec) {
 using OpcodeLookupEnvTest = ::testing::TestWithParam<OpcodeLookupEnvCase>;
 
 TEST_P(OpcodeLookupEnvTest, OpcodeLookupForEnv_ByName) {
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   auto status =
       LookupOpcodeForEnv(GetParam().env, GetParam().name.data(), &desc);
   if (GetParam().expect_pass) {
@@ -119,7 +119,7 @@ TEST_P(OpcodeLookupEnvTest, OpcodeLookupForEnv_ByName) {
 }
 
 TEST_P(OpcodeLookupEnvTest, OpcodeLookupForEnv_ByOpcode) {
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   spv::Op opcode = static_cast<spv::Op>(GetParam().opcode);
   auto status = LookupOpcodeForEnv(GetParam().env, opcode, &desc);
   if (GetParam().expect_pass) {
@@ -157,7 +157,7 @@ TEST(OpcodeLookupExtInstTest, Operands) {
   // extended instruction enum, such as 'cos'.
   // See https://github.com/KhronosGroup/SPIRV-Tools/issues/233
   // Test the exact sequence of operand types extracted for OpExtInst.
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   auto status = LookupOpcode("ExtInst", &desc);
   EXPECT_EQ(status, SPV_SUCCESS);
   ASSERT_NE(desc, nullptr);
@@ -192,7 +192,7 @@ using OpcodePrintingClassTest =
     ::testing::TestWithParam<OpcodePrintingClassCase>;
 
 TEST_P(OpcodePrintingClassTest, OpcodeLookup_ByName) {
-  InstructionDesc* desc = nullptr;
+  const InstructionDesc* desc = nullptr;
   auto status = LookupOpcode(GetParam().name.data(), &desc);
   EXPECT_EQ(status, SPV_SUCCESS);
   ASSERT_NE(desc, nullptr);

--- a/test/opcode_require_capabilities_test.cpp
+++ b/test/opcode_require_capabilities_test.cpp
@@ -31,7 +31,7 @@ using OpcodeTableCapabilitiesTest =
     ::testing::TestWithParam<ExpectedOpCodeCapabilities>;
 
 TEST_P(OpcodeTableCapabilitiesTest, TableEntryMatchesExpectedCapabilities) {
-  spvtools::InstructionDesc* desc = nullptr;
+  const spvtools::InstructionDesc* desc = nullptr;
   ASSERT_EQ(SPV_SUCCESS, spvtools::LookupOpcode(GetParam().opcode, &desc));
   auto caps = desc->capabilities();
   EXPECT_EQ(ElementsIn(GetParam().capabilities),

--- a/test/operand_capabilities_test.cpp
+++ b/test/operand_capabilities_test.cpp
@@ -81,7 +81,7 @@ TEST_P(EnumCapabilityTest, Sample) {
   const auto env = std::get<0>(GetParam());
   const auto context = spvContextCreate(env);
   const AssemblyGrammar grammar(context);
-  spvtools::OperandDesc* entry = nullptr;
+  const spvtools::OperandDesc* entry = nullptr;
 
   ASSERT_EQ(SPV_SUCCESS,
             spvtools::LookupOperand(std::get<1>(GetParam()).type,

--- a/test/operand_lookup_test.cpp
+++ b/test/operand_lookup_test.cpp
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& os, const OperandLookupCase& olc) {
 using OperandLookupTest = ::testing::TestWithParam<OperandLookupCase>;
 
 TEST_P(OperandLookupTest, OperandLookup_ByName) {
-  OperandDesc* desc = nullptr;
+  const OperandDesc* desc = nullptr;
   auto status = LookupOperand(GetParam().type, GetParam().name.data(),
                               GetParam().name_length, &desc);
   if (GetParam().expect_pass) {
@@ -59,7 +59,7 @@ TEST_P(OperandLookupTest, OperandLookup_ByName) {
 }
 
 TEST_P(OperandLookupTest, OperandLookup_ByValue_Success) {
-  OperandDesc* desc = nullptr;
+  const OperandDesc* desc = nullptr;
   if (GetParam().expect_pass) {
     const auto value = GetParam().value;
     auto status = LookupOperand(GetParam().type, GetParam().value, &desc);
@@ -105,7 +105,7 @@ TEST(OperandLookupSingleTest, OperandLookup_ByValue_Fails) {
   std::array<uint32_t, 3> bad_values = {{99999, 37737, 110101}};
   for (auto type : types) {
     for (auto bad_value : bad_values) {
-      OperandDesc* desc = nullptr;
+      const OperandDesc* desc = nullptr;
       auto status = LookupOperand(type, bad_value, &desc);
       EXPECT_NE(status, SPV_SUCCESS);
       ASSERT_EQ(desc, nullptr);
@@ -115,7 +115,7 @@ TEST(OperandLookupSingleTest, OperandLookup_ByValue_Fails) {
 
 TEST(OperandLookupOperands, Sample) {
   // Check the operand list for a valid operand lookup.
-  OperandDesc* desc = nullptr;
+  const OperandDesc* desc = nullptr;
   auto status = LookupOperand(SPV_OPERAND_TYPE_IMAGE, "Grad", 4, &desc);
   EXPECT_EQ(status, SPV_SUCCESS);
   ASSERT_NE(desc, nullptr);

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -2375,7 +2375,7 @@ spv_result_t spvCoreOperandTableNameLookup(spv_target_env env,
                                            const size_t nameLength) {
   if (!name) return SPV_ERROR_INVALID_POINTER;
 
-  spvtools::OperandDesc* entry = nullptr;
+  const spvtools::OperandDesc* entry = nullptr;
   if (SPV_SUCCESS == spvtools::LookupOperand(type, name, nameLength, &entry)) {
     // Check for min version only.
     if (spvVersionForTargetEnv(env) >= entry->minVersion) {

--- a/utils/ggt.py
+++ b/utils/ggt.py
@@ -246,10 +246,13 @@ constexpr inline IndexRange IR(uint32_t first, uint32_t count) {
 // The fields in order are:
 //   name, indexing into kStrings
 //   enum value""")
-        parts.append("std::array<NameValue, {}> kExtensionNames{{{{".format(len(self.extensions)))
+        parts.append("const std::array<NameValue,{}>& getExtensionNames() {{".format(len(self.extensions)))
+        parts.append("  static const std::array<NameValue,{}> kExtensionNames{{{{".format(len(self.extensions)))
         for e in self.extensions:
-            parts.append('  {{{}, static_cast<uint32_t>({})}},'.format(self.context.AddString(e), to_safe_identifier(e)))
-        parts.append("}};\n")
+            parts.append('    {{{}, static_cast<uint32_t>({})}},'.format(self.context.AddString(e), to_safe_identifier(e)))
+        parts.append("  }};")
+        parts.append("  return kExtensionNames;")
+        parts.append("}\n")
         self.body_decls.extend(parts)
 
     def ComputeOperandTables(self) -> None:
@@ -355,9 +358,12 @@ struct OperandDesc {
 // The fields in order are:
 //   name, either the primary name or an alias, indexing into kStrings
 //   enum value""")
-        parts.append("std::array<NameValue, {}> kOperandNames{{{{".format(len(operand_name_strings)))
-        parts.extend(['  ' + str(x) for x in operand_name_strings])
-        parts.append("}};\n")
+        parts.append("const std::array<NameValue, {}>& getOperandNames() {{".format(len(operand_name_strings)))
+        parts.append("  static const std::array<NameValue, {}> kOperandNames{{{{".format(len(operand_name_strings)))
+        parts.extend(['    ' + str(x) for x in operand_name_strings])
+        parts.append("  }};")
+        parts.append("  return kOperandNames;")
+        parts.append("}\n")
         self.body_decls.extend(parts)
 
         parts.append("""// Maps an operand kind to possible names for operands of that kind.
@@ -415,9 +421,12 @@ struct OperandDesc {
 //   extensions, as an IndexRange into kExtensionSpans
 //   version, first version of SPIR-V that has it
 //   lastVersion, last version of SPIR-V that has it""")
-        parts.append("std::array<OperandDesc, {}> kOperandsByValue{{{{".format(len(operands_by_value)))
-        parts.extend(['  ' + str(x) for x in operands_by_value])
-        parts.append("}};\n")
+        parts.append("const std::array<OperandDesc, {}>& getOperandsByValue() {{".format(len(operands_by_value)))
+        parts.append("  static const std::array<OperandDesc, {}> kOperandsByValue{{{{".format(len(operands_by_value)))
+        parts.extend(['    ' + str(x) for x in operands_by_value])
+        parts.append("  }};\n")
+        parts.append("  return kOperandsByValue;\n")
+        parts.append("}\n")
         self.body_decls.extend(parts)
 
         parts = []
@@ -498,9 +507,12 @@ struct InstructionDesc {
 // The fields in order are:
 //   name, either the primary name or an alias, indexing into kStrings
 //   opcode value""")
-        parts.append("std::array<NameValue, {}> kInstructionNames{{{{".format(len(inst_name_strings)))
-        parts.extend(['  ' + str(x) for x in inst_name_strings])
-        parts.append("}};\n")
+        parts.append("const std::array<NameValue, {}>& getInstructionNames() {{".format(len(inst_name_strings)))
+        parts.append("  static const std::array<NameValue, {}> kInstructionNames{{{{".format(len(inst_name_strings)))
+        parts.extend(['    ' + str(x) for x in inst_name_strings])
+        parts.append("  }};\n")
+        parts.append("  return kInstructionNames;\n")
+        parts.append("}\n")
         self.body_decls.extend(parts)
 
         # Create the array of InstructionDesc
@@ -553,9 +565,12 @@ struct InstructionDesc {
 //   extensions, as an IndexRange into kExtensionSpans
 //   version, first version of SPIR-V that has it
 //   lastVersion, last version of SPIR-V that has it""")
-        parts.append("std::array<InstructionDesc, {}> kInstructionDesc{{{{".format(len(lines)));
+        parts.append("const std::array<InstructionDesc, {}>& getInstructionDesc() {{".format(len(lines)));
+        parts.append("  static const std::array<InstructionDesc, {}> kInstructionDesc{{{{".format(len(lines)));
         parts.extend(['  ' + l for l in lines])
-        parts.append("}};\n");
+        parts.append("  }};\n");
+        parts.append("  return kInstructionDesc;");
+        parts.append("}\n");
         self.body_decls.extend(parts)
 
 


### PR DESCRIPTION
Chromium bans static initializers of class objects.

Wrap the std::array static variables with a function that returns a reference to them.
This is option 2 to remove static initializers, at https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/static_initializers.md#Removing-Static-Initializers

Also, lookup methods update a pointer-to-const pointer.