### PR TITLE
Add initial support for SPV_EXT_float8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': 'c84a140c93352cdabbfb547c531be34515b12228',
 
-  'spirv_headers_revision': '7168a5ad041f6b6b9170f027c7417f98a2056ff0',
+  'spirv_headers_revision': 'fd96661925488574fe247a779babe5d380b63635',
 }
 
 deps = {

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -390,6 +390,18 @@ typedef enum spv_number_kind_t {
   SPV_NUMBER_FLOATING,
 } spv_number_kind_t;
 
+// Represent the encoding of floating point values
+typedef enum spv_fp_encoding_t {
+  SPV_FP_ENCODING_UNKNOWN =
+      0,  // The encoding is not specified. Has to be deduced from bitwidth
+  SPV_FP_ENCODING_IEEE754_BINARY16,  // half float
+  SPV_FP_ENCODING_IEEE754_BINARY32,  // single float
+  SPV_FP_ENCODING_IEEE754_BINARY64,  // double float
+  SPV_FP_ENCODING_BFLOAT16,
+  SPV_FP_ENCODING_E4M3,
+  SPV_FP_ENCODING_E5M2,
+} spv_fp_encoding_t;
+
 typedef enum spv_text_to_binary_options_t {
   SPV_TEXT_TO_BINARY_OPTION_NONE = SPV_BIT(0),
   // Numeric IDs in the binary will have the same values as in the source.
@@ -445,6 +457,8 @@ typedef struct spv_parsed_operand_t {
   spv_number_kind_t number_kind;
   // The number of bits for a literal number type.
   uint32_t number_bit_width;
+  // The encoding used for floating point values
+  spv_fp_encoding_t fp_encoding;
 } spv_parsed_operand_t;
 
 // An instruction parsed from a binary SPIR-V module.

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -398,8 +398,8 @@ typedef enum spv_fp_encoding_t {
   SPV_FP_ENCODING_IEEE754_BINARY32,  // single float
   SPV_FP_ENCODING_IEEE754_BINARY64,  // double float
   SPV_FP_ENCODING_BFLOAT16,
-  SPV_FP_ENCODING_E4M3,
-  SPV_FP_ENCODING_E5M2,
+  SPV_FP_ENCODING_FLOAT8_E4M3,
+  SPV_FP_ENCODING_FLOAT8_E5M2,
 } spv_fp_encoding_t;
 
 typedef enum spv_text_to_binary_options_t {

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -190,6 +190,7 @@ class Parser {
   struct NumberType {
     spv_number_kind_t type;
     uint32_t bit_width;
+    spv_fp_encoding_t encoding;
   };
 
   // The state used to parse a single SPIR-V binary module.
@@ -385,8 +386,6 @@ spv_result_t Parser::parseInstruction() {
   assert(_.requires_endian_conversion ||
          (_.endian_converted_words.size() == 1));
 
-  recordNumberType(inst_offset, &inst);
-
   if (_.requires_endian_conversion) {
     // We must wait until here to set this pointer, because the vector might
     // have been be resized while we accumulated its elements.
@@ -397,6 +396,8 @@ spv_result_t Parser::parseInstruction() {
     inst.words = _.words + inst_offset;
   }
   inst.num_words = inst_word_count;
+
+  recordNumberType(inst_offset, &inst);
 
   // We must wait until here to set this pointer, because the vector might
   // have been be resized while we accumulated its elements.
@@ -833,6 +834,7 @@ spv_result_t Parser::setNumericTypeInfoForType(
 
   parsed_operand->number_kind = info.type;
   parsed_operand->number_bit_width = info.bit_width;
+  parsed_operand->fp_encoding = info.encoding;
   // Round up the word count.
   parsed_operand->num_words = static_cast<uint16_t>((info.bit_width + 31) / 32);
   return SPV_SUCCESS;
@@ -850,6 +852,15 @@ void Parser::recordNumberType(size_t inst_offset,
     } else if (spv::Op::OpTypeFloat == opcode) {
       info.type = SPV_NUMBER_FLOATING;
       info.bit_width = peekAt(inst_offset + 2);
+      if (inst->num_words >= 4) {
+        const char* encoding = grammar_.lookupOperandName(
+            SPV_OPERAND_TYPE_FPENCODING, peekAt(inst_offset + 3));
+        if (0 == strcmp(encoding, "Float8E4M3EXT"))
+          info.encoding = SPV_FP_ENCODING_E4M3;
+        else if (0 == strcmp(encoding, "Float8E5M2EXT"))
+          info.encoding = SPV_FP_ENCODING_E5M2;
+        // TODO Bfloat16
+      }
     }
     // The *result* Id of a type generating instruction is the type Id.
     _.type_id_to_number_type_info[inst->result_id] = info;

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -853,13 +853,15 @@ void Parser::recordNumberType(size_t inst_offset,
       info.type = SPV_NUMBER_FLOATING;
       info.bit_width = peekAt(inst_offset + 2);
       if (inst->num_words >= 4) {
-        const char* encoding = grammar_.lookupOperandName(
-            SPV_OPERAND_TYPE_FPENCODING, peekAt(inst_offset + 3));
-        if (0 == strcmp(encoding, "Float8E4M3EXT"))
-          info.encoding = SPV_FP_ENCODING_E4M3;
-        else if (0 == strcmp(encoding, "Float8E5M2EXT"))
-          info.encoding = SPV_FP_ENCODING_E5M2;
-        // TODO Bfloat16
+        const spvtools::OperandDesc* desc;
+        spv_result_t status = spvtools::LookupOperand(
+            SPV_OPERAND_TYPE_FPENCODING, peekAt(inst_offset + 3), &desc);
+        if (status == SPV_SUCCESS) {
+          info.encoding = spvFPEncodingFromOperandFPEncoding(
+              static_cast<spv::FPEncoding>(desc->value));
+        } else {
+          info.encoding = SPV_FP_ENCODING_UNKNOWN;
+        }
       }
     }
     // The *result* Id of a type generating instruction is the type Id.

--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -217,6 +217,14 @@ spv_result_t FriendlyNameMapper::ParseInstruction(
           SaveName(result_id, "bfloat16");
           break;
         }
+        if (spv::FPEncoding(inst.words[3]) == spv::FPEncoding::Float8E4M3EXT) {
+          SaveName(result_id, "fp8e4m3");
+          break;
+        }
+        if (spv::FPEncoding(inst.words[3]) == spv::FPEncoding::Float8E5M2EXT) {
+          SaveName(result_id, "fp8e5m2");
+          break;
+        }
       }
       switch (bit_width) {
         case 16:

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -625,9 +625,9 @@ spv_fp_encoding_t spvFPEncodingFromOperandFPEncoding(spv::FPEncoding encoding) {
     case spv::FPEncoding::BFloat16KHR:
       return SPV_FP_ENCODING_BFLOAT16;
     case spv::FPEncoding::Float8E4M3EXT:
-      return SPV_FP_ENCODING_E4M3;
+      return SPV_FP_ENCODING_FLOAT8_E4M3;
     case spv::FPEncoding::Float8E5M2EXT:
-      return SPV_FP_ENCODING_E5M2;
+      return SPV_FP_ENCODING_FLOAT8_E5M2;
     case spv::FPEncoding::Max:
       break;
   }

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -619,3 +619,17 @@ std::function<bool(unsigned)> spvDbgInfoExtOperandCanBeForwardDeclaredFunction(
   }
   return out;
 }
+
+spv_fp_encoding_t spvFPEncodingFromOperandFPEncoding(spv::FPEncoding encoding) {
+  switch (encoding) {
+    case spv::FPEncoding::BFloat16KHR:
+      return SPV_FP_ENCODING_BFLOAT16;
+    case spv::FPEncoding::Float8E4M3EXT:
+      return SPV_FP_ENCODING_E4M3;
+    case spv::FPEncoding::Float8E5M2EXT:
+      return SPV_FP_ENCODING_E5M2;
+    case spv::FPEncoding::Max:
+      break;
+  }
+  return SPV_FP_ENCODING_UNKNOWN;
+}

--- a/source/operand.h
+++ b/source/operand.h
@@ -122,4 +122,7 @@ std::function<bool(unsigned)> spvOperandCanBeForwardDeclaredFunction(
 std::function<bool(unsigned)> spvDbgInfoExtOperandCanBeForwardDeclaredFunction(
     spv::Op opcode, spv_ext_inst_type_t ext_type, uint32_t key);
 
+// Converts an spv::FPEncoding to spv_fp_encoding_t
+spv_fp_encoding_t spvFPEncodingFromOperandFPEncoding(spv::FPEncoding encoding);
+
 #endif  // SOURCE_OPERAND_H_

--- a/source/opt/types.cpp
+++ b/source/opt/types.cpp
@@ -320,6 +320,14 @@ std::string Float::str() const {
       assert(width_ == 16);
       oss << "bfloat16";
       break;
+    case spv::FPEncoding::Float8E4M3EXT:
+      assert(width_ == 8);
+      oss << "fp8e4m3";
+      break;
+    case spv::FPEncoding::Float8E5M2EXT:
+      assert(width_ == 8);
+      oss << "fp8e5m2";
+      break;
     default:
       oss << "float" << width_;
       break;

--- a/source/parsed_operand.cpp
+++ b/source/parsed_operand.cpp
@@ -43,12 +43,35 @@ void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
         *out << word;
         break;
       case SPV_NUMBER_FLOATING:
-        if (operand.number_bit_width == 16) {
-          *out << spvtools::utils::FloatProxy<spvtools::utils::Float16>(
-              uint16_t(word & 0xFFFF));
-        } else {
-          // Assume 32-bit floats.
-          *out << spvtools::utils::FloatProxy<float>(word);
+        switch (operand.fp_encoding) {
+          case SPV_FP_ENCODING_IEEE754_BINARY16:
+            *out << spvtools::utils::FloatProxy<spvtools::utils::Float16>(
+                uint16_t(word & 0xFFFF));
+            break;
+          case SPV_FP_ENCODING_IEEE754_BINARY32:
+            *out << spvtools::utils::FloatProxy<float>(word);
+            break;
+          case SPV_FP_ENCODING_E4M3:
+            *out << spvtools::utils::FloatProxy<spvtools::utils::Float8_E4M3>(
+                uint8_t(word & 0xFF));
+            break;
+          case SPV_FP_ENCODING_E5M2:
+            *out << spvtools::utils::FloatProxy<spvtools::utils::Float8_E5M2>(
+                uint8_t(word & 0xFF));
+            break;
+          // TODO Bfloat16
+          case SPV_FP_ENCODING_UNKNOWN:
+            switch (operand.number_bit_width) {
+              case 16:
+                *out << spvtools::utils::FloatProxy<spvtools::utils::Float16>(
+                    uint16_t(word & 0xFFFF));
+                break;
+              case 32:
+                *out << spvtools::utils::FloatProxy<float>(word);
+                break;
+            }
+          default:
+            break;
         }
         break;
       default:

--- a/source/parsed_operand.cpp
+++ b/source/parsed_operand.cpp
@@ -51,11 +51,11 @@ void EmitNumericLiteral(std::ostream* out, const spv_parsed_instruction_t& inst,
           case SPV_FP_ENCODING_IEEE754_BINARY32:
             *out << spvtools::utils::FloatProxy<float>(word);
             break;
-          case SPV_FP_ENCODING_E4M3:
+          case SPV_FP_ENCODING_FLOAT8_E4M3:
             *out << spvtools::utils::FloatProxy<spvtools::utils::Float8_E4M3>(
                 uint8_t(word & 0xFF));
             break;
-          case SPV_FP_ENCODING_E5M2:
+          case SPV_FP_ENCODING_FLOAT8_E5M2:
             *out << spvtools::utils::FloatProxy<spvtools::utils::Float8_E5M2>(
                 uint8_t(word & 0xFF));
             break;

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -811,7 +811,7 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
   }
 
   if (spvOpcodeGeneratesType(pInst->opcode)) {
-    if (context->recordTypeDefinition(pInst) != SPV_SUCCESS) {
+    if (context->recordTypeDefinition(grammar, pInst) != SPV_SUCCESS) {
       return SPV_ERROR_INVALID_TEXT;
     }
   } else if (opcodeEntry->hasType) {

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -811,7 +811,7 @@ spv_result_t spvTextEncodeOpcode(const spvtools::AssemblyGrammar& grammar,
   }
 
   if (spvOpcodeGeneratesType(pInst->opcode)) {
-    if (context->recordTypeDefinition(grammar, pInst) != SPV_SUCCESS) {
+    if (context->recordTypeDefinition(pInst) != SPV_SUCCESS) {
       return SPV_ERROR_INVALID_TEXT;
     }
   } else if (opcodeEntry->hasType) {

--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -254,13 +254,13 @@ spv_result_t AssemblyContext::binaryEncodeNumericLiteral(
              << "Unexpected numeric literal type";
     case IdTypeClass::kScalarIntegerType:
       if (type.isSigned) {
-        number_type = {type.bitwidth, SPV_NUMBER_SIGNED_INT};
+        number_type = {type.bitwidth, SPV_NUMBER_SIGNED_INT, type.encoding};
       } else {
-        number_type = {type.bitwidth, SPV_NUMBER_UNSIGNED_INT};
+        number_type = {type.bitwidth, SPV_NUMBER_UNSIGNED_INT, type.encoding};
       }
       break;
     case IdTypeClass::kScalarFloatType:
-      number_type = {type.bitwidth, SPV_NUMBER_FLOATING};
+      number_type = {type.bitwidth, SPV_NUMBER_FLOATING, type.encoding};
       break;
     case IdTypeClass::kBottom:
       // kBottom means the type is unknown and we need to infer the type before
@@ -270,11 +270,11 @@ spv_result_t AssemblyContext::binaryEncodeNumericLiteral(
       // signed integer, otherwise an unsigned integer.
       uint32_t bitwidth = static_cast<uint32_t>(assumedBitWidth(type));
       if (strchr(val, '.')) {
-        number_type = {bitwidth, SPV_NUMBER_FLOATING};
+        number_type = {bitwidth, SPV_NUMBER_FLOATING, type.encoding};
       } else if (type.isSigned || val[0] == '-') {
-        number_type = {bitwidth, SPV_NUMBER_SIGNED_INT};
+        number_type = {bitwidth, SPV_NUMBER_SIGNED_INT, type.encoding};
       } else {
-        number_type = {bitwidth, SPV_NUMBER_UNSIGNED_INT};
+        number_type = {bitwidth, SPV_NUMBER_UNSIGNED_INT, type.encoding};
       }
       break;
   }
@@ -319,7 +319,7 @@ spv_result_t AssemblyContext::binaryEncodeString(const char* value,
 }
 
 spv_result_t AssemblyContext::recordTypeDefinition(
-    const spv_instruction_t* pInst) {
+    const spvtools::AssemblyGrammar& grammar, const spv_instruction_t* pInst) {
   uint32_t value = pInst->words[1];
   if (types_.find(value) != types_.end()) {
     return diagnostic() << "Value " << value
@@ -330,14 +330,28 @@ spv_result_t AssemblyContext::recordTypeDefinition(
     if (pInst->words.size() != 4)
       return diagnostic() << "Invalid OpTypeInt instruction";
     types_[value] = {pInst->words[2], pInst->words[3] != 0,
-                     IdTypeClass::kScalarIntegerType};
+                     IdTypeClass::kScalarIntegerType, SPV_FP_ENCODING_UNKNOWN};
   } else if (pInst->opcode == spv::Op::OpTypeFloat) {
     if ((pInst->words.size() != 3) && (pInst->words.size() != 4))
       return diagnostic() << "Invalid OpTypeFloat instruction";
-    // TODO(kpet) Do we need to record the FP Encoding here?
-    types_[value] = {pInst->words[2], false, IdTypeClass::kScalarFloatType};
+    spv_fp_encoding_t enc = SPV_FP_ENCODING_UNKNOWN;
+    if (pInst->words.size() >= 4) {
+      const char* encoding = grammar.lookupOperandName(
+          SPV_OPERAND_TYPE_FPENCODING, pInst->words[3]);
+      if (0 == strcmp(encoding, "Float8E4M3EXT"))
+        enc = SPV_FP_ENCODING_E4M3;
+      else if (0 == strcmp(encoding, "Float8E5M2EXT"))
+        enc = SPV_FP_ENCODING_E5M2;
+      else if (0 == strcmp(encoding, "BFloat16KHR"))
+        enc = SPV_FP_ENCODING_BFLOAT16;
+      else
+        return diagnostic() << "Invalid OpTypeFloat encoding";
+    }
+    types_[value] = {pInst->words[2], false, IdTypeClass::kScalarFloatType,
+                     enc};
   } else {
-    types_[value] = {0, false, IdTypeClass::kOtherType};
+    types_[value] = {0, false, IdTypeClass::kOtherType,
+                     SPV_FP_ENCODING_UNKNOWN};
   }
   return SPV_SUCCESS;
 }

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -23,7 +23,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "source/assembly_grammar.h"
 #include "source/diagnostic.h"
 #include "source/instruction.h"
 #include "source/text.h"
@@ -228,8 +227,7 @@ class AssemblyContext {
   // pInst is expected to be completely filled in by the time this instruction
   // is called.
   // Returns SPV_SUCCESS on success, or SPV_ERROR_INVALID_VALUE on error.
-  spv_result_t recordTypeDefinition(const spvtools::AssemblyGrammar& grammar,
-                                    const spv_instruction_t* pInst);
+  spv_result_t recordTypeDefinition(const spv_instruction_t* pInst);
 
   // Tracks the relationship between the value and its type.
   spv_result_t recordTypeIdForValue(uint32_t value, uint32_t type);

--- a/source/text_handler.h
+++ b/source/text_handler.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "source/assembly_grammar.h"
 #include "source/diagnostic.h"
 #include "source/instruction.h"
 #include "source/text.h"
@@ -47,6 +48,7 @@ struct IdType {
   uint32_t bitwidth;  // Safe to assume that we will not have > 2^32 bits.
   bool isSigned;      // This is only significant if type_class is integral.
   IdTypeClass type_class;
+  spv_fp_encoding_t encoding;
 };
 
 // Default equality operator for IdType. Tests if all members are the same.
@@ -226,7 +228,8 @@ class AssemblyContext {
   // pInst is expected to be completely filled in by the time this instruction
   // is called.
   // Returns SPV_SUCCESS on success, or SPV_ERROR_INVALID_VALUE on error.
-  spv_result_t recordTypeDefinition(const spv_instruction_t* pInst);
+  spv_result_t recordTypeDefinition(const spvtools::AssemblyGrammar& grammar,
+                                    const spv_instruction_t* pInst);
 
   // Tracks the relationship between the value and its type.
   spv_result_t recordTypeIdForValue(uint32_t value, uint32_t type);

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -620,18 +620,18 @@ class HexFloat {
   // even if they are not going to be executed. Eg:
   // constant_number < 0? 0: constant_number
   // These convert the negative left-shifts into right shifts.
-  template <int N>
+  template <int_type N>
   struct negatable_left_shift {
     static uint_type val(uint_type val) {
       if (N > 0) {
-        return static_cast<uint_type>(val << N);
+        return static_cast<uint_type>(static_cast<uint64_t>(val) << N);
       } else {
-        return static_cast<uint_type>(val >> N);
+        return static_cast<uint_type>(static_cast<uint64_t>(val) >> N);
       }
     }
   };
 
-  template <int N>
+  template <int_type N>
   struct negatable_right_shift {
     static uint_type val(uint_type val) {
       if (N > 0) {
@@ -647,31 +647,31 @@ class HexFloat {
   // even if they are not going to be executed. Eg:
   // constant_number < 0? 0: constant_number
   // These convert the negative left-shifts into right shifts.
-  template <int N, typename enable = void>
+  template <int_type N, typename enable = void>
   struct negatable_left_shift {
     static uint_type val(uint_type val) {
-      return static_cast<uint_type>(val >> -N);
+      return static_cast<uint_type>(static_cast<uint64_t>(val) >> -N);
     }
   };
 
-  template <int N>
+  template <int_type N>
   struct negatable_left_shift<N, typename std::enable_if<N >= 0>::type> {
     static uint_type val(uint_type val) {
-      return static_cast<uint_type>(val << N);
+      return static_cast<uint_type>(static_cast<uint64_t>(val) << N);
     }
   };
 
-  template <int N, typename enable = void>
+  template <int_type N, typename enable = void>
   struct negatable_right_shift {
     static uint_type val(uint_type val) {
-      return static_cast<uint_type>(val << -N);
+      return static_cast<uint_type>(static_cast<uint64_t>(val) << -N);
     }
   };
 
-  template <int N>
+  template <int_type N>
   struct negatable_right_shift<N, typename std::enable_if<N >= 0>::type> {
     static uint_type val(uint_type val) {
-      return static_cast<uint_type>(val >> N);
+      return static_cast<uint_type>(static_cast<uint64_t>(val) >> N);
     }
   };
 #endif

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -36,6 +36,50 @@
 namespace spvtools {
 namespace utils {
 
+class Float8_E4M3 {
+ public:
+  Float8_E4M3(uint8_t v) : val(v) {}
+  Float8_E4M3() = default;
+  static bool isNan(const Float8_E4M3& val) { return (val.val & 0x7f) == 0x7f; }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(const Float8_E4M3&) {
+    return false;  // E4M3 has no infinity representation
+  }
+  Float8_E4M3(const Float8_E4M3& other) { val = other.val; }
+  uint8_t get_value() const { return val; }
+
+  // Returns the maximum normal value.
+  static Float8_E4M3 max() { return Float8_E4M3(0x7e); }
+  // Returns the lowest normal value.
+  static Float8_E4M3 lowest() { return Float8_E4M3(0x8); }
+
+ private:
+  uint8_t val;
+};
+
+class Float8_E5M2 {
+ public:
+  Float8_E5M2(uint8_t v) : val(v) {}
+  Float8_E5M2() = default;
+  static bool isNan(const Float8_E5M2& val) {
+    return ((val.val & 0x7c) == 0x7c) && ((val.val & 0x3) != 0);
+  }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(const Float8_E5M2& val) {
+    return (val.val & 0x7f) == 0x7c;
+  }
+  Float8_E5M2(const Float8_E5M2& other) { val = other.val; }
+  uint8_t get_value() const { return val; }
+
+  // Returns the maximum normal value.
+  static Float8_E5M2 max() { return Float8_E5M2(0x7b); }
+  // Returns the lowest normal value.
+  static Float8_E5M2 lowest() { return Float8_E5M2(0x4); }
+
+ private:
+  uint8_t val;
+};
+
 class Float16 {
  public:
   Float16(uint16_t v) : val(v) {}
@@ -108,6 +152,46 @@ struct FloatProxyTraits<double> {
   }
   // Returns the bitwidth.
   static uint32_t width() { return 64u; }
+};
+
+template <>
+struct FloatProxyTraits<Float8_E4M3> {
+  using uint_type = uint8_t;
+  static bool isNan(Float8_E4M3 f) { return Float8_E4M3::isNan(f); }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(Float8_E4M3 f) { return Float8_E4M3::isInfinity(f); }
+  // Returns the maximum normal value.
+  static Float8_E4M3 max() { return Float8_E4M3::max(); }
+  // Returns the lowest normal value.
+  static Float8_E4M3 lowest() { return Float8_E4M3::lowest(); }
+  // Returns the value as the native floating point format.
+  static Float8_E4M3 getAsFloat(const uint_type& t) { return Float8_E4M3(t); }
+  // Returns the bits from the given floating pointer number.
+  static uint_type getBitsFromFloat(const Float8_E4M3& t) {
+    return t.get_value();
+  }
+  // Returns the bitwidth.
+  static uint32_t width() { return 8u; }
+};
+
+template <>
+struct FloatProxyTraits<Float8_E5M2> {
+  using uint_type = uint8_t;
+  static bool isNan(Float8_E5M2 f) { return Float8_E5M2::isNan(f); }
+  // Returns true if the given value is any kind of infinity.
+  static bool isInfinity(Float8_E5M2 f) { return Float8_E5M2::isInfinity(f); }
+  // Returns the maximum normal value.
+  static Float8_E5M2 max() { return Float8_E5M2::max(); }
+  // Returns the lowest normal value.
+  static Float8_E5M2 lowest() { return Float8_E5M2::lowest(); }
+  // Returns the value as the native floating point format.
+  static Float8_E5M2 getAsFloat(const uint_type& t) { return Float8_E5M2(t); }
+  // Returns the bits from the given floating pointer number.
+  static uint_type getBitsFromFloat(const Float8_E5M2& t) {
+    return t.get_value();
+  }
+  // Returns the bitwidth.
+  static uint32_t width() { return 8u; }
 };
 
 template <>
@@ -216,6 +300,7 @@ struct HexFloatTraits {
   using int_type = void;
   // The numerical type that this HexFloat represents.
   using underlying_type = void;
+  using underlying_typetraits = void;
   // The type needed to construct the underlying type.
   using native_type = void;
   // The number of bits that are actually relevant in the uint_type.
@@ -229,6 +314,8 @@ struct HexFloatTraits {
   // The bias of the exponent. (How much we need to subtract from the stored
   // value to get the correct value.)
   static const uint32_t exponent_bias = 0;
+  static const bool has_infinity = true;
+  static const uint32_t NaN_pattern = 0;
 };
 
 // Traits for IEEE float.
@@ -238,11 +325,14 @@ struct HexFloatTraits<FloatProxy<float>> {
   using uint_type = uint32_t;
   using int_type = int32_t;
   using underlying_type = FloatProxy<float>;
+  using underlying_typetraits = FloatProxyTraits<float>;
   using native_type = float;
   static const uint_type num_used_bits = 32;
   static const uint_type num_exponent_bits = 8;
   static const uint_type num_fraction_bits = 23;
   static const uint_type exponent_bias = 127;
+  static const bool has_infinity = true;
+  static const uint_type NaN_pattern = 0x7f80000;
 };
 
 // Traits for IEEE double.
@@ -252,11 +342,48 @@ struct HexFloatTraits<FloatProxy<double>> {
   using uint_type = uint64_t;
   using int_type = int64_t;
   using underlying_type = FloatProxy<double>;
+  using underlying_typetraits = FloatProxyTraits<double>;
   using native_type = double;
   static const uint_type num_used_bits = 64;
   static const uint_type num_exponent_bits = 11;
   static const uint_type num_fraction_bits = 52;
   static const uint_type exponent_bias = 1023;
+  static const bool has_infinity = true;
+  static const uint_type NaN_pattern = 0x7FF0000000000000;
+};
+
+// Traits for FP8 E4M3.
+// 1 sign bit, 4 exponent bits, 3 fractional bits.
+template <>
+struct HexFloatTraits<FloatProxy<Float8_E4M3>> {
+  using uint_type = uint8_t;
+  using int_type = int8_t;
+  using underlying_type = FloatProxy<Float8_E4M3>;
+  using underlying_typetraits = FloatProxyTraits<Float8_E4M3>;
+  using native_type = uint8_t;
+  static const uint_type num_used_bits = 8;
+  static const uint_type num_exponent_bits = 4;
+  static const uint_type num_fraction_bits = 3;
+  static const uint_type exponent_bias = 7;
+  static const bool has_infinity = false;
+  static const uint_type NaN_pattern = 0x7F;
+};
+
+// Traits for FP8 E5M2.
+// 1 sign bit, 4 exponent bits, 3 fractional bits.
+template <>
+struct HexFloatTraits<FloatProxy<Float8_E5M2>> {
+  using uint_type = uint8_t;
+  using int_type = int8_t;
+  using underlying_type = FloatProxy<Float8_E5M2>;
+  using underlying_typetraits = FloatProxyTraits<Float8_E5M2>;
+  using native_type = uint8_t;
+  static const uint_type num_used_bits = 8;
+  static const uint_type num_exponent_bits = 5;
+  static const uint_type num_fraction_bits = 2;
+  static const uint_type exponent_bias = 15;
+  static const bool has_infinity = true;
+  static const uint_type NaN_pattern = 0x7c;
 };
 
 // Traits for IEEE half.
@@ -265,12 +392,15 @@ template <>
 struct HexFloatTraits<FloatProxy<Float16>> {
   using uint_type = uint16_t;
   using int_type = int16_t;
-  using underlying_type = uint16_t;
+  using underlying_type = FloatProxy<Float16>;
+  using underlying_typetraits = FloatProxyTraits<Float16>;
   using native_type = uint16_t;
   static const uint_type num_used_bits = 16;
   static const uint_type num_exponent_bits = 5;
   static const uint_type num_fraction_bits = 10;
   static const uint_type exponent_bias = 15;
+  static const bool has_infinity = true;
+  static const uint_type NaN_pattern = 0x7c00;
 };
 
 enum class round_direction {
@@ -291,6 +421,7 @@ class HexFloat {
   using int_type = typename Traits::int_type;
   using underlying_type = typename Traits::underlying_type;
   using native_type = typename Traits::native_type;
+  using traits = Traits;
 
   explicit HexFloat(T f) : value_(f) {}
 
@@ -639,6 +770,9 @@ class HexFloat {
   // underflow to (0 or min depending on rounding) if the number underflows.
   template <typename other_T>
   void castTo(other_T& other, round_direction round_dir) {
+    using other_traits = typename other_T::traits;
+    using other_underlyingtraits = typename other_traits::underlying_typetraits;
+
     other = other_T(static_cast<typename other_T::native_type>(0));
     bool negate = isNegative();
     if (getUnsignedBits() == 0) {
@@ -664,18 +798,24 @@ class HexFloat {
       }
     }
 
-    bool is_nan =
-        (getBits() & exponent_mask) == exponent_mask && significand != 0;
+    bool is_nan = T(getBits()).isNan();
     bool is_inf =
         !is_nan &&
         ((exponent + carried) > static_cast<int_type>(other_T::exponent_bias) ||
-         (significand == 0 && (getBits() & exponent_mask) == exponent_mask));
+         T(getBits()).isInfinity());
 
     // If we are Nan or Inf we should pass that through.
     if (is_inf) {
-      other.set_value(typename other_T::underlying_type(
-          static_cast<typename other_T::uint_type>(
-              (negate ? other_T::sign_mask : 0) | other_T::exponent_mask)));
+      if (other_traits::has_infinity)
+        other.set_value(typename other_T::underlying_type(
+            static_cast<typename other_T::uint_type>(
+                (negate ? other_T::sign_mask : 0) | other_T::exponent_mask)));
+      else  // if the type doesnt use infinity, set it to max value (E4M3)
+        other.set_value(typename other_T::underlying_type(
+            static_cast<typename other_T::uint_type>(
+                (negate ? other_T::sign_mask : 0) |
+                other_underlyingtraits::getBitsFromFloat(
+                    other_underlyingtraits::max()))));
       return;
     }
     if (is_nan) {
@@ -690,7 +830,8 @@ class HexFloat {
       // just set the last bit.
       other.set_value(typename other_T::underlying_type(
           static_cast<typename other_T::uint_type>(
-              (negate ? other_T::sign_mask : 0) | other_T::exponent_mask |
+              other_traits::NaN_pattern | (negate ? other_T::sign_mask : 0) |
+              other_T::exponent_mask |
               (shifted_significand == 0 ? 0x1 : shifted_significand))));
       return;
     }
@@ -738,8 +879,8 @@ inline uint8_t get_nibble_from_character(int character) {
 template <typename T, typename Traits>
 std::ostream& operator<<(std::ostream& os, const HexFloat<T, Traits>& value) {
   using HF = HexFloat<T, Traits>;
-  using uint_type = typename HF::uint_type;
-  using int_type = typename HF::int_type;
+  using uint_type = uint64_t;
+  using int_type = int64_t;
 
   static_assert(HF::num_used_bits != 0,
                 "num_used_bits must be non-zero for a valid float");
@@ -889,8 +1030,82 @@ ParseNormalFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>(
 
   // Overflow on 16-bit behaves the same as for 32- and 64-bit: set the
   // fail bit and set the lowest or highest value.
+  // /!\ We get an error if there is no overflow but the value is infinity.
+  // Is it what we want?
   if (Float16::isInfinity(value.value().getAsFloat())) {
     value.set_value(value.isNegative() ? Float16::lowest() : Float16::max());
+    is.setstate(std::ios_base::failbit);
+  }
+  return is;
+}
+// Specialization of ParseNormalFloat for FloatProxy<Float8_E4M3> values.
+// This will parse the float as it were a 32-bit floating point number,
+// and then round it down to fit into a Float8_E4M3 value.
+// The number is rounded towards zero.
+// If negate_value is true then the number may not have a leading minus or
+// plus, and if it successfully parses, then the number is negated before
+// being stored into the value parameter.
+// If the value cannot be correctly parsed or overflows the target floating
+// point type, then set the fail bit on the stream.
+// TODO(dneto): Promise C++11 standard behavior in how the value is set in
+// the error case, but only after all target platforms implement it correctly.
+// In particular, the Microsoft C++ runtime appears to be out of spec.
+template <>
+inline std::istream& ParseNormalFloat<FloatProxy<Float8_E4M3>,
+                                      HexFloatTraits<FloatProxy<Float8_E4M3>>>(
+    std::istream& is, bool negate_value,
+    HexFloat<FloatProxy<Float8_E4M3>, HexFloatTraits<FloatProxy<Float8_E4M3>>>&
+        value) {
+  // First parse as a 32-bit float.
+  HexFloat<FloatProxy<float>> float_val(0.0f);
+  ParseNormalFloat(is, negate_value, float_val);
+
+  if (float_val.value().getAsFloat() > 448.0f) {
+    is.setstate(std::ios_base::failbit);
+    value.set_value(Float8_E4M3::max());
+    return is;
+  } else if (float_val.value().getAsFloat() < -448.0f) {
+    is.setstate(std::ios_base::failbit);
+    value.set_value(0x80 | Float8_E4M3::max().get_value());
+    return is;
+  }
+  // Then convert to E4M3 float, saturating at infinities, and
+  // rounding toward zero.
+  float_val.castTo(value, round_direction::kToZero);
+
+  return is;
+}
+// Specialization of ParseNormalFloat for FloatProxy<Float8_E5M2> values.
+// This will parse the float as it were a Float8_E5M2 floating point number,
+// and then round it down to fit into a Float16 value.
+// The number is rounded towards zero.
+// If negate_value is true then the number may not have a leading minus or
+// plus, and if it successfully parses, then the number is negated before
+// being stored into the value parameter.
+// If the value cannot be correctly parsed or overflows the target floating
+// point type, then set the fail bit on the stream.
+// TODO(dneto): Promise C++11 standard behavior in how the value is set in
+// the error case, but only after all target platforms implement it correctly.
+// In particular, the Microsoft C++ runtime appears to be out of spec.
+template <>
+inline std::istream& ParseNormalFloat<FloatProxy<Float8_E5M2>,
+                                      HexFloatTraits<FloatProxy<Float8_E5M2>>>(
+    std::istream& is, bool negate_value,
+    HexFloat<FloatProxy<Float8_E5M2>, HexFloatTraits<FloatProxy<Float8_E5M2>>>&
+        value) {
+  // First parse as a 32-bit float.
+  HexFloat<FloatProxy<float>> float_val(0.0f);
+  ParseNormalFloat(is, negate_value, float_val);
+
+  // Then convert to Float8_E5M2 float, saturating at infinities, and
+  // rounding toward zero.
+  float_val.castTo(value, round_direction::kToZero);
+
+  // Overflow on Float8_E5M2 behaves the same as for 32- and 64-bit: set the
+  // fail bit and set the lowest or highest value.
+  if (Float8_E5M2::isInfinity(value.value().getAsFloat())) {
+    value.set_value(value.isNegative() ? Float8_E5M2::lowest()
+                                       : Float8_E5M2::max());
     is.setstate(std::ios_base::failbit);
   }
   return is;
@@ -1250,6 +1465,20 @@ template <>
 inline std::ostream& operator<<<Float16>(std::ostream& os,
                                          const FloatProxy<Float16>& value) {
   os << HexFloat<FloatProxy<Float16>>(value);
+  return os;
+}
+
+template <>
+inline std::ostream& operator<< <Float8_E4M3>(
+    std::ostream& os, const FloatProxy<Float8_E4M3>& value) {
+  os << HexFloat<FloatProxy<Float8_E4M3>>(value);
+  return os;
+}
+
+template <>
+inline std::ostream& operator<< <Float8_E5M2>(
+    std::ostream& os, const FloatProxy<Float8_E5M2>& value) {
+  os << HexFloat<FloatProxy<Float8_E5M2>>(value);
   return os;
 }
 

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -620,7 +620,7 @@ class HexFloat {
   // even if they are not going to be executed. Eg:
   // constant_number < 0? 0: constant_number
   // These convert the negative left-shifts into right shifts.
-  template <int_type N>
+  template <int N>
   struct negatable_left_shift {
     static uint_type val(uint_type val) {
       if (N > 0) {
@@ -631,7 +631,7 @@ class HexFloat {
     }
   };
 
-  template <int_type N>
+  template <int N>
   struct negatable_right_shift {
     static uint_type val(uint_type val) {
       if (N > 0) {
@@ -647,28 +647,28 @@ class HexFloat {
   // even if they are not going to be executed. Eg:
   // constant_number < 0? 0: constant_number
   // These convert the negative left-shifts into right shifts.
-  template <int_type N, typename enable = void>
+  template <int N, typename enable = void>
   struct negatable_left_shift {
     static uint_type val(uint_type val) {
       return static_cast<uint_type>(val >> -N);
     }
   };
 
-  template <int_type N>
+  template <int N>
   struct negatable_left_shift<N, typename std::enable_if<N >= 0>::type> {
     static uint_type val(uint_type val) {
       return static_cast<uint_type>(val << N);
     }
   };
 
-  template <int_type N, typename enable = void>
+  template <int N, typename enable = void>
   struct negatable_right_shift {
     static uint_type val(uint_type val) {
       return static_cast<uint_type>(val << -N);
     }
   };
 
-  template <int_type N>
+  template <int N>
   struct negatable_right_shift<N, typename std::enable_if<N >= 0>::type> {
     static uint_type val(uint_type val) {
       return static_cast<uint_type>(val >> N);

--- a/source/util/parse_number.cpp
+++ b/source/util/parse_number.cpp
@@ -131,6 +131,19 @@ EncodeNumberStatus ParseAndEncodeIntegerNumber(
   return EncodeNumberStatus::kSuccess;
 }
 
+spv_fp_encoding_t DeduceEncoding(const NumberType& type) {
+  if (type.encoding != SPV_FP_ENCODING_UNKNOWN) return type.encoding;
+  switch (type.bitwidth) {
+    case 16:
+      return SPV_FP_ENCODING_IEEE754_BINARY16;
+    case 32:
+      return SPV_FP_ENCODING_IEEE754_BINARY32;
+    case 64:
+      return SPV_FP_ENCODING_IEEE754_BINARY64;
+    default:
+      return SPV_FP_ENCODING_UNKNOWN;
+  }
+}
 EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
     const char* text, const NumberType& type,
     std::function<void(uint32_t)> emit, std::string* error_msg) {
@@ -145,8 +158,35 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
   }
 
   const auto bit_width = AssumedBitWidth(type);
-  switch (bit_width) {
-    case 16: {
+  switch (DeduceEncoding(type)) {
+    case SPV_FP_ENCODING_E4M3: {
+      HexFloat<FloatProxy<Float8_E4M3>> hVal(0);
+      if (!ParseNumber(text, &hVal)) {
+        ErrorMsgStream(error_msg) << "Invalid E4M3 float literal: " << text;
+        return EncodeNumberStatus::kInvalidText;
+      }
+      // getAsFloat will return the Float16 value, and get_value
+      // will return a uint16_t representing the bits of the float.
+      // The encoding is therefore correct from the perspective of the SPIR-V
+      // spec since the top 16 bits will be 0.
+      emit(static_cast<uint32_t>(hVal.value().getAsFloat().get_value()));
+      return EncodeNumberStatus::kSuccess;
+    } break;
+    case SPV_FP_ENCODING_E5M2: {
+      HexFloat<FloatProxy<Float8_E5M2>> hVal(0);
+      if (!ParseNumber(text, &hVal)) {
+        ErrorMsgStream(error_msg) << "Invalid E5M2 float literal: " << text;
+        return EncodeNumberStatus::kInvalidText;
+      }
+      // getAsFloat will return the Float16 value, and get_value
+      // will return a uint16_t representing the bits of the float.
+      // The encoding is therefore correct from the perspective of the SPIR-V
+      // spec since the top 16 bits will be 0.
+      emit(static_cast<uint32_t>(hVal.value().getAsFloat().get_value()));
+      return EncodeNumberStatus::kSuccess;
+    } break;
+    case SPV_FP_ENCODING_BFLOAT16:  // FIXME this likely needs separate handling
+    case SPV_FP_ENCODING_IEEE754_BINARY16: {
       HexFloat<FloatProxy<Float16>> hVal(0);
       if (!ParseNumber(text, &hVal)) {
         ErrorMsgStream(error_msg) << "Invalid 16-bit float literal: " << text;
@@ -159,7 +199,7 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
       emit(static_cast<uint32_t>(hVal.value().getAsFloat().get_value()));
       return EncodeNumberStatus::kSuccess;
     } break;
-    case 32: {
+    case SPV_FP_ENCODING_IEEE754_BINARY32: {
       HexFloat<FloatProxy<float>> fVal(0.0f);
       if (!ParseNumber(text, &fVal)) {
         ErrorMsgStream(error_msg) << "Invalid 32-bit float literal: " << text;
@@ -168,7 +208,7 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
       emit(BitwiseCast<uint32_t>(fVal));
       return EncodeNumberStatus::kSuccess;
     } break;
-    case 64: {
+    case SPV_FP_ENCODING_IEEE754_BINARY64: {
       HexFloat<FloatProxy<double>> dVal(0.0);
       if (!ParseNumber(text, &dVal)) {
         ErrorMsgStream(error_msg) << "Invalid 64-bit float literal: " << text;

--- a/source/util/parse_number.cpp
+++ b/source/util/parse_number.cpp
@@ -159,7 +159,7 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
 
   const auto bit_width = AssumedBitWidth(type);
   switch (DeduceEncoding(type)) {
-    case SPV_FP_ENCODING_E4M3: {
+    case SPV_FP_ENCODING_FLOAT8_E4M3: {
       HexFloat<FloatProxy<Float8_E4M3>> hVal(0);
       if (!ParseNumber(text, &hVal)) {
         ErrorMsgStream(error_msg) << "Invalid E4M3 float literal: " << text;
@@ -172,7 +172,7 @@ EncodeNumberStatus ParseAndEncodeFloatingPointNumber(
       emit(static_cast<uint32_t>(hVal.value().getAsFloat().get_value()));
       return EncodeNumberStatus::kSuccess;
     } break;
-    case SPV_FP_ENCODING_E5M2: {
+    case SPV_FP_ENCODING_FLOAT8_E5M2: {
       HexFloat<FloatProxy<Float8_E5M2>> hVal(0);
       if (!ParseNumber(text, &hVal)) {
         ErrorMsgStream(error_msg) << "Invalid E5M2 float literal: " << text;

--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -146,6 +146,7 @@ bool IsSupportOptionalVulkan_1_0(uint32_t capability) {
     case spv::Capability::Float16:
     case spv::Capability::Int8:
     case spv::Capability::BFloat16TypeKHR:
+    case spv::Capability::Float8EXT:
       return true;
     default:
       break;

--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -267,15 +267,12 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
       // Scalar type
       const uint32_t resScalarType = _.GetComponentType(result_type);
       const uint32_t inputScalartype = _.GetComponentType(input_type);
-      if (_.GetBitWidth(resScalarType) == _.GetBitWidth(inputScalartype))
-        if ((_.IsBfloat16ScalarType(resScalarType) &&
-             _.IsBfloat16ScalarType(inputScalartype)) ||
-            (!_.IsBfloat16ScalarType(inputScalartype) &&
-             !_.IsBfloat16ScalarType(resScalarType)))
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Expected input to have different bit width from Result "
-                    "Type: "
-                 << spvOpcodeString(opcode);
+      if (resScalarType == inputScalartype) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Expected component type of Value to be different from "
+                  "component type of Result Type: "
+               << spvOpcodeString(opcode);
+      }
       break;
     }
 

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -663,6 +663,25 @@ spv_result_t ValidateStorageClass(ValidationState_t& _,
                  << _.getIdName(interface_var->id()) << " must not be declared "
                  << "with a Storage Class of Input or Output.";
         }
+        if (_.ContainsType(
+                result_type->GetOperandAs<uint32_t>(2),
+                [](const Instruction* inst) {
+                  if (inst && inst->opcode() == spv::Op::OpTypeFloat) {
+                    if (inst->words().size() > 3) {
+                      auto encoding = inst->GetOperandAs<spv::FPEncoding>(2);
+                      if ((encoding == spv::FPEncoding::Float8E4M3EXT) ||
+                          (encoding == spv::FPEncoding::Float8E5M2EXT)) {
+                        return true;
+                      }
+                    }
+                  }
+                  return false;
+                })) {
+          return _.diag(SPV_ERROR_INVALID_ID, interface_var)
+                 << "FP8 E4M3/E5M2 OpVariable <id> "  // TODO VUID
+                 << _.getIdName(interface_var->id()) << " must not be declared "
+                 << "with a Storage Class of Input or Output.";
+        }
       }
       default:
         break;

--- a/source/val/validate_invalid_type.cpp
+++ b/source/val/validate_invalid_type.cpp
@@ -74,6 +74,11 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
       }
+      if (_.IsFP8ScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << spvOpcodeString(opcode)
+               << " doesn't support FP8 E4M3/E5M2 types.";
+      }
       break;
     }
 
@@ -83,6 +88,11 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
       if (_.IsBfloat16VectorType(data_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
+      }
+      if (_.IsFP8VectorType(data_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << spvOpcodeString(opcode)
+               << " doesn't support FP8 E4M3/E5M2 types.";
       }
       break;
     }
@@ -98,6 +108,11 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
       }
+      if (_.IsFP8ScalarOrVectorType(operand_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << spvOpcodeString(opcode)
+               << " doesn't support FP8 E4M3/E5M2 types.";
+      }
       break;
     }
 
@@ -108,6 +123,12 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
       }
+      if (_.IsFP8ScalarOrVectorType(value_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << spvOpcodeString(opcode)
+               << " doesn't support FP8 E4M3/E5M2 types.";
+      }
+
       break;
     }
 
@@ -123,6 +144,11 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << spvOpcodeString(opcode)
                  << " doesn't support BFloat16 type.";
+        }
+        if (_.IsFP8ScalarOrVectorType(res_component_type)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << spvOpcodeString(opcode)
+                 << " doesn't support FP8 E4M3/E5M2 types.";
         }
       }
       break;

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -117,13 +117,6 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
     return SPV_SUCCESS;
   }
   auto operands = inst->words();
-  if (operands.size() > 3) {
-    if (operands[3] != 0) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Current FPEncoding only supports BFloat16KHR.";
-    }
-    return SPV_SUCCESS;
-  }
 
   if (num_bits == 16) {
     // An absence of FP encoding implies IEEE 754. The Float16 and Float16Buffer
@@ -135,6 +128,28 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
            << "Using a 16-bit floating point "
            << "type requires the Float16 or Float16Buffer capability,"
               " or an extension that explicitly enables 16-bit floating point.";
+  }
+  if (num_bits == 8) {
+    if (!_.features().declare_float8_type) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Using a 8-bit floating point "
+             << "type requires the Float8EXT capability.";
+    }
+    if (inst->words().size() < 4) {
+      // we don't support fp8 without encoding
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "8-bit floating point type requires an encoding.";
+    }
+    const char* encoding = _.grammar().lookupOperandName(
+        SPV_OPERAND_TYPE_FPENCODING, inst->words()[3]);
+    const std::set<std::string> known_encodings{"Float8E4M3EXT",
+                                                "Float8E5M2EXT"};
+    if (known_encodings.find(encoding) == known_encodings.end())
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Unsupported 8-bit floating point encoding: " << encoding
+             << ".";
+
+    return SPV_SUCCESS;
   }
   if (num_bits == 64) {
     if (_.HasCapability(spv::Capability::Float64)) {
@@ -661,6 +676,15 @@ spv_result_t ValidateTypeCooperativeMatrix(ValidationState_t& _,
              << "OpTypeCooperativeMatrix Component Type <id> "
              << _.getIdName(component_type_id)
              << "require BFloat16CooperativeMatrixKHR be declared.";
+    }
+  }
+
+  if (_.IsFP8ScalarType(component_type_id)) {
+    if (!_.HasCapability(spv::Capability::Float8CooperativeMatrixEXT)) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << "OpTypeCooperativeMatrix Component Type <id> "
+             << _.getIdName(component_type_id)
+             << "require Float8CooperativeMatrixEXT be declared.";
     }
   }
 

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -68,6 +68,7 @@ class ValidationState_t {
   struct Feature {
     bool declare_int16_type = false;     // Allow OpTypeInt with 16 bit width?
     bool declare_float16_type = false;   // Allow OpTypeFloat with 16 bit width?
+    bool declare_float8_type = false;    // Allow OpTypeFloat with 8 bit width?
     bool free_fp_rounding_mode = false;  // Allow the FPRoundingMode decoration
                                          // and its values to be used without
                                          // requiring any capability
@@ -637,6 +638,9 @@ class ValidationState_t {
   bool IsScalarType(uint32_t id) const;
   bool IsBfloat16ScalarType(uint32_t id) const;
   bool IsBfloat16VectorType(uint32_t id) const;
+  bool IsFP8ScalarType(uint32_t id) const;
+  bool IsFP8VectorType(uint32_t id) const;
+  bool IsFP8ScalarOrVectorType(uint32_t id) const;
   bool IsFloatScalarType(uint32_t id) const;
   bool IsFloatArrayType(uint32_t id) const;
   bool IsFloatVectorType(uint32_t id) const;

--- a/test/parse_number_test.cpp
+++ b/test/parse_number_test.cpp
@@ -898,6 +898,120 @@ TEST(ParseAndEncodeFloat16, Sample) {
   EXPECT_EQ("Invalid 16-bit float literal: -1e400", err_msg);
 }
 
+TEST(ParseAndEncodeFloat8_E4M3, Sample) {
+  EncodeNumberStatus rc = EncodeNumberStatus::kSuccess;
+  std::string err_msg;
+  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_E4M3};
+
+  // Invalid
+  rc = ParseAndEncodeFloatingPointNumber("", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: ", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("0=", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: 0=", err_msg);
+
+  // Representative samples
+  rc = ParseAndEncodeFloatingPointNumber(
+      "0.0", type, [](uint32_t word) { EXPECT_EQ(0x0u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "-0.0", type, [](uint32_t word) { EXPECT_EQ(0x80u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "1.0", type, [](uint32_t word) { EXPECT_EQ(0x38u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "2.5", type, [](uint32_t word) { EXPECT_EQ(0x42u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "-0.625", type, [](uint32_t word) { EXPECT_EQ(0xB2u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+
+  // Overflow
+  rc =
+      ParseAndEncodeFloatingPointNumber("1e38", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: 1e38", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e38", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: -1e38", err_msg);
+  rc =
+      ParseAndEncodeFloatingPointNumber("1e40", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: 1e40", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e40", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: -1e40", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("1e400", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: 1e400", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e400", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E4M3 float literal: -1e400", err_msg);
+}
+
+TEST(ParseAndEncodeFloat8_E5M2, Sample) {
+  EncodeNumberStatus rc = EncodeNumberStatus::kSuccess;
+  std::string err_msg;
+  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_E5M2};
+
+  // Invalid
+  rc = ParseAndEncodeFloatingPointNumber("", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: ", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("0=", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: 0=", err_msg);
+
+  // Representative samples
+  rc = ParseAndEncodeFloatingPointNumber(
+      "0.0", type, [](uint32_t word) { EXPECT_EQ(0x0u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "-0.0", type, [](uint32_t word) { EXPECT_EQ(0x80u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "1.0", type, [](uint32_t word) { EXPECT_EQ(0x3cu, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "2.5", type, [](uint32_t word) { EXPECT_EQ(0x41u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+  rc = ParseAndEncodeFloatingPointNumber(
+      "-0.625", type, [](uint32_t word) { EXPECT_EQ(0xB9u, word); }, nullptr);
+  EXPECT_EQ(EncodeNumberStatus::kSuccess, rc);
+
+  // Overflow
+  rc =
+      ParseAndEncodeFloatingPointNumber("1e38", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: 1e38", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e38", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: -1e38", err_msg);
+  rc =
+      ParseAndEncodeFloatingPointNumber("1e40", type, AssertEmitFunc, &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: 1e40", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e40", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: -1e40", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("1e400", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: 1e400", err_msg);
+  rc = ParseAndEncodeFloatingPointNumber("-1e400", type, AssertEmitFunc,
+                                         &err_msg);
+  EXPECT_EQ(EncodeNumberStatus::kInvalidText, rc);
+  EXPECT_EQ("Invalid E5M2 float literal: -1e400", err_msg);
+}
+
 TEST(ParseAndEncodeFloatingPointNumber, TypeNone) {
   EncodeNumberStatus rc = EncodeNumberStatus::kSuccess;
   std::string err_msg;

--- a/test/parse_number_test.cpp
+++ b/test/parse_number_test.cpp
@@ -901,7 +901,7 @@ TEST(ParseAndEncodeFloat16, Sample) {
 TEST(ParseAndEncodeFloat8_E4M3, Sample) {
   EncodeNumberStatus rc = EncodeNumberStatus::kSuccess;
   std::string err_msg;
-  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_E4M3};
+  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_FLOAT8_E4M3};
 
   // Invalid
   rc = ParseAndEncodeFloatingPointNumber("", type, AssertEmitFunc, &err_msg);
@@ -958,7 +958,7 @@ TEST(ParseAndEncodeFloat8_E4M3, Sample) {
 TEST(ParseAndEncodeFloat8_E5M2, Sample) {
   EncodeNumberStatus rc = EncodeNumberStatus::kSuccess;
   std::string err_msg;
-  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_E5M2};
+  NumberType type = {8, SPV_NUMBER_FLOATING, SPV_FP_ENCODING_FLOAT8_E5M2};
 
   // Invalid
   rc = ParseAndEncodeFloatingPointNumber("", type, AssertEmitFunc, &err_msg);

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -1463,5 +1463,37 @@ INSTANTIATE_TEST_SUITE_P(
              MakeInstruction(spv::Op::OpTensorQuerySizeARM, {1, 2, 3, 4})},
         })));
 
+// SPV_EXT_float8
+INSTANTIATE_TEST_SUITE_P(
+    SPV_EXT_float8, ExtensionRoundTripTest,
+    Combine(
+        Values(SPV_ENV_UNIVERSAL_1_0, SPV_ENV_UNIVERSAL_1_6, SPV_ENV_VULKAN_1_0,
+               SPV_ENV_VULKAN_1_1, SPV_ENV_VULKAN_1_2, SPV_ENV_VULKAN_1_3,
+               SPV_ENV_OPENCL_2_1),
+        ValuesIn(std::vector<AssemblyCase>{
+            {"OpExtension \"SPV_EXT_float8\"\n",
+             MakeInstruction(spv::Op::OpExtension,
+                             MakeVector("SPV_EXT_float8"))},
+            {"OpCapability Float8EXT\n",
+             MakeInstruction(spv::Op::OpCapability,
+                             {(uint32_t)spv::Capability::Float8EXT})},
+            {"OpCapability Float8CooperativeMatrixEXT\n",
+             MakeInstruction(
+                 spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::Float8CooperativeMatrixEXT})},
+            {"%1 = OpTypeFloat 8 Float8E4M3EXT\n",
+             MakeInstruction(spv::Op::OpTypeFloat,
+                             {1, 8, (uint32_t)spv::FPEncoding::Float8E4M3EXT})},
+            {"%1 = OpTypeFloat 8 Float8E5M2EXT\n",
+             MakeInstruction(spv::Op::OpTypeFloat,
+                             {1, 8, (uint32_t)spv::FPEncoding::Float8E5M2EXT})},
+            {"OpDecorate %1 SaturatedToLargestFloat8NormalConversionEXT\n",
+             MakeInstruction(
+                 spv::Op::OpDecorate,
+                 {1,
+                  uint32_t(spv::Decoration::
+                               SaturatedToLargestFloat8NormalConversionEXT)})},
+        })));
+
 }  // namespace
 }  // namespace spvtools

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -374,7 +374,7 @@ TEST_F(ValidateData, float16_good) {
 
 TEST_F(ValidateData, float8_good) {
   std::string str = header_with_float8 +
-R"(%2 = OpTypeFloat 8 Float8E4M3EXT
+                    R"(%2 = OpTypeFloat 8 Float8E4M3EXT
 %3 = OpTypeFloat 8 Float8E5M2EXT
 )";
   CompileSuccessfully(str.c_str());
@@ -413,7 +413,8 @@ TEST_F(ValidateData, cooperative_matrix_float8_no_capability_bad) {
 )";
   CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_3);
   ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("require Float8CooperativeMatrixEXT be declared"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("require Float8CooperativeMatrixEXT be declared"));
 }
 
 TEST_F(ValidateData, float16_buffer_good) {
@@ -439,7 +440,7 @@ TEST_F(ValidateData, bfloat16_bad) {
 
 TEST_F(ValidateData, float8_bad) {
   std::string str = header +
-R"(%2 = OpTypeFloat 8 Float8E4M3EXT
+                    R"(%2 = OpTypeFloat 8 Float8E4M3EXT
 %3 = OpTypeFloat 8 Float8E5M2EXT
 )";
   CompileSuccessfully(str.c_str());
@@ -457,7 +458,8 @@ TEST_F(ValidateData, float8_no_encoding_bad) {
 }
 
 TEST_F(ValidateData, float8_bad_encoding) {
-  std::string str = header_with_float8_and_bfloat16 + "%2 = OpTypeFloat 8 BFloat16KHR";
+  std::string str =
+      header_with_float8_and_bfloat16 + "%2 = OpTypeFloat 8 BFloat16KHR";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -80,6 +80,35 @@ std::string header_with_bfloat16 = R"(
      OpExtension "SPV_KHR_bfloat16"
      OpMemoryModel Logical GLSL450
 )";
+std::string header_with_float8 = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpCapability Float8EXT
+     OpCapability Float8CooperativeMatrixEXT
+     OpExtension "SPV_EXT_float8"
+     OpMemoryModel Logical GLSL450
+)";
+std::string header_with_float8_and_bfloat16 = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpCapability Float8EXT
+     OpCapability Float8CooperativeMatrixEXT
+     OpCapability BFloat16TypeKHR
+     OpExtension "SPV_EXT_float8"
+     OpExtension "SPV_KHR_bfloat16"
+     OpMemoryModel Logical GLSL450
+)";
+std::string header_with_float8_no_coop_matrix = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpCapability Float8EXT
+     OpCapability CooperativeMatrixKHR
+     OpCapability VulkanMemoryModel
+     OpExtension "SPV_EXT_float8"
+     OpExtension "SPV_KHR_cooperative_matrix"
+     OpExtension "SPV_KHR_vulkan_memory_model"
+     OpMemoryModel Logical VulkanKHR
+)";
 std::string header_with_float16 = R"(
      OpCapability Shader
      OpCapability Linkage
@@ -343,6 +372,15 @@ TEST_F(ValidateData, float16_good) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateData, float8_good) {
+  std::string str = header_with_float8 +
+R"(%2 = OpTypeFloat 8 Float8E4M3EXT
+%3 = OpTypeFloat 8 Float8E5M2EXT
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateData, bfloat16_good) {
   std::string str = header_with_bfloat16 + "%2 = OpTypeFloat 16 BFloat16KHR";
   CompileSuccessfully(str.c_str());
@@ -360,6 +398,22 @@ TEST_F(ValidateData, cooperative_matrix_bfloat16_good) {
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateData, cooperative_matrix_float8_no_capability_bad) {
+  std::string str = header_with_float8_no_coop_matrix + R"(
+%u32 = OpTypeInt 32 0
+%u32_16 = OpConstant %u32 16
+%useA = OpConstant %u32 0
+%subgroup = OpConstant %u32 3
+%fp8e4m3 = OpTypeFloat 8 Float8E4M3EXT
+%fp8e5m2 = OpTypeFloat 8 Float8E5M2EXT
+%fp8e4m3_matA = OpTypeCooperativeMatrixKHR %fp8e4m3 %subgroup %u32_16 %u32_16 %useA
+%fp8e5m2_matA = OpTypeCooperativeMatrixKHR %fp8e5m2 %subgroup %u32_16 %u32_16 %useA
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_UNIVERSAL_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("require Float8CooperativeMatrixEXT be declared"));
 }
 
 TEST_F(ValidateData, float16_buffer_good) {
@@ -381,6 +435,33 @@ TEST_F(ValidateData, bfloat16_bad) {
   ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("requires one of these capabilities: BFloat16TypeKHR"));
+}
+
+TEST_F(ValidateData, float8_bad) {
+  std::string str = header +
+R"(%2 = OpTypeFloat 8 Float8E4M3EXT
+%3 = OpTypeFloat 8 Float8E5M2EXT
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: Float8EXT"));
+}
+
+TEST_F(ValidateData, float8_no_encoding_bad) {
+  std::string str = header_with_float8 + "%2 = OpTypeFloat 8";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("8-bit floating point type requires an encoding"));
+}
+
+TEST_F(ValidateData, float8_bad_encoding) {
+  std::string str = header_with_float8_and_bfloat16 + "%2 = OpTypeFloat 8 BFloat16KHR";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Unsupported 8-bit floating point encoding"));
 }
 
 TEST_F(ValidateData, dot_bfloat16_bad) {

--- a/test/val/val_extensions_test.cpp
+++ b/test/val/val_extensions_test.cpp
@@ -61,8 +61,8 @@ INSTANTIATE_TEST_SUITE_P(
         "SPV_AMD_shader_image_load_store_lod", "SPV_AMD_shader_fragment_mask",
         "SPV_GOOGLE_decorate_string", "SPV_GOOGLE_hlsl_functionality1",
         "SPV_NV_shader_subgroup_partitioned", "SPV_EXT_descriptor_indexing",
-        "SPV_KHR_terminate_invocation",
-        "SPV_KHR_relaxed_extended_instruction"));
+        "SPV_KHR_terminate_invocation", "SPV_KHR_relaxed_extended_instruction",
+        "SPV_EXT_float8"));
 
 INSTANTIATE_TEST_SUITE_P(FailSilently, ValidateUnknownExtensions,
                          Values("ERROR_unknown_extension", "SPV_KHR_",

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -2022,7 +2022,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
 }
 
-TEST_F(ValidateInterfacesTest, ValidInstructionType) {
+TEST_F(ValidateInterfacesTest,
+       InvalidBfloat16VariableWithInputOutputStorageClass) {
   const std::string text = R"(
 OpCapability Shader
 OpCapability BFloat16TypeKHR
@@ -2050,6 +2051,70 @@ OpFunctionEnd
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Bfloat16 OpVariable <id> '2[%2]' must not be declared "
                         "with a Storage Class of Input or Output.\n"));
+}
+
+TEST_F(ValidateInterfacesTest,
+       InvalidFP8E4M3VariableWithInputOutputStorageClass) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Float8EXT
+OpExtension "SPV_EXT_float8"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %in %out
+OpExecutionMode %main OriginUpperLeft
+OpDecorate %in Location 0
+OpDecorate %out Location 0
+%void = OpTypeVoid
+%fp8e4m3 = OpTypeFloat 8 Float8E4M3EXT
+%in_ptr = OpTypePointer Input %fp8e4m3
+%out_ptr = OpTypePointer Output %fp8e4m3
+%in = OpVariable %in_ptr Input
+%out = OpVariable %out_ptr Output
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("FP8 E4M3/E5M2 OpVariable <id> '2[%2]' must not be declared "
+                "with a Storage Class of Input or Output.\n"));
+}
+
+TEST_F(ValidateInterfacesTest,
+       InvalidFP8E5M2VariableWithInputOutputStorageClass) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Float8EXT
+OpExtension "SPV_EXT_float8"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %in %out
+OpExecutionMode %main OriginUpperLeft
+OpDecorate %in Location 0
+OpDecorate %out Location 0
+%void = OpTypeVoid
+%fp8e5m2 = OpTypeFloat 8 Float8E5M2EXT
+%in_ptr = OpTypePointer Input %fp8e5m2
+%out_ptr = OpTypePointer Output %fp8e5m2
+%in = OpVariable %in_ptr Input
+%out = OpVariable %out_ptr Output
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("FP8 E4M3/E5M2 OpVariable <id> '2[%2]' must not be declared "
+                "with a Storage Class of Input or Output.\n"));
 }
 
 }  // namespace


### PR DESCRIPTION
This also overhauls the number parsing code. It seems further work will be needed to correctly handle BFloat16. This change intends to leave the code no worse than it was. TODOs were added where relevant.

Co-authored-by: Guillaume Trebuchet <guillaume.trebuchet@arm.com>
Co-authored-by: Kevin Petit <kevin.petit@arm.com>