### PR TITLE
spirv-val: Give hints when user is forgetting feature bit

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -464,7 +464,9 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << _.VkErrorID(10213)
                << "Image Operand Offset can only be used with "
-                  "OpImage*Gather operations";
+                  "OpImage*Gather operations. This is allowed if you enable "
+                  "the maintenance8 feature (or use "
+                  "--allow-offset-texture-operand from command line)";
       }
     }
   }

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -464,9 +464,9 @@ spv_result_t ValidateImageOperands(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << _.VkErrorID(10213)
                << "Image Operand Offset can only be used with "
-                  "OpImage*Gather operations. This is allowed if you enable "
-                  "the maintenance8 feature (or use "
-                  "--allow-offset-texture-operand from command line)";
+                  "OpImage*Gather operations."
+               << _.MissingFeature("maintenance8 feature",
+                                   "--allow-offset-texture-operand", false);
       }
     }
   }

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -765,10 +765,10 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
           !_.IsLocalSizeIdAllowed()) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << "LocalSizeId mode is not allowed by the current environment."
-               << (is_vulkan_env ? " This is allowed if you enable the "
-                                   "maintenance4 feature (or use "
-                                   "--allow-localsizeid from command line)"
-                                 : "");
+               << (is_vulkan_env
+                       ? _.MissingFeature("maintenance4 feature",
+                                          "--allow-localsizeid", false)
+                       : "");
       }
 
       if (!std::all_of(

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -557,6 +557,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
               "Operands that are not id operands.";
   }
 
+  const bool is_vulkan_env = (spvIsVulkanEnv(_.context()->target_env));
   const auto* models = _.GetExecutionModels(entry_point_id);
   switch (mode) {
     case spv::ExecutionMode::Invocations:
@@ -667,7 +668,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                     "tessellation execution model.";
         }
       }
-      if (spvIsVulkanEnv(_.context()->target_env)) {
+      if (is_vulkan_env) {
         if (_.HasCapability(spv::Capability::MeshShadingEXT) &&
             inst->GetOperandAs<uint32_t>(2) == 0) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
@@ -690,8 +691,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
                   "execution "
                   "model.";
       }
-      if (mode == spv::ExecutionMode::OutputPrimitivesEXT &&
-          spvIsVulkanEnv(_.context()->target_env)) {
+      if (mode == spv::ExecutionMode::OutputPrimitivesEXT && is_vulkan_env) {
         if (_.HasCapability(spv::Capability::MeshShadingEXT) &&
             inst->GetOperandAs<uint32_t>(2) == 0) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
@@ -761,9 +761,15 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
       break;
     case spv::ExecutionMode::LocalSize:
     case spv::ExecutionMode::LocalSizeId:
-      if (mode == spv::ExecutionMode::LocalSizeId && !_.IsLocalSizeIdAllowed())
+      if (mode == spv::ExecutionMode::LocalSizeId &&
+          !_.IsLocalSizeIdAllowed()) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "LocalSizeId mode is not allowed by the current environment.";
+               << "LocalSizeId mode is not allowed by the current environment."
+               << (is_vulkan_env ? " This is allowed if you enable the "
+                                   "maintenance4 feature (or use "
+                                   "--allow-localsizeid from command line)"
+                                 : "");
+      }
 
       if (!std::all_of(
               models->begin(), models->end(),
@@ -812,7 +818,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
     }
   }
 
-  if (spvIsVulkanEnv(_.context()->target_env)) {
+  if (is_vulkan_env) {
     if (mode == spv::ExecutionMode::OriginLowerLeft) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << _.VkErrorID(4653)

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1914,6 +1914,14 @@ bool ValidationState_t::IsValidStorageClass(
   return true;
 }
 
+std::string ValidationState_t::MissingFeature(const std::string& feature,
+                                              const std::string& cmdline,
+                                              bool hint) const {
+  return "\nThis is " + (hint ? std::string("may be ") : "") +
+         "allowed if you enable the " + feature + " (or use the " + cmdline +
+         " command line flag)";
+}
+
 #define VUID_WRAP(vuid) "[" #vuid "] "
 
 // Currently no 2 VUID share the same id, so no need for |reference|

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -840,6 +840,12 @@ class ValidationState_t {
   // Validates the storage class for the target environment.
   bool IsValidStorageClass(spv::StorageClass storage_class) const;
 
+  // Helps formulate a mesesage to user that setting one of the validator
+  // options might make their SPIR-V actually valid The |hint| option is because
+  // some checks are intertwined with each other, so hard to give confirmation
+  std::string MissingFeature(const std::string& feature,
+                             const std::string& cmdline, bool hint) const;
+
   // Takes a Vulkan Valid Usage ID (VUID) as |id| and optional |reference| and
   // will return a non-empty string only if ID is known and targeting Vulkan.
   // VUIDs are found in the Vulkan-Docs repo in the form "[[VUID-ref-ref-id]]"


### PR DESCRIPTION
Have had a number of times people think scalar block layout is broken on VVL because they never enabled the `scalarBlockLayoutfeature` feature

Debating still if to just detected "supported" features instead of "enabled" features, but for now, wanted to add these "hints" in the error message to help aid people who don't fully grasp the handshake VVL does with `spirv-val` to turn on runtime options for them

```
error: line 216: Structure id 683 decorated as Block for variable in StorageBuffer storage class must follow relaxed storage buffer layout rules: member 0 contains an array with stride 12 not satisfying alignment to 16
This might be valid if you enable the scalarBlockLayoutfeature (or use --scalar-block-layout from the command line) 
  %_struct_683 = OpTypeStruct %_runtimearr_v3uint
```
