### PR TITLE
spirv-val: Label maintenance9 new VUID

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -771,6 +771,7 @@ SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowOffsetTextureOperand(
     spv_validator_options options, bool val);
 
 // Allow base operands of some bit operations to be non-32-bit wide.
+// Was added for VK_KHR_maintenance9
 SPIRV_TOOLS_EXPORT void spvValidatorOptionsSetAllowVulkan32BitBitwise(
     spv_validator_options options, bool val);
 

--- a/include/spirv-tools/libspirv.hpp
+++ b/include/spirv-tools/libspirv.hpp
@@ -133,6 +133,7 @@ class SPIRV_TOOLS_EXPORT ValidatorOptions {
   }
 
   // Allow base operands of some bit operations to be non-32-bit wide.
+  // Was added for VK_KHR_maintenance9
   void SetAllowVulkan32BitBitwise(bool val) {
     spvValidatorOptionsSetAllowVulkan32BitBitwise(options_, val);
   }

--- a/source/val/validate_bitwise.cpp
+++ b/source/val/validate_bitwise.cpp
@@ -39,9 +39,11 @@ spv_result_t ValidateBaseType(ValidationState_t& _, const Instruction* inst,
     if (_.GetBitWidth(base_type) != 32 &&
         !_.options()->allow_vulkan_32_bit_bitwise) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << _.VkErrorID(4781)
+             << _.VkErrorID(10824)
              << "Expected 32-bit int type for Base operand: "
-             << spvOpcodeString(opcode);
+             << spvOpcodeString(opcode)
+             << _.MissingFeature("maintenance9 feature",
+                                 "--allow-vulkan-32-bit-bitwise", false);
     }
   }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2493,8 +2493,6 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpImage-04777);
     case 4780:
       return VUID_WRAP(VUID-StandaloneSpirv-Result-04780);
-    case 4781:
-      return VUID_WRAP(VUID-StandaloneSpirv-Base-04781);
     case 4915:
       return VUID_WRAP(VUID-StandaloneSpirv-Location-04915);
     case 4916:
@@ -2640,6 +2638,9 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-None-10684);
     case 10685:
       return VUID_WRAP(VUID-StandaloneSpirv-None-10685);
+    case 10824:
+      // This use to be a standalone, but maintenance9 will set allow_vulkan_32_bit_bitwise now
+      return VUID_WRAP(VUID-RuntimeSpirv-None-10824);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_bitwise_test.cpp
+++ b/test/val/val_bitwise_test.cpp
@@ -420,8 +420,7 @@ TEST_F(ValidateBitwise, OpBitFieldInsertNot32Vulkan) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Base-04781"));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-RuntimeSpirv-None-10824"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Expected 32-bit int type for Base operand: BitFieldInsert"));
@@ -514,8 +513,7 @@ TEST_F(ValidateBitwise, OpBitFieldSExtractNot32Vulkan) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Base-04781"));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-RuntimeSpirv-None-10824"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Expected 32-bit int type for Base operand: BitFieldSExtract"));
@@ -572,8 +570,7 @@ TEST_F(ValidateBitwise, OpBitReverseNot32Vulkan) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Base-04781"));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-RuntimeSpirv-None-10824"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Expected 32-bit int type for Base operand: BitReverse"));
@@ -645,8 +642,7 @@ TEST_F(ValidateBitwise, OpBitCountNot32Vulkan) {
 
   CompileSuccessfully(GenerateShaderCode(body).c_str(), SPV_ENV_VULKAN_1_0);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
-  EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-Base-04781"));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-RuntimeSpirv-None-10824"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Expected 32-bit int type for Base operand: BitCount"));
 }


### PR DESCRIPTION
The 1.4.317 spec released `VK_KHR_maintenance9` and the main thing is the one standalone VUID was moved to a runtime VUID which we decided to gate with `--allow-vulkan-32-bit-bitwise`