### PR TITLE
use static std::array for grammar tables again

### DIFF
--- a/source/table2.cpp
+++ b/source/table2.cpp
@@ -139,13 +139,12 @@ utils::Span<const spvtools::Extension> InstructionDesc::extensions() const {
 spv_result_t LookupOpcode(spv::Op opcode, const InstructionDesc** desc) {
   // Metaphor: Look for the needle in the haystack.
   const InstructionDesc needle(opcode);
-  const auto& descs = getInstructionDesc();
   auto where = std::lower_bound(
-      descs.begin(), descs.end(), needle,
+      kInstructionDesc.begin(), kInstructionDesc.end(), needle,
       [&](const InstructionDesc& lhs, const InstructionDesc& rhs) {
         return uint32_t(lhs.opcode) < uint32_t(rhs.opcode);
       });
-  if (where != descs.end() && where->opcode == opcode) {
+  if (where != kInstructionDesc.end() && where->opcode == opcode) {
     *desc = &*where;
     return SPV_SUCCESS;
   }
@@ -163,9 +162,10 @@ spv_result_t LookupOpcode(const char* name, const InstructionDesc** desc) {
     return std::strcmp(lhs_chars, rhs_chars) < 0;
   };
 
-  const auto& names = getInstructionNames();
-  auto where = std::lower_bound(names.begin(), names.end(), needle, less);
-  if (where != names.end() && std::strcmp(getChars(where->name), name) == 0) {
+  auto where = std::lower_bound(kInstructionNames.begin(),
+                                kInstructionNames.end(), needle, less);
+  if (where != kInstructionNames.end() &&
+      std::strcmp(getChars(where->name), name) == 0) {
     return LookupOpcode(static_cast<spv::Op>(where->value), desc);
   }
   return SPV_ERROR_INVALID_LOOKUP;
@@ -209,7 +209,7 @@ spv_result_t LookupOperand(spv_operand_type_t type, uint32_t value,
     return SPV_ERROR_INVALID_LOOKUP;
   }
 
-  auto span = ir.apply(getOperandsByValue().data());
+  auto span = ir.apply(kOperandsByValue.data());
 
   // Metaphor: Look for the needle in the haystack.
   // The operand value is the first member.
@@ -233,7 +233,7 @@ spv_result_t LookupOperand(spv_operand_type_t type, const char* name,
     return SPV_ERROR_INVALID_LOOKUP;
   }
 
-  auto span = ir.apply(getOperandNames().data());
+  auto span = ir.apply(kOperandNames.data());
 
   // The comparison function knows to use (name, name_len) as the
   // string to compare against when the value is kSentinel.
@@ -278,10 +278,9 @@ bool GetExtensionFromString(const char* name, Extension* extension) {
     return std::strcmp(lhs_chars, rhs_chars) < 0;
   };
 
-  const auto& extension_names = getExtensionNames();
-  auto where = std::lower_bound(extension_names.begin(), extension_names.end(),
+  auto where = std::lower_bound(kExtensionNames.begin(), kExtensionNames.end(),
                                 needle, less);
-  if (where != extension_names.end() &&
+  if (where != kExtensionNames.end() &&
       std::strcmp(getChars(where->name), name) == 0) {
     *extension = static_cast<Extension>(where->value);
     return true;

--- a/source/table2.h
+++ b/source/table2.h
@@ -110,8 +110,8 @@ struct OperandDesc {
   utils::Span<const spv::Capability> capabilities() const;
   utils::Span<const spvtools::Extension> extensions() const;
 
-  OperandDesc(uint32_t v, IndexRange o, IndexRange n, IndexRange a,
-              IndexRange c, IndexRange e, uint32_t mv, uint32_t lv)
+  constexpr OperandDesc(uint32_t v, IndexRange o, IndexRange n, IndexRange a,
+                        IndexRange c, IndexRange e, uint32_t mv, uint32_t lv)
       : value(v),
         operands_range(o),
         name_range(n),
@@ -121,7 +121,7 @@ struct OperandDesc {
         minVersion(mv),
         lastVersion(lv) {}
 
-  OperandDesc(uint32_t v) : value(v) {}
+  constexpr OperandDesc(uint32_t v) : value(v) {}
 
   OperandDesc(const OperandDesc&) = delete;
   OperandDesc(OperandDesc&&) = delete;
@@ -158,9 +158,10 @@ struct InstructionDesc {
   utils::Span<const spv::Capability> capabilities() const;
   utils::Span<const spvtools::Extension> extensions() const;
 
-  InstructionDesc(spv::Op oc, bool hr, bool ht, IndexRange o, IndexRange n,
-                  IndexRange a, IndexRange c, IndexRange e, uint32_t mv,
-                  uint32_t lv, PrintingClass pc)
+  constexpr InstructionDesc(spv::Op oc, bool hr, bool ht, IndexRange o,
+                            IndexRange n, IndexRange a, IndexRange c,
+                            IndexRange e, uint32_t mv, uint32_t lv,
+                            PrintingClass pc)
       : opcode(oc),
         hasResult(hr),
         hasType(ht),
@@ -173,7 +174,7 @@ struct InstructionDesc {
         lastVersion(lv),
         printingClass(pc) {}
 
-  InstructionDesc(spv::Op oc) : opcode(oc) {}
+  constexpr InstructionDesc(spv::Op oc) : opcode(oc) {}
 
   InstructionDesc(const InstructionDesc&) = delete;
   InstructionDesc(InstructionDesc&&) = delete;

--- a/utils/ggt.py
+++ b/utils/ggt.py
@@ -246,13 +246,10 @@ constexpr inline IndexRange IR(uint32_t first, uint32_t count) {
 // The fields in order are:
 //   name, indexing into kStrings
 //   enum value""")
-        parts.append("const std::array<NameValue,{}>& getExtensionNames() {{".format(len(self.extensions)))
-        parts.append("  static const std::array<NameValue,{}> kExtensionNames{{{{".format(len(self.extensions)))
+        parts.append("static const std::array<NameValue,{}> kExtensionNames{{{{".format(len(self.extensions)))
         for e in self.extensions:
             parts.append('    {{{}, static_cast<uint32_t>({})}},'.format(self.context.AddString(e), to_safe_identifier(e)))
-        parts.append("  }};")
-        parts.append("  return kExtensionNames;")
-        parts.append("}\n")
+        parts.append("}};\n")
         self.body_decls.extend(parts)
 
     def ComputeOperandTables(self) -> None:
@@ -358,12 +355,9 @@ struct OperandDesc {
 // The fields in order are:
 //   name, either the primary name or an alias, indexing into kStrings
 //   enum value""")
-        parts.append("const std::array<NameValue, {}>& getOperandNames() {{".format(len(operand_name_strings)))
-        parts.append("  static const std::array<NameValue, {}> kOperandNames{{{{".format(len(operand_name_strings)))
-        parts.extend(['    ' + str(x) for x in operand_name_strings])
-        parts.append("  }};")
-        parts.append("  return kOperandNames;")
-        parts.append("}\n")
+        parts.append("static const std::array<NameValue, {}> kOperandNames{{{{".format(len(operand_name_strings)))
+        parts.extend(['  ' + str(x) for x in operand_name_strings])
+        parts.append("}};\n")
         self.body_decls.extend(parts)
 
         parts.append("""// Maps an operand kind to possible names for operands of that kind.
@@ -421,12 +415,9 @@ struct OperandDesc {
 //   extensions, as an IndexRange into kExtensionSpans
 //   version, first version of SPIR-V that has it
 //   lastVersion, last version of SPIR-V that has it""")
-        parts.append("const std::array<OperandDesc, {}>& getOperandsByValue() {{".format(len(operands_by_value)))
-        parts.append("  static const std::array<OperandDesc, {}> kOperandsByValue{{{{".format(len(operands_by_value)))
-        parts.extend(['    ' + str(x) for x in operands_by_value])
-        parts.append("  }};\n")
-        parts.append("  return kOperandsByValue;\n")
-        parts.append("}\n")
+        parts.append("static const std::array<OperandDesc, {}> kOperandsByValue{{{{".format(len(operands_by_value)))
+        parts.extend(['  ' + str(x) for x in operands_by_value])
+        parts.append("}};\n")
         self.body_decls.extend(parts)
 
         parts = []
@@ -507,12 +498,9 @@ struct InstructionDesc {
 // The fields in order are:
 //   name, either the primary name or an alias, indexing into kStrings
 //   opcode value""")
-        parts.append("const std::array<NameValue, {}>& getInstructionNames() {{".format(len(inst_name_strings)))
-        parts.append("  static const std::array<NameValue, {}> kInstructionNames{{{{".format(len(inst_name_strings)))
-        parts.extend(['    ' + str(x) for x in inst_name_strings])
-        parts.append("  }};\n")
-        parts.append("  return kInstructionNames;\n")
-        parts.append("}\n")
+        parts.append("static const std::array<NameValue, {}> kInstructionNames{{{{".format(len(inst_name_strings)))
+        parts.extend(['  ' + str(x) for x in inst_name_strings])
+        parts.append("}};\n")
         self.body_decls.extend(parts)
 
         # Create the array of InstructionDesc
@@ -565,12 +553,9 @@ struct InstructionDesc {
 //   extensions, as an IndexRange into kExtensionSpans
 //   version, first version of SPIR-V that has it
 //   lastVersion, last version of SPIR-V that has it""")
-        parts.append("const std::array<InstructionDesc, {}>& getInstructionDesc() {{".format(len(lines)));
-        parts.append("  static const std::array<InstructionDesc, {}> kInstructionDesc{{{{".format(len(lines)));
+        parts.append("static const std::array<InstructionDesc, {}> kInstructionDesc{{{{".format(len(lines)));
         parts.extend(['  ' + l for l in lines])
-        parts.append("  }};\n");
-        parts.append("  return kInstructionDesc;");
-        parts.append("}\n");
+        parts.append("}};\n");
         self.body_decls.extend(parts)
 
 


### PR DESCRIPTION
This avoids the C++ global initializers by making the constructors for OperandDesc and InstructionDesc constexpr. In turn, the std::array static variables over those types can be initialized at compile time, not at runtime.

This also avoids the implied mutex inside the function bodies.