### PR TITLE
[OPT] Remove recursion from redundancy_elimination

### DIFF
--- a/source/opt/redundancy_elimination.h
+++ b/source/opt/redundancy_elimination.h
@@ -46,8 +46,7 @@ class RedundancyEliminationPass : public LocalRedundancyEliminationPass {
   //
   // Returns true if at least one instruction is deleted.
   bool EliminateRedundanciesFrom(DominatorTreeNode* bb,
-                                 const ValueNumberTable& vnTable,
-                                 std::map<uint32_t, uint32_t> value_to_ids);
+                                 const ValueNumberTable& vnTable);
 };
 
 }  // namespace opt


### PR DESCRIPTION
Remove unnecessary recursion from redundancy elimination. This should
avoid potenitail stack overflows for function with deep dominator trees.

Fixes #6104
