### PR TITLE
Add mimalloc to improve multithreaded performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ compile_commands.json
 /external/effcee
 /external/re2
 /external/protobuf
+/external/mimalloc
 /out
 /TAGS
 /third_party/llvm-build/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,6 +130,8 @@ cc_library(
         "source/*.cpp",
         "source/util/*.cpp",
         "source/val/*.cpp",
+    ], exclude = [
+        "source/mimalloc.cpp"
     ]) + [
         ":build_version_inc",
         ":gen_compressed_tables",

--- a/DEPS
+++ b/DEPS
@@ -15,6 +15,8 @@ vars = {
   're2_revision': 'c84a140c93352cdabbfb547c531be34515b12228',
 
   'spirv_headers_revision': '50daff941d88609b4d2ad076eae558e727f8e5cd',
+
+  'mimalloc_revision': '51c09e7b6a0ac5feeba998710f00c7dd7aa67bbf',
 }
 
 deps = {
@@ -36,5 +38,8 @@ deps = {
   'external/spirv-headers':
       Var('github') +  '/KhronosGroup/SPIRV-Headers.git@' +
           Var('spirv_headers_revision'),
+
+  'external/mimalloc':
+      Var('github') + '/microsoft/mimalloc.git@' + Var('mimalloc_revision'),
 }
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ For some kinds of development, you may need the latest sources from the third-pa
     git clone https://github.com/google/effcee.git              spirv-tools/external/effcee
     git clone https://github.com/google/re2.git                 spirv-tools/external/re2
     git clone https://github.com/abseil/abseil-cpp.git          spirv-tools/external/abseil_cpp
+    git clone https://github.com/microsoft/mimalloc.git         spirv-tools/external/mimalloc
 
 #### Dependency on Effcee
 
@@ -311,6 +312,23 @@ Effcee itself depends on [RE2][re2], and RE2 depends on [Abseil][abseil-cpp].
 * Otherwise, SPIRV-Tools expects Effcee sources to appear in `external/effcee`,
   RE2 sources to appear in `external/re2`, and Abseil sources to appear in 
   `external/abseil_cpp`.
+
+#### Dependency on mimalloc
+
+SPIRV-Tools may be configured to use the [mimalloc][mimalloc] library to improve memory
+allocation performance. In order to avoid unexpectedly changing allocation behavior of
+applications that link SPIRV-Tools libraries statically, this option has no effect on
+the static libraries.
+
+In the CMake build, usage of mimalloc is controlled by the `SPIRV_TOOLS_USE_MIMALLOC`
+option. This variable defaults on `ON` when building for Windows and `OFF` when building
+for other platforms. Enabling this option on non-Windows platforms is supported and is
+expected to work normally, but this has not been tested as thoroughly and extensively as
+the Windows version. In the future, the `SPIRV_TOOLS_USE_MIMALLOC` option may default to
+`ON` for non-Windows platforms as well.
+
+*Note*: mimalloc is currently only supported when building with CMake. When using Bazel,
+mimalloc is not used.
 
 ### Source code organization
 
@@ -325,6 +343,7 @@ Effcee itself depends on [RE2][re2], and RE2 depends on [Abseil][abseil-cpp].
 * `external/abseil_cpp`: Location of [Abseil][abseil-cpp] sources, if Abseil is
    not already configured by an enclosing project.
   (The RE2 project already requires Abseil.)
+* `external/mimalloc`: Intended location for [mimalloc][mimalloc] sources, not provided
 * `include/`: API clients should add this directory to the include search path
 * `external/spirv-headers`: Intended location for
   [SPIR-V headers][spirv-headers], not provided
@@ -801,6 +820,7 @@ limitations under the License.
 [effcee]: https://github.com/google/effcee
 [re2]: https://github.com/google/re2
 [abseil-cpp]: https://github.com/abseil/abseil-cpp
+[mimalloc]: https://github.com/microsoft/mimalloc
 [CMake]: https://cmake.org/
 [cpp-style-guide]: https://google.github.io/styleguide/cppguide.html
 [clang-sanitizers]: http://clang.llvm.org/docs/UsersManual.html#controlling-code-generation

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -26,6 +26,46 @@ function(pop_variable var)
     set(${var} ${val} PARENT_SCOPE)
 endfunction()
 
+if (DEFINED mimalloc_SOURCE_DIR)
+  # This allows flexible position of the mimalloc repo.
+  set(MIMALLOC_DIR ${mimalloc_SOURCE_DIR})
+else()
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mimalloc)
+    set(MIMALLOC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/mimalloc)
+  endif()
+endif()
+
+# Used on Windows by default, but allow opt-in on other platforms
+if (WIN32)
+  set(SPIRV_TOOLS_USE_MIMALLOC_DEFAULT_VALUE ON)
+else()
+  set(SPIRV_TOOLS_USE_MIMALLOC_DEFAULT_VALUE OFF)
+endif()
+
+# To avoid unexpected side effects on users of the static library, mimalloc
+# may only be used when building executables and shared libraries.
+include(CMakeDependentOption)
+cmake_dependent_option(SPIRV_TOOLS_USE_MIMALLOC
+  "Executables and shared libraries use mimalloc instead of the default allocator"
+  ${SPIRV_TOOLS_USE_MIMALLOC_DEFAULT_VALUE} "MIMALLOC_DIR" OFF)
+
+if (SPIRV_TOOLS_USE_MIMALLOC)
+  if (NOT WIN32)
+    push_variable(MI_OVERRIDE 0)
+  endif()
+  push_variable(MI_BUILD_TESTS 0)
+
+  add_subdirectory(${MIMALLOC_DIR} ${CMAKE_BINARY_DIR}/external/mimalloc EXCLUDE_FROM_ALL)
+  if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+    target_compile_options(mimalloc-static PRIVATE -Wno-int-conversion)
+  endif()
+
+  if (NOT WIN32)
+    pop_variable(MI_OVERRIDE)
+  endif()
+  pop_variable(MI_BUILD_TESTS)
+endif()
+
 if (DEFINED SPIRV-Headers_SOURCE_DIR)
   # This allows flexible position of the SPIRV-Headers repo.
   set(SPIRV_HEADER_DIR ${SPIRV-Headers_SOURCE_DIR})

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -294,6 +294,12 @@ if (${SPIRV_TIMER_ENABLED})
     ${CMAKE_CURRENT_SOURCE_DIR}/util/timer.cpp)
 endif()
 
