### PR TITLE
grammar tables: emit good error when missing an operand type

### DIFF
--- a/utils/ggt.py
+++ b/utils/ggt.py
@@ -30,6 +30,9 @@ from Table.Context import Context
 from Table.IndexRange import IndexRange
 from Table.Operand import Operand
 
+class GrammarError(Exception):
+    pass
+
 # Extensions to recognize, but which don't necessarily come from the SPIR-V
 # core or KHR grammar files.  Get this list from the SPIR-V registry web page.
 # NOTE: Only put things on this list if it is not in those grammar files.
@@ -428,9 +431,16 @@ struct OperandDesc {
                 kind_key,
                 str(operands_by_value_by_kind[kind_key])))
         for kind in self.operand_kinds_needing_optional_variant:
-            parts.append("    case {}: return {};".format(
-                ctype(kind, '?'),
-                str(operands_by_value_by_kind[ctype(kind,'')])))
+            non_optional_kind = ctype(kind,'')
+            if non_optional_kind in operands_by_value_by_kind:
+                parts.append("    case {}: return {};".format(
+                    ctype(kind, '?'),
+                    str(operands_by_value_by_kind[ctype(kind,'')])))
+            else:
+                raise GrammarError(
+                        "error: unknown operand type {}, from JSON grammar operand '{}':".format(non_optional_kind, kind) +
+                        " consider updating spv_operand_type_t in spirv-tools/libspirv.h")
+            
         parts.append("    default: break;");
         parts.append("  }\n  return IR(0,0);\n}\n")
         self.body_decls.extend(parts)
@@ -954,4 +964,8 @@ def main():
 
 
 if __name__ == '__main__':
-  main()
+  try:
+    main()
+  except GrammarError as ge:
+    print(ge)
+    sys.exit(1)


### PR DESCRIPTION
If a grammar change introduces a new optional operand kind, then currently the error message is very unfriendly.  It's a Python dictionary key error, with a call stack.

With this change, we get a single friendly error line like this, but all on one line:

   error: unknown operand type SPV_OPERAND_TYPE_TENSOR_OPERANDS,
   from JSON grammar operand 'TensorOperands':
   consider updating spv_operand_type_t in spirv-tools/libspirv.h