### PR TITLE
[OPT] Use conservative default case for `GetPtr`

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -250,8 +250,7 @@ Instruction* Instruction::GetBaseAddress() const {
       case spv::Op::OpInBoundsPtrAccessChain:
       case spv::Op::OpImageTexelPointer:
       case spv::Op::OpCopyObject:
-        // All of these instructions have the base pointer use a base pointer
-        // in in-operand 0.
+        // All of these instructions have their base pointer in in-operand 0.
         base = base_inst->GetSingleWordInOperand(0);
         base_inst = context()->get_def_use_mgr()->GetDef(base);
         break;


### PR DESCRIPTION
The `MemPass::GetPtr` assumed that variable pointers were not used. So
if the pointer instruction was not a variable or function parameter, it
assumed it was something like an OpAccessChain. This is not correct with
variable pointers. It could be a load or a phi or other things.

This modifies the code the have a default case that assumes the base
variable could not be found. It will only return a variable id if it
recornizes all of the instructions.

Fixes #6157