+if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+  set(SPIRV_SOURCES
+      ${SPIRV_SOURCES}
+      ${CMAKE_CURRENT_SOURCE_DIR}/mimalloc.cpp)
+endif()
+
 # The software_version.cpp file includes build-version.inc.
 # Rebuild the software_version.cpp object file if it is older than
 # build-version.inc or whenever build-version.inc itself is out of
@@ -330,6 +336,9 @@ endfunction()
 # Always build ${SPIRV_TOOLS}-shared. This is expected distro packages, and
 # unlike the other SPIRV_TOOLS target, defaults to hidden symbol visibility.
 add_library(${SPIRV_TOOLS}-shared SHARED ${SPIRV_SOURCES})
+if (SPIRV_TOOLS_USE_MIMALLOC)
+  target_link_libraries(${SPIRV_TOOLS}-shared PRIVATE mimalloc-static)
+endif()
 spirv_tools_default_target_options(${SPIRV_TOOLS}-shared)
 set_target_properties(${SPIRV_TOOLS}-shared PROPERTIES CXX_VISIBILITY_PRESET hidden)
 target_compile_definitions(${SPIRV_TOOLS}-shared
@@ -354,6 +363,9 @@ if(SPIRV_TOOLS_BUILD_STATIC)
   set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS}-static ${SPIRV_TOOLS}-shared)
 else()
   add_library(${SPIRV_TOOLS} ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_SOURCES})
+  if (SPIRV_TOOLS_USE_MIMALLOC)
+    target_link_libraries(${SPIRV_TOOLS} PRIVATE mimalloc-static)
+  endif()
   spirv_tools_default_target_options(${SPIRV_TOOLS})
   set(SPIRV_TOOLS_TARGETS ${SPIRV_TOOLS} ${SPIRV_TOOLS}-shared)
 endif()
