### PR TITLE
opt: Allow ADCE to kill DebugDeclare

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -44,6 +44,9 @@ constexpr uint32_t kExtInstSetInIdx = 0;
 constexpr uint32_t kExtInstOpInIdx = 1;
 constexpr uint32_t kInterpolantInIdx = 2;
 constexpr uint32_t kCooperativeMatrixLoadSourceAddrInIdx = 0;
+constexpr uint32_t kDebugValueLocalVariable = 2;
+constexpr uint32_t kDebugValueValue = 3;
+constexpr uint32_t kDebugValueExpression = 4;
 
 // Sorting functor to present annotation instructions in an easy-to-process
 // order. The functor orders by opcode first and falls back on unique id
@@ -277,7 +280,51 @@ bool AggressiveDCEPass::AggressiveDCE(Function* func) {
   live_local_vars_.clear();
   InitializeWorkList(func, structured_order);
   ProcessWorkList(func);
+  ProcessDebugInformation(structured_order);
+  ProcessWorkList(func);
   return KillDeadInstructions(func, structured_order);
+}
+
+void AggressiveDCEPass::ProcessDebugInformation(
+    std::list<BasicBlock*>& structured_order) {
+  for (auto bi = structured_order.begin(); bi != structured_order.end(); bi++) {
+    (*bi)->ForEachInst([this](Instruction* inst) {
+      // DebugDeclare is not dead. It must be converted to DebugValue in a
+      // later pass
+      if (inst->IsNonSemanticInstruction() &&
+          inst->GetShader100DebugOpcode() ==
+              NonSemanticShaderDebugInfo100DebugDeclare) {
+        AddToWorklist(inst);
+        return;
+      }
+
+      // If the Value of a DebugValue is killed, set Value operand to Undef
+      if (inst->IsNonSemanticInstruction() &&
+          inst->GetShader100DebugOpcode() ==
+              NonSemanticShaderDebugInfo100DebugValue) {
+        uint32_t id = inst->GetSingleWordInOperand(kDebugValueValue);
+        auto def = get_def_use_mgr()->GetDef(id);
+        if (!live_insts_.Set(def->unique_id())) {
+          AddToWorklist(inst);
+          context()->get_def_use_mgr()->UpdateDefUse(inst);
+          worklist_.push(def);
+          def->SetOpcode(spv::Op::OpUndef);
+          def->SetInOperands({});
+          id = inst->GetSingleWordInOperand(kDebugValueLocalVariable);
+          auto localVar = get_def_use_mgr()->GetDef(id);
+          AddToWorklist(localVar);
+          context()->get_def_use_mgr()->UpdateDefUse(localVar);
+          AddOperandsToWorkList(localVar);
+          context()->get_def_use_mgr()->UpdateDefUse(def);
+          id = inst->GetSingleWordInOperand(kDebugValueExpression);
+          auto expression = get_def_use_mgr()->GetDef(id);
+          AddToWorklist(expression);
+          context()->get_def_use_mgr()->UpdateDefUse(expression);
+          return;
+        }
+      }
+    });
+  }
 }
 
 bool AggressiveDCEPass::KillDeadInstructions(

--- a/source/opt/aggressive_dead_code_elim_pass.h
+++ b/source/opt/aggressive_dead_code_elim_pass.h
@@ -150,6 +150,12 @@ class AggressiveDCEPass : public MemPass {
   // will be empty at the end.
   void ProcessWorkList(Function* func);
 
+  // Process each DebugDeclare and DebugValue in |func| that has not been
+  // marked as live in the work list. DebugDeclare's are marked live now, and
+  // DebugValue Value operands are set to OpUndef.  The work list will be empty
+  // at the end.
+  void ProcessDebugInformation(std::list<BasicBlock*>& structured_order);
+
   // Kills any instructions in |func| that have not been marked as live.
   bool KillDeadInstructions(const Function* func,
                             std::list<BasicBlock*>& structured_order);

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -1035,6 +1035,12 @@ bool Instruction::IsOpcodeSafeToDelete() const {
     return true;
   }
 
+  if (IsNonSemanticInstruction() &&
+      (GetShader100DebugOpcode() == NonSemanticShaderDebugInfo100DebugDeclare ||
+       GetShader100DebugOpcode() == NonSemanticShaderDebugInfo100DebugValue)) {
+    return true;
+  }
+
   switch (opcode()) {
     case spv::Op::OpDPdx:
     case spv::Op::OpDPdy:

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -6757,79 +6757,78 @@ TEST_F(AggressiveDCETest, ShaderDebugInfoKeepInFunctionElimStoreVar) {
    %g_sAniso = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
 %in_var_TEXCOORD2 = OpVariable %_ptr_Input_v2float Input
 %out_var_SV_Target0 = OpVariable %_ptr_Output_v4float Output
-         %51 = OpExtInst %void %1 DebugInfoNone
-         %52 = OpExtInst %void %1 DebugExpression
-         %53 = OpExtInst %void %1 DebugOperation %uint_0
-         %54 = OpExtInst %void %1 DebugExpression %53
-         %55 = OpExtInst %void %1 DebugSource %7
-         %56 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %55 %uint_5
-         %59 = OpExtInst %void %1 DebugTypeBasic %9 %uint_32 %uint_3 %uint_0
-         %60 = OpExtInst %void %1 DebugTypeVector %59 %uint_4
-         %58 = OpExtInst %void %1 DebugTypeMember %10 %60 %55 %uint_12 %uint_5 %uint_0 %uint_128 %uint_3
-         %57 = OpExtInst %void %1 DebugTypeComposite %8 %uint_1 %55 %uint_10 %uint_1 %56 %8 %uint_128 %uint_3 %58
-         %63 = OpExtInst %void %1 DebugTypeVector %59 %uint_2
-         %62 = OpExtInst %void %1 DebugTypeMember %12 %63 %55 %uint_7 %uint_5 %uint_0 %uint_64 %uint_3
-         %61 = OpExtInst %void %1 DebugTypeComposite %11 %uint_1 %55 %uint_5 %uint_1 %56 %11 %uint_64 %uint_3 %62
-         %64 = OpExtInst %void %1 DebugTypeComposite %13 %uint_0 %55 %uint_0 %uint_0 %56 %14 %51 %uint_3
-         %67 = OpExtInst %void %1 DebugTypeFunction %uint_3 %57 %61
-         %68 = OpExtInst %void %1 DebugFunction %16 %67 %55 %uint_15 %uint_1 %56 %16 %uint_3 %uint_16
-         %69 = OpExtInst %void %1 DebugLexicalBlock %55 %uint_16 %uint_1 %68
-         %70 = OpExtInst %void %1 DebugLocalVariable %17 %63 %55 %uint_19 %uint_12 %69 %uint_4
-         %71 = OpExtInst %void %1 DebugLocalVariable %18 %57 %55 %uint_17 %uint_15 %69 %uint_4
-         %72 = OpExtInst %void %1 DebugLocalVariable %19 %61 %55 %uint_15 %uint_29 %68 %uint_4 %uint_1
-         %73 = OpExtInst %void %1 DebugTypeComposite %20 %uint_1 %55 %uint_0 %uint_0 %56 %21 %51 %uint_3
-         %74 = OpExtInst %void %1 DebugGlobalVariable %22 %73 %55 %uint_3 %uint_14 %56 %22 %g_sAniso %uint_8
-         %75 = OpExtInst %void %1 DebugGlobalVariable %23 %64 %55 %uint_1 %uint_11 %56 %23 %g_tColor %uint_8
+         %75 = OpExtInst %void %1 DebugInfoNone
+         %76 = OpExtInst %void %1 DebugExpression
+         %77 = OpExtInst %void %1 DebugOperation %uint_0
+         %78 = OpExtInst %void %1 DebugExpression %77
+         %79 = OpExtInst %void %1 DebugSource %7
+         %80 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %79 %uint_5
+         %81 = OpExtInst %void %1 DebugTypeBasic %9 %uint_32 %uint_3 %uint_0
+         %82 = OpExtInst %void %1 DebugTypeVector %81 %uint_4
+         %83 = OpExtInst %void %1 DebugTypeMember %10 %82 %79 %uint_12 %uint_5 %uint_0 %uint_128 %uint_3
+         %84 = OpExtInst %void %1 DebugTypeComposite %8 %uint_1 %79 %uint_10 %uint_1 %80 %8 %uint_128 %uint_3 %83
+         %85 = OpExtInst %void %1 DebugTypeVector %81 %uint_2
+         %86 = OpExtInst %void %1 DebugTypeMember %12 %85 %79 %uint_7 %uint_5 %uint_0 %uint_64 %uint_3
+         %87 = OpExtInst %void %1 DebugTypeComposite %11 %uint_1 %79 %uint_5 %uint_1 %80 %11 %uint_64 %uint_3 %86
+         %88 = OpExtInst %void %1 DebugTypeComposite %13 %uint_0 %79 %uint_0 %uint_0 %80 %14 %75 %uint_3
+         %89 = OpExtInst %void %1 DebugTypeFunction %uint_3 %84 %87
+         %90 = OpExtInst %void %1 DebugFunction %16 %89 %79 %uint_15 %uint_1 %80 %16 %uint_3 %uint_16
+         %91 = OpExtInst %void %1 DebugLexicalBlock %79 %uint_16 %uint_1 %90
+         %92 = OpExtInst %void %1 DebugLocalVariable %17 %85 %79 %uint_19 %uint_12 %91 %uint_4
+         %93 = OpExtInst %void %1 DebugLocalVariable %18 %84 %79 %uint_17 %uint_15 %91 %uint_4
+         %94 = OpExtInst %void %1 DebugLocalVariable %19 %87 %79 %uint_15 %uint_29 %90 %uint_4 %uint_1
+         %95 = OpExtInst %void %1 DebugTypeComposite %20 %uint_1 %79 %uint_0 %uint_0 %80 %21 %75 %uint_3
+         %96 = OpExtInst %void %1 DebugGlobalVariable %22 %95 %79 %uint_3 %uint_14 %80 %22 %g_sAniso %uint_8
+         %97 = OpExtInst %void %1 DebugGlobalVariable %23 %88 %79 %uint_1 %uint_11 %80 %23 %g_tColor %uint_8
      %MainPs = OpFunction %void None %45
-         %76 = OpLabel
-         %78 = OpVariable %_ptr_Function_PS_OUTPUT Function
-         %79 = OpVariable %_ptr_Function_v2float Function
-         %81 = OpVariable %_ptr_Function_PS_OUTPUT Function
+         %98 = OpLabel
+         %99 = OpVariable %_ptr_Function_PS_OUTPUT Function
+        %100 = OpVariable %_ptr_Function_v2float Function
+        %101 = OpVariable %_ptr_Function_PS_OUTPUT Function
 %param_var_i = OpVariable %_ptr_Function_PS_INPUT Function
-         %82 = OpLoad %v2float %in_var_TEXCOORD2
-         %83 = OpCompositeConstruct %PS_INPUT %82
-               OpStore %param_var_i %83
-        %112 = OpExtInst %void %1 DebugFunctionDefinition %68 %MainPs
-        %109 = OpExtInst %void %1 DebugScope %68
-         %85 = OpExtInst %void %1 DebugDeclare %72 %param_var_i %52
-        %110 = OpExtInst %void %1 DebugScope %69
-         %87 = OpExtInst %void %1 DebugDeclare %71 %78 %52
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugFunctionDefinition %68 %MainPs
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugScope %68
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %72 %param_var_i %52
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugScope %69
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %71 %78 %52
-        %300 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_17 %uint_30
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_17 %uint_30
-         %88 = OpAccessChain %_ptr_Function_v2float %param_var_i %int_0
-         %89 = OpLoad %v2float %88
-        %301 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
-               OpStore %79 %89
-;CHECK-NOT:    OpStore %79 %89
-        %302 = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %55 %uint_19 %uint_19 %uint_12 %uint_35
-        %106 = OpExtInst %void %1 DebugValue %70 %89 %52
-;CHECK: {{%\w+}} = OpExtInst %void %1 DebugValue %70 %89 %52
-        %303 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_25 %uint_32
-         %91 = OpLoad %type_2d_image %g_tColor
-        %304 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_41 %uint_48
-         %92 = OpLoad %type_sampler %g_sAniso
-        %305 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_25 %uint_53
-         %94 = OpSampledImage %type_sampled_image %91 %92
-         %95 = OpImageSampleImplicitLod %v4float %94 %89 None
-        %306 = OpExtInst %void %1 DebugLine %55 %uint_20 %uint_20 %uint_5 %uint_53
-         %96 = OpAccessChain %_ptr_Function_v4float %78 %int_0
-               OpStore %96 %95
-        %307 = OpExtInst %void %1 DebugLine %55 %uint_21 %uint_21 %uint_12 %uint_20
-         %97 = OpLoad %PS_OUTPUT %78
-        %308 = OpExtInst %void %1 DebugLine %55 %uint_21 %uint_21 %uint_5 %uint_20
-               OpStore %81 %97
-        %309 = OpExtInst %void %1 DebugNoLine
+        %102 = OpLoad %v2float %in_var_TEXCOORD2
+        %103 = OpCompositeConstruct %PS_INPUT %102
+               OpStore %param_var_i %103
+        %104 = OpExtInst %void %1 DebugFunctionDefinition %90 %MainPs
+        %142 = OpExtInst %void %1 DebugScope %90
+        %106 = OpExtInst %void %1 DebugDeclare %94 %param_var_i %76
+        %143 = OpExtInst %void %1 DebugScope %91
+        %108 = OpExtInst %void %1 DebugDeclare %93 %99 %76
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugFunctionDefinition %90 %MainPs
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugScope %90
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %94 %param_var_i %76
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugScope %91
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugDeclare %93 %99 %76
+        %109 = OpExtInst %void %1 DebugLine %79 %uint_19 %uint_19 %uint_17 %uint_30
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %79 %uint_19 %uint_19 %uint_17 %uint_30
+        %110 = OpAccessChain %_ptr_Function_v2float %param_var_i %int_0
+        %111 = OpLoad %v2float %110
+        %112 = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_25 %uint_32
+;CHECK: {{%\w+}} = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_25 %uint_32
+               OpStore %100 %111
+;CHECK-NOT:    OpStore %100 %111
+        %114 = OpExtInst %void %1 DebugValue %92 %111 %76
+;CHECK-NOT: {{%\w+}} = OpExtInst %void %1 DebugValue %92 %111 %76
+        %115 = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_25 %uint_32
+        %116 = OpLoad %type_2d_image %g_tColor
+        %117 = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_41 %uint_48
+        %118 = OpLoad %type_sampler %g_sAniso
+        %119 = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_25 %uint_53
+        %120 = OpSampledImage %type_sampled_image %116 %118
+        %121 = OpImageSampleImplicitLod %v4float %120 %111 None
+        %122 = OpExtInst %void %1 DebugLine %79 %uint_20 %uint_20 %uint_5 %uint_53
+        %123 = OpAccessChain %_ptr_Function_v4float %99 %int_0
+               OpStore %123 %121
+        %124 = OpExtInst %void %1 DebugLine %79 %uint_21 %uint_21 %uint_12 %uint_20
+        %125 = OpLoad %PS_OUTPUT %99
+        %126 = OpExtInst %void %1 DebugLine %79 %uint_21 %uint_21 %uint_5 %uint_20
+               OpStore %101 %125
+        %127 = OpExtInst %void %1 DebugNoLine
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugNoLine
-        %111 = OpExtInst %void %1 DebugNoScope
+        %144 = OpExtInst %void %1 DebugNoScope
 ;CHECK: {{%\w+}} = OpExtInst %void %1 DebugNoScope
-        %100 = OpCompositeExtract %v4float %97 0
-               OpStore %out_var_SV_Target0 %100
+        %129 = OpCompositeExtract %v4float %125 0
+               OpStore %out_var_SV_Target0 %129
                OpReturn
                OpFunctionEnd
 )";
@@ -8477,7 +8476,261 @@ TEST_F(AggressiveDCETest, KeepCopyLogical) {
   SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER);
   SinglePassRunAndMatch<AggressiveDCEPass>(before, true);
 }
+TEST_F(AggressiveDCETest, KeepOnlyLiveDebugValues) {
+  // DebugValue should only be live when Value is live.
+  const std::string before =
+      R"(OpCapability MinLod
+OpCapability StorageImageWriteWithoutFormat
+OpCapability StorageImageReadWithoutFormat
+OpCapability FragmentShaderSampleInterlockEXT
+OpCapability FragmentShaderPixelInterlockEXT
+OpCapability FragmentShaderShadingRateInterlockEXT
+OpCapability ComputeDerivativeGroupQuadsKHR
+OpCapability ComputeDerivativeGroupLinearKHR
+OpCapability RayQueryKHR
+OpCapability GroupNonUniformPartitionedNV
+OpCapability InterpolationFunction
+OpCapability QuadControlKHR
+OpCapability Shader
+OpCapability SampledBuffer
+OpCapability ImageBuffer
+OpExtension "SPV_EXT_fragment_shader_interlock"
+OpExtension "SPV_KHR_compute_shader_derivatives"
+OpExtension "SPV_KHR_ray_query"
+OpExtension "SPV_NV_shader_subgroup_partitioned"
+OpExtension "SPV_KHR_quad_control"
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%3 = OpString "partially_unused_var.cs.hlsl"
+%17 = OpString "int"
+%25 = OpString "main"
+%26 = OpString ""
+%30 = OpString "a"
+%33 = OpString "__dxc_setup"
+%35 = OpString "cb000c74"
+%36 = OpString " -E main -T cs_6_6 -spirv -fspv-print-all -fspv-debug=vulkan -Qembed_debug"
+%39 = OpString "@type.buffer.image"
+%40 = OpString "type.buffer.image"
+%42 = OpString "TemplateParam"
+%45 = OpString "b"
+OpName %type_buffer_image "type.buffer.image"
+OpName %b "b"
+OpName %main "main"
+OpDecorate %b DescriptorSet 0
+OpDecorate %b Binding 0
+%uint = OpTypeInt 32 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%int = OpTypeInt 32 1
+%uint_0 = OpConstant %uint 0
+%uint_32 = OpConstant %uint 32
+%type_buffer_image = OpTypeImage %int Buffer 2 0 0 2 R32i
+%_ptr_UniformConstant_type_buffer_image = OpTypePointer UniformConstant %type_buffer_image
+%void = OpTypeVoid
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_13 = OpConstant %uint 13
+%uint_7 = OpConstant %uint 7
+%uint_15 = OpConstant %uint 15
+%uint_8 = OpConstant %uint 8
+%49 = OpTypeFunction %void
+%_arr_int_uint_3 = OpTypeArray %int %uint_3
+%v4int = OpTypeVector %int 4
+%uint_21 = OpConstant %uint 21
+%uint_27 = OpConstant %uint 27
+%uint_14 = OpConstant %uint 14
+%uint_31 = OpConstant %uint 31
+%uint_6 = OpConstant %uint 6
+%b = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
+%int_1 = OpConstant %int 1
+%int_2 = OpConstant %int 2
+%38 = OpExtInst %void %1 DebugInfoNone
+%16 = OpExtInst %void %1 DebugExpression
+%18 = OpExtInst %void %1 DebugTypeBasic %17 %uint_32 %uint_4 %uint_0
+%20 = OpExtInst %void %1 DebugTypeArray %18 %uint_3
+%21 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%22 = OpExtInst %void %1 DebugSource %3
+%23 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %22 %uint_5
+%27 = OpExtInst %void %1 DebugFunction %25 %21 %22 %uint_4 %uint_1 %23 %26 %uint_3 %uint_4
+%28 = OpExtInst %void %1 DebugLexicalBlock %22 %uint_4 %uint_13 %27
+%31 = OpExtInst %void %1 DebugLocalVariable %30 %20 %22 %uint_5 %uint_7 %28 %uint_4
+%34 = OpExtInst %void %1 DebugFunction %33 %21 %22 %uint_4 %uint_1 %23 %26 %uint_3 %uint_4
+%41 = OpExtInst %void %1 DebugTypeComposite %39 %uint_0 %22 %uint_0 %uint_0 %23 %40 %38 %uint_3
+%43 = OpExtInst %void %1 DebugTypeTemplateParameter %42 %18 %38 %22 %uint_0 %uint_0
+%44 = OpExtInst %void %1 DebugTypeTemplate %41 %43
+%46 = OpExtInst %void %1 DebugGlobalVariable %45 %44 %22 %uint_1 %uint_15 %23 %45 %b %uint_8
+%37 = OpExtInst %void %1 DebugEntryPoint %34 %23 %35 %36
+%138 = OpExtInst %void %1 DebugInlinedAt %uint_4 %34
+%main = OpFunction %void None %49
+%50 = OpLabel
+%311 = OpExtInst %void %1 DebugScope %34
+%52 = OpExtInst %void %1 DebugFunctionDefinition %34 %main
+%312 = OpExtInst %void %1 DebugScope %28 %138
+%155 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_15 %uint_15
+%141 = OpLoad %type_buffer_image %b
+%142 = OpImageRead %v4int %141 %uint_1 None
+%143 = OpCompositeExtract %int %142 0
+; CHECK: %141 = OpLoad %type_buffer_image %b
+; CHECK: %142 = OpImageRead %v4int %141 %uint_1 None
+; CHECK: %143 = OpCompositeExtract %int %142 0
+%158 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_21 %uint_21
+%144 = OpLoad %type_buffer_image %b
+%145 = OpImageRead %v4int %144 %uint_2 None
+%146 = OpCompositeExtract %int %145 0
+; CHECK-NOT: %144 = OpLoad %type_buffer_image %b
+; CHECK-NOT: %145 = OpImageRead %v4int %144 %uint_2 None
+; CHECK-NOT: %146 = OpCompositeExtract %int %145 0
+%161 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_27 %uint_27
+%147 = OpLoad %type_buffer_image %b
+%148 = OpImageRead %v4int %147 %uint_3 None
+%149 = OpCompositeExtract %int %148 0
+; CHECK-NOT: %147 = OpLoad %type_buffer_image %b
+; CHECK-NOT: %148 = OpImageRead %v4int %147 %uint_3 None
+; CHECK-NOT: %149 = OpCompositeExtract %int %148 0
+%164 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_14 %uint_31
+%150 = OpCompositeConstruct %_arr_int_uint_3 %143 %146 %149
+; CHECK-NOT: %150 = OpCompositeConstruct %_arr_int_uint_3 %143 %146 %149
+%210 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_3 %uint_31
+%209 = OpUndef %int
+%250 = OpExtInst %void %1 DebugValue %31 %209 %16 %int_1
+%247 = OpExtInst %void %1 DebugValue %31 %209 %16 %int_2
+; CHECK-NOT: %247 = OpExtInst %void %1 DebugValue %31 %209 %16 %int_2
+%169 = OpExtInst %void %1 DebugLine %22 %uint_6 %uint_6 %uint_3 %uint_13
+%154 = OpLoad %type_buffer_image %b
+OpImageWrite %154 %uint_0 %143 None
+%313 = OpExtInst %void %1 DebugScope %34
+%55 = OpExtInst %void %1 DebugLine %22 %uint_7 %uint_7 %uint_1 %uint_1
+OpReturn
+%314 = OpExtInst %void %1 DebugNoScope
+OpFunctionEnd
+)";
 
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  SinglePassRunAndMatch<AggressiveDCEPass>(before, false);
+}
+TEST_F(AggressiveDCETest, KeepLocalDebugValue) {
+  // DebugValue should only be live when Value is live.
+  const std::string before =
+      R"(
+OpCapability MinLod
+OpCapability StorageImageWriteWithoutFormat
+OpCapability StorageImageReadWithoutFormat
+OpCapability FragmentShaderSampleInterlockEXT
+OpCapability FragmentShaderPixelInterlockEXT
+OpCapability FragmentShaderShadingRateInterlockEXT
+OpCapability ComputeDerivativeGroupQuadsKHR
+OpCapability ComputeDerivativeGroupLinearKHR
+OpCapability RayQueryKHR
+OpCapability GroupNonUniformPartitionedNV
+OpCapability InterpolationFunction
+OpCapability QuadControlKHR
+OpCapability Shader
+OpCapability SampledBuffer
+OpCapability ImageBuffer
+OpExtension "SPV_EXT_fragment_shader_interlock"
+OpExtension "SPV_KHR_compute_shader_derivatives"
+OpExtension "SPV_KHR_ray_query"
+OpExtension "SPV_NV_shader_subgroup_partitioned"
+OpExtension "SPV_KHR_quad_control"
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%3 = OpString "partially_unused_var2.cs.hlsl"
+%17 = OpString "int"
+%25 = OpString "main"
+%26 = OpString ""
+%30 = OpString "some_real_obvious_name"
+%33 = OpString "__dxc_setup"
+%35 = OpString "cb000c74"
+%36 = OpString " -E main -T cs_6_6 -spirv -fspv-print-all -fspv-debug=vulkan -Qembed_debug"
+%39 = OpString "@type.buffer.image"
+%40 = OpString "type.buffer.image"
+%42 = OpString "TemplateParam"
+%45 = OpString "b"
+OpName %type_buffer_image "type.buffer.image"
+OpName %b "b"
+OpName %main "main"
+OpDecorate %b DescriptorSet 0
+OpDecorate %b Binding 0
+%uint = OpTypeInt 32 0
+%uint_1 = OpConstant %uint 1
+%uint_3 = OpConstant %uint 3
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint_0 = OpConstant %uint 0
+%uint_32 = OpConstant %uint 32
+%type_buffer_image = OpTypeImage %int Buffer 2 0 0 2 R32i
+%_ptr_UniformConstant_type_buffer_image = OpTypePointer UniformConstant %type_buffer_image
+%void = OpTypeVoid
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_13 = OpConstant %uint 13
+%uint_7 = OpConstant %uint 7
+%uint_15 = OpConstant %uint 15
+%uint_8 = OpConstant %uint 8
+%49 = OpTypeFunction %void
+%uint_52 = OpConstant %uint 52
+%uint_6 = OpConstant %uint 6
+%uint_10 = OpConstant %uint 10
+%b = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
+%int_1 = OpConstant %int 1
+%int_2 = OpConstant %int 2
+%38 = OpExtInst %void %1 DebugInfoNone
+%16 = OpExtInst %void %1 DebugExpression
+%18 = OpExtInst %void %1 DebugTypeBasic %17 %uint_32 %uint_4 %uint_0
+%20 = OpExtInst %void %1 DebugTypeArray %18 %uint_3
+%21 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%22 = OpExtInst %void %1 DebugSource %3
+%23 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %22 %uint_5
+%27 = OpExtInst %void %1 DebugFunction %25 %21 %22 %uint_4 %uint_1 %23 %26 %uint_3 %uint_4
+%28 = OpExtInst %void %1 DebugLexicalBlock %22 %uint_4 %uint_13 %27
+%31 = OpExtInst %void %1 DebugLocalVariable %30 %20 %22 %uint_5 %uint_7 %28 %uint_4
+; CHECK: %31 = OpExtInst %void %1 DebugLocalVariable %30 %20 %22 %uint_5 %uint_7 %28 %uint_4
+%34 = OpExtInst %void %1 DebugFunction %33 %21 %22 %uint_4 %uint_1 %23 %26 %uint_3 %uint_4
+%41 = OpExtInst %void %1 DebugTypeComposite %39 %uint_0 %22 %uint_0 %uint_0 %23 %40 %38 %uint_3
+%43 = OpExtInst %void %1 DebugTypeTemplateParameter %42 %18 %38 %22 %uint_0 %uint_0
+%44 = OpExtInst %void %1 DebugTypeTemplate %41 %43
+%46 = OpExtInst %void %1 DebugGlobalVariable %45 %44 %22 %uint_1 %uint_15 %23 %45 %b %uint_8
+%37 = OpExtInst %void %1 DebugEntryPoint %34 %23 %35 %36
+%133 = OpExtInst %void %1 DebugInlinedAt %uint_4 %34
+%main = OpFunction %void None %49
+%50 = OpLabel
+%303 = OpExtInst %void %1 DebugScope %34
+%52 = OpExtInst %void %1 DebugFunctionDefinition %34 %main
+%304 = OpExtInst %void %1 DebugScope %28 %133
+%199 = OpExtInst %void %1 DebugLine %22 %uint_5 %uint_5 %uint_3 %uint_52
+%198 = OpUndef %int
+%245 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_0
+%242 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_1
+%239 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_2
+; CHECK: %245 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_0
+; CHECK-NOT: %242 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_1
+; CHECK-NOT: %239 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_2
+%160 = OpExtInst %void %1 DebugLine %22 %uint_6 %uint_6 %uint_3 %uint_10
+%147 = OpLoad %type_buffer_image %b
+OpImageWrite %147 %uint_0 %int_0 None
+%305 = OpExtInst %void %1 DebugScope %34
+%55 = OpExtInst %void %1 DebugLine %22 %uint_7 %uint_7 %uint_1 %uint_1
+OpReturn
+%306 = OpExtInst %void %1 DebugNoScope
+OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_6);
+  SetAssembleOptions(SPV_TEXT_TO_BINARY_OPTION_PRESERVE_NUMERIC_IDS);
+  SetDisassembleOptions(SPV_BINARY_TO_TEXT_OPTION_NO_HEADER |
+                        SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  SinglePassRunAndMatch<AggressiveDCEPass>(before, false);
+}
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
The spirv-opt ADCE pass currently does not mark NS100 DebugDeclare instructions as safe to delete.  A cursory review of ADCE results when NS100 is enabled shows that virtually no dead code is ever eliminated.  This is because DebugDeclare instructions are placed in the worklist during initialization.  When the worklist is processed, every operand referenced by all the DebugDeclares are then marked live as well.  So no blocks with a DebugDeclare can be eliminated.  This PR simply marks DebugDeclare as "safe to delete" at worklist initialization.  DebugDeclare's which should remain are still found when a live OpStore referencing them is processed on the worklist.  This change allows ADCE results when NS100 is enabled to approximate other levels of debug info, or no debug info.