### PR TITLE
Keep instructions used by the DebugBuildIdentifier

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -916,8 +916,17 @@ bool AggressiveDCEPass::ProcessGlobalValues() {
     }
     // Save debug build identifier even if no other instructions refer to it.
     if (dbg.GetShader100DebugOpcode() ==
-        NonSemanticShaderDebugInfo100DebugBuildIdentifier)
+        NonSemanticShaderDebugInfo100DebugBuildIdentifier) {
+      // The debug build identifier refers to other instructions that
+      // can potentially be removed, they also need to be kept alive.
+      dbg.ForEachInId([this](const uint32_t* id) {
+          Instruction* ref_inst = get_def_use_mgr()->GetDef(*id);
+          if (ref_inst) {
+              live_insts_.Set(ref_inst->unique_id());
+          }
+      });
       continue;
+    }
     to_kill_.push_back(&dbg);
     modified = true;
   }


### PR DESCRIPTION
Update DCE to keep instructions referred to by the DebugBuildIdentifier and update the test to verify these are present in the output SPIR-V.