### PR TITLE
Add SPV_NV_cluster_acceleration_structure to allow lists

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -1039,7 +1039,8 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_KHR_ray_tracing_position_fetch",
       "SPV_KHR_fragment_shading_rate",
       "SPV_KHR_quad_control",
-      "SPV_NV_shader_invocation_reorder"
+      "SPV_NV_shader_invocation_reorder",
+      "SPV_NV_cluster_acceleration_structure"
   });
   // clang-format on
 }

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -434,7 +434,8 @@ void LocalAccessChainConvertPass::InitExtensions() {
        "SPV_KHR_compute_shader_derivatives", "SPV_NV_cooperative_matrix",
        "SPV_KHR_cooperative_matrix", "SPV_KHR_ray_tracing_position_fetch",
        "SPV_AMDX_shader_enqueue", "SPV_KHR_fragment_shading_rate",
-       "SPV_KHR_quad_control", "SPV_NV_shader_invocation_reorder"});
+       "SPV_KHR_quad_control", "SPV_NV_shader_invocation_reorder",
+       "SPV_NV_cluster_acceleration_structure"});
 }
 
 bool LocalAccessChainConvertPass::AnyIndexIsOutOfBounds(

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -300,7 +300,8 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
                                 "SPV_KHR_ray_tracing_position_fetch",
                                 "SPV_KHR_fragment_shading_rate",
                                 "SPV_KHR_quad_control",
-                                "SPV_NV_shader_invocation_reorder"});
+                                "SPV_NV_shader_invocation_reorder",
+                                "SPV_NV_cluster_acceleration_structure"});
 }
 
 }  // namespace opt

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -152,7 +152,8 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
                                 "SPV_KHR_ray_tracing",
                                 "SPV_KHR_quad_control",
                                 "SPV_GOOGLE_user_type",
-                                "SPV_NV_shader_invocation_reorder"});
+                                "SPV_NV_shader_invocation_reorder",
+                                "SPV_NV_cluster_acceleration_structure"});
 }
 bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {
   std::vector<Instruction*> users;


### PR DESCRIPTION
This fixes [microsoft/DirectXShaderCompiler/issues/7487](https://github.com/microsoft/DirectXShaderCompiler/issues/7487) (and the duplicate issue [microsoft/DirectXShaderCompiler/issues/7476](https://github.com/microsoft/DirectXShaderCompiler/issues/7476])) by adding `SPV_NV_cluster_acceleration_structure` to the various allow lists.

Verified by locally compiling the sample code from both issues with DXC; both code samples can be successfully compiled with these changes.