### PR TITLE
[OPT] prevent private_to_local_pass optimizing double pointer

### DIFF
--- a/source/opt/private_to_local_pass.cpp
+++ b/source/opt/private_to_local_pass.cpp
@@ -90,13 +90,13 @@ Function* PrivateToLocalPass::FindLocalFunction(const Instruction& inst) const {
   Function* target_function = nullptr;
   context()->get_def_use_mgr()->ForEachUser(
       inst.result_id(),
-      [&target_function, &found_first_use, this](Instruction* use) {
+      [&target_function, &found_first_use, inst, this](Instruction* use) {
         BasicBlock* current_block = context()->get_instr_block(use);
         if (current_block == nullptr) {
           return;
         }
 
-        if (!IsValidUse(use)) {
+        if (!IsValidUse(use, inst.result_id())) {
           found_first_use = true;
           target_function = nullptr;
           return;
@@ -153,7 +153,7 @@ uint32_t PrivateToLocalPass::GetNewType(uint32_t old_type_id) {
   return new_type_id;
 }
 
-bool PrivateToLocalPass::IsValidUse(const Instruction* inst) const {
+bool PrivateToLocalPass::IsValidUse(const Instruction* inst, uint32_t private_variable_id) const {
   // The cases in this switch have to match the cases in |UpdateUse|.
   // If we don't know how to update it, it is not valid.
   if (inst->GetCommonDebugOpcode() == CommonDebugInfoDebugGlobalVariable) {
@@ -161,13 +161,14 @@ bool PrivateToLocalPass::IsValidUse(const Instruction* inst) const {
   }
   switch (inst->opcode()) {
     case spv::Op::OpLoad:
-    case spv::Op::OpStore:
     case spv::Op::OpImageTexelPointer:  // Treat like a load
       return true;
+    case spv::Op::OpStore:
+      return inst->GetOperand(1).AsId() != private_variable_id;
     case spv::Op::OpAccessChain:
       return context()->get_def_use_mgr()->WhileEachUser(
-          inst, [this](const Instruction* user) {
-            if (!IsValidUse(user)) return false;
+          inst, [this, inst](const Instruction* user) {
+            if (!IsValidUse(user, inst->result_id())) return false;
             return true;
           });
     case spv::Op::OpName:

--- a/source/opt/private_to_local_pass.h
+++ b/source/opt/private_to_local_pass.h
@@ -53,7 +53,7 @@ class PrivateToLocalPass : public Pass {
   // Returns true is |inst| is a valid use of a pointer.  In this case, a
   // valid use is one where the transformation is able to rewrite the type to
   // match a change in storage class of the original variable.
-  bool IsValidUse(const Instruction* inst) const;
+  bool IsValidUse(const Instruction* inst, uint32_t private_variable_id) const;
 
   // Given the result id of a pointer type, |old_type_id|, this function
   // returns the id of a the same pointer type except the storage class has


### PR DESCRIPTION
Fixes #6156

before this fix the pass will optimize the following code:
```
  %v = OpVariable %_ptr_Private_uint Private %uint_0
%load_thread_local = OpFunction %void None %function_type__1561_
 %37 = OpLabel
 %31 = OpVariable %_ptr_Function__ptr_Private_uint Function
 %32 = OpVariable %_ptr_Function_uint Function
 %33 = OpVariable %_ptr_Function_uint Function
       OpStore %31 %v
 %34 = OpLoad %_ptr_Private_uint %31
 %35 = OpLoad %uint %34
       OpStore %32 %35
 %36 = OpLoad %uint %v
       OpStore %33 %36
       OpReturn
       OpFunctionEnd
```

to this:
```
%load_thread_local = OpFunction %void None %function_type__1561_
 %37 = OpLabel
  %v = OpVariable %_ptr_Function_uint Function %uint_0
 %31 = OpVariable %_ptr_Function__ptr_Private_uint Function
 %32 = OpVariable %_ptr_Function_uint Function
 %33 = OpVariable %_ptr_Function_uint Function
       OpStore %31 %v
       OpStore %32 %uint_0
       OpStore %33 %uint_0
       OpReturn
       OpFunctionEnd
```

resulting in the following error:
```
error: line 81: OpStore Pointer <id> '31[%31]'s type does not match Object <id> '47[%v]'s type.
  OpStore %31 %v

```

private_to_local_pass does not update the storage class of the double pointer %31 correctly. It currently doesn't have enough context to tell if %31 is later loaded from and used to store with. For now, just prevent the optimization if the address of the private variable is used as the object operand of the OpStore instruction.

with this commit, the spirv code is optimized to this:
```
%v = OpVariable %_ptr_Private_uint Private %uint_0
%load_thread_local = OpFunction %void None %function_type__1561_
         %37 = OpLabel
         %31 = OpVariable %_ptr_Function__ptr_Private_uint Function
         %32 = OpVariable %_ptr_Function_uint Function
         %33 = OpVariable %_ptr_Function_uint Function
               OpStore %31 %v
         %35 = OpLoad %uint %v
               OpStore %32 %35
         %36 = OpLoad %uint %v
               OpStore %33 %36
               OpReturn
               OpFunctionEnd
```