### PR TITLE
spirv-val: add positive test for FP8 cooperative matrices

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': 'c84a140c93352cdabbfb547c531be34515b12228',
 
-  'spirv_headers_revision': 'fd96661925488574fe247a779babe5d380b63635',
+  'spirv_headers_revision': '3b9447dc98371e96b59a6225bd062a9867e1d203',
 }
 
 deps = {

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -400,6 +400,21 @@ TEST_F(ValidateData, cooperative_matrix_bfloat16_good) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateData, cooperative_matrix_float8_good) {
+  std::string str = header_with_float8 + R"(
+%u32 = OpTypeInt 32 0
+%u32_16 = OpConstant %u32 16
+%useA = OpConstant %u32 0
+%subgroup = OpConstant %u32 3
+%fp8e4m3 = OpTypeFloat 8 Float8E4M3EXT
+%fp8e5m2 = OpTypeFloat 8 Float8E5M2EXT
+%fp8e4m3_matA = OpTypeCooperativeMatrixKHR %fp8e4m3 %subgroup %u32_16 %u32_16 %useA
+%fp8e5m2_matA = OpTypeCooperativeMatrixKHR %fp8e5m2 %subgroup %u32_16 %u32_16 %useA
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateData, cooperative_matrix_float8_no_capability_bad) {
   std::string str = header_with_float8_no_coop_matrix + R"(
 %u32 = OpTypeInt 32 0


### PR DESCRIPTION
The headers need updating to pick up
https://github.com/KhronosGroup/SPIRV-Headers/pull/519 which this test uncovered as an issue.

Change-Id: I79c292db6d2fbff6e31a7ccc9dfd4d65f4f49ab2