@@ -362,12 +374,15 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   find_library(LIBRT rt)
   if(LIBRT)
     foreach(target ${SPIRV_TOOLS_TARGETS})
-      target_link_libraries(${target} rt)
+      target_link_libraries(${target} PUBLIC rt)
     endforeach()
   endif()
 endif()
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
+  if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+    list(APPEND SPIRV_TOOLS_TARGETS mimalloc-static)
+  endif()
   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets)
   export(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Target.cmake)
 

--- a/source/diff/CMakeLists.txt
+++ b/source/diff/CMakeLists.txt
@@ -18,7 +18,15 @@ set(SPIRV_TOOLS_DIFF_SOURCES
   diff.cpp
 )
 
+if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+  list(APPEND SPIRV_TOOLS_DIFF_SOURCES ${spirv-tools_SOURCE_DIR}/source/mimalloc.cpp)
+endif()
+
 add_library(SPIRV-Tools-diff ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_TOOLS_DIFF_SOURCES})
+
+if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+  target_link_libraries(SPIRV-Tools-diff PRIVATE mimalloc-static)
+endif()
 
 spvtools_default_compile_options(SPIRV-Tools-diff)
 target_include_directories(SPIRV-Tools-diff
@@ -39,7 +47,13 @@ set_property(TARGET SPIRV-Tools-diff PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-diff)
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
-  install(TARGETS SPIRV-Tools-diff EXPORT SPIRV-Tools-diffTargets)
+  set(SPIRV-Tools-diff-InstallTargets SPIRV-Tools-diff)
+
+  if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+    list(APPEND SPIRV-Tools-diff-InstallTargets mimalloc-static)
+  endif()
+
+  install(TARGETS ${SPIRV-Tools-diff-InstallTargets} EXPORT SPIRV-Tools-diffTargets)
   export(EXPORT SPIRV-Tools-diffTargets FILE SPIRV-Tools-diffTargets.cmake)
 
   spvtools_config_package_dir(SPIRV-Tools-diff PACKAGE_DIR)

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -438,7 +438,15 @@ if(SPIRV_BUILD_FUZZER)
 
   spvtools_pch(SPIRV_TOOLS_FUZZ_SOURCES pch_source_fuzz)
 
+  if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+    list(APPEND SPIRV_TOOLS_DIFF_SOURCES ${spirv-tools_SOURCE_DIR}/source/mimalloc.cpp)
+  endif()
+
   add_library(SPIRV-Tools-fuzz ${SPIRV_TOOLS_FUZZ_SOURCES})
+
+  if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+    target_link_libraries(SPIRV-Tools-fuzz PRIVATE mimalloc-static)
+  endif()
 
   spvtools_default_compile_options(SPIRV-Tools-fuzz)
 
@@ -470,7 +478,13 @@ if(SPIRV_BUILD_FUZZER)
   spvtools_check_symbol_exports(SPIRV-Tools-fuzz)
 
   if(ENABLE_SPIRV_TOOLS_INSTALL)
-      install(TARGETS SPIRV-Tools-fuzz EXPORT SPIRV-Tools-fuzzTargets)
+      set(SPIRV-Tools-fuzz-InstallTargets SPIRV-Tools-fuzz)
+
+      if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+        list(APPEND SPIRV-Tools-fuzz-InstallTargets mimalloc-static)
+      endif()
+
+      install(TARGETS ${SPIRV-Tools-fuzz-InstallTargets} EXPORT SPIRV-Tools-fuzzTargets)
       export(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTarget.cmake)
 
       spvtools_config_package_dir(SPIRV-Tools-fuzz PACKAGE_DIR)

--- a/source/mimalloc.cpp
+++ b/source/mimalloc.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mimalloc-new-delete.h"

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -260,7 +260,15 @@ endif()
 
 spvtools_pch(SPIRV_TOOLS_OPT_SOURCES pch_source_opt)
 
+if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+  list(APPEND SPIRV_TOOLS_OPT_SOURCES ${spirv-tools_SOURCE_DIR}/source/mimalloc.cpp)
+endif()
+
 add_library(SPIRV-Tools-opt ${SPIRV_TOOLS_LIBRARY_TYPE} ${SPIRV_TOOLS_OPT_SOURCES})
+
+if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+  target_link_libraries(SPIRV-Tools-opt PRIVATE mimalloc-static)
+endif()
 
 spvtools_default_compile_options(SPIRV-Tools-opt)
 target_include_directories(SPIRV-Tools-opt
@@ -278,7 +286,13 @@ set_property(TARGET SPIRV-Tools-opt PROPERTY FOLDER "SPIRV-Tools libraries")
 spvtools_check_symbol_exports(SPIRV-Tools-opt)
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
-  install(TARGETS SPIRV-Tools-opt EXPORT SPIRV-Tools-optTargets)
+  set(SPIRV-Tools-opt-InstallTargets SPIRV-Tools-opt)
+
+  if (SPIRV_TOOLS_USE_MIMALLOC AND NOT SPIRV_TOOLS_BUILD_STATIC)
+    list(APPEND SPIRV-Tools-opt-InstallTargets mimalloc-static)
+  endif()
+
+  install(TARGETS ${SPIRV-Tools-opt-InstallTargets} EXPORT SPIRV-Tools-optTargets)
   export(EXPORT SPIRV-Tools-optTargets FILE SPIRV-Tools-optTargets.cmake)
 
   spvtools_config_package_dir(SPIRV-Tools-opt PACKAGE_DIR)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -24,12 +24,21 @@ add_subdirectory(emacs)
 #     LIBS   lib_target1 lib_target2
 #   )
 function(add_spvtools_tool)
+  if (SPIRV_TOOLS_USE_MIMALLOC)
+    list(APPEND SRCS mimalloc.cpp)
+  endif()
+
   set(one_value_args TARGET)
   set(multi_value_args SRCS LIBS)
   cmake_parse_arguments(
     ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
   add_executable(${ARG_TARGET} ${ARG_SRCS})
+
+  if (SPIRV_TOOLS_USE_MIMALLOC)
+    target_link_libraries(${ARG_TARGET} PRIVATE mimalloc-static)
+  endif()
+
   spvtools_default_compile_options(${ARG_TARGET})
   target_link_libraries(${ARG_TARGET} PRIVATE ${ARG_LIBS})
   target_include_directories(${ARG_TARGET} PRIVATE

--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -35,6 +35,7 @@ dependency_to_branch_map["external/effcee/"]="origin/main"
 dependency_to_branch_map["external/googletest/"]="origin/main"
 dependency_to_branch_map["external/re2/"]="origin/main"
 dependency_to_branch_map["external/spirv-headers/"]="origin/main"
+dependency_to_branch_map["external/mimalloc/"]="origin/main"
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..


### PR DESCRIPTION
This PR adds an option for SPIRV-Tools to use the mimalloc allocator to substantially improve the performance of memory allocation, especially in multithreaded operation. Because of this approach's overwhelming performance advantages in our extensive benchmarking and in production use with real world shaders, this option is enabled by default when building SPIRV-Tools as a dynamic library and when building the standalone executables (but is not enabled when building as a static library in order to avoid unexpected side effects on whatever the static libraries are statically linked to).

In profiling highly multithreaded (i.e., -j %NUMBER_OF_PROCESSORS%) compilation/optimization of complex, real world game shader corpora including some with total compile times in the tens of hours, we found that approximately 30% of the total time was being spent waiting on locks in malloc/free calls from SPIRV-Tools-opt. This in turn led to concerningly low CPU utilization and artificially lengthened compile times beyond what would be reasonable to expect based on comparison with other shader compilation toolchains.

In considering possible solutions, we found that the Vulkan validation layer had encountered similar issues with SPIRV-Tools in the past and had success in using mimalloc to remedy them (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5083).

By following VVL's lead and modifying our shader compiler's (dynamic) SPIRV-Tools-opt library to use mimalloc, we were able to reduce total compilation time of representative workloads by approximately 40%, and achieve close to 100% CPU utilization for the entire duration of compilation. It should be noted that in our environment glslang and SPIRV-Tools-opt are each used as independent dynamic libraries, so using mimalloc in SPIRV-Tools-opt has no direct impact on the behavior or performance of glslang.

The following is a comparison of total wall clock shader compilation time (including both GLSL compilation using glslang and optimization using SPIRV-Tools-opt) of variously sized subsets of a typical real world workload using the default MSVCRT malloc implementation versus using mimalloc.

| Allocator | # Shaders | Time     | # Threads |
|-----------|-----------|----------|-----------|
| default   | 35000     | 3 h 37 m | 32        |
| mimalloc  | 35000     | 1 h 55 m | 32        |
| default   | 3400      | 677 s    | 32        |
| mimalloc  | 3400      | 414 s    | 32        |
| default   | 1700      | 358 s    | 32        |
| mimalloc  | 1700      | 225 s    | 32        |
| default   | 170       | 235 s    | 1         |
| mimalloc  | 170       | 189 s    | 1         |

The first column indicates which malloc implementation is used. The second column indicates the size of the subset of shader variations compiled. The third column indicates the total elapsed wall clock time to compile the specified number of shaders. The times listed are averages of multiple trials. The final column indicates the number of threads used for concurrent compilation (note that the CPU used for testing had 32 logical cores).

In the most representative sample (35,000 variations using all 32 cores), compilation was 1.5 hours (~40%) faster using mimalloc as compared to using the default malloc implementation. There was a similar effect in smaller sample sizes, demonstrating that the performance benefit of using mimalloc is roughly consistent regardless of the number of shaders compiled.

The performance of single threaded compilation was also tested and likewise demonstrated significant advantages to using mimalloc (with a roughly 25% decrease in compilation time).

The following graph shows the results of optimizing 400 shader variations with the default performance recipe (-O) using the standalone spirv-opt executable as is, versus modified to use mimalloc.

![mimalloc](https://github.com/user-attachments/assets/19dcddd2-6bf0-475c-8ae9-c48e228c9690)

The shader variations used fell broadly into three categories: some that optimized almost instantly, some that took around a quarter of a second to optimize, and some that took around two seconds to optimize.

On average, the standalone spirv-opt executable with mimalloc was found to be 25% faster than when using the default malloc implementation. None of the variations with optimization times above the noise were slower to optimize with mimalloc than without. We also observed less variance in optimization time between runs when using mimalloc compared to using the default allocator.

CPU utilization and memory usage were not formally measured, however informal observation showed that the CPU was fully saturated when using mimalloc, and that total memory usage increased slightly (but not meaningfully) -- because the CPU was substantially busier.

While this change was originally motivated by improving the performance SPIRV-Tools-opt specifically, this PR also adds mimalloc support to the rest of SPIRV-Tools including both the dynamic versions of the libraries and the standalone executables since they all stand to benefit similarly from these improvements.

As an alternative to using a canned solution like mimalloc, it would also be possible to follow glslang's lead and implement a bespoke allocator to achieve similar (or perhaps even greater) performance benefits. This kind of approach has been previously suggested as a solution to this class of problems in https://github.com/KhronosGroup/SPIRV-Tools/issues/1947.

A bespoke allocator would have the advantage of being able to realize the same performance improvements in the static versions of the libraries as it would avoid the need to override the general purpose allocation functions (malloc, free, operator new/delete) and would therefore be safe for static linking into other programs. However, this would require the consistent use of custom allocators in all usages of STL containers and operator new/delete in SPIRV-Tools and would therefore constitute a large and invasive change.

Additionally, developing a custom allocator would take considerably more time and effort and may pose unknown additional risks further downstream in the ecosystem. In comparison, mimalloc is a widely trusted and actively maintained general purpose allocator with a strong track record of existing usage in a broad range of applications, and has already been battle tested in conjunction with SPIRV-Tools by VVL.

We believe that regardless of any further improvements that may be possible in the future that the solution in this PR constitutes a worthwhile improvement in its own right.

Since mimalloc is only used when building the dynamic library and in standalone executables and since its entry points are not exported, users can treat it as an internal implementation detail and it can always be removed or replaced in the future if/when a better solution becomes available.