### PR TITLE
spirv-opt: Fix crash if shader uses linkage decoration

### DIFF
--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -1067,7 +1067,11 @@ void TypeManager::AttachDecoration(const Instruction& inst, Type* type) {
       const auto count = inst.NumOperands();
       std::vector<uint32_t> data;
       for (uint32_t i = 1; i < count; ++i) {
-        data.push_back(inst.GetSingleWordOperand(i));
+        // LinkageAttributes has a literal string as an operand, which is a
+        // varible length word. We cannot assume that all operands are single
+        // word.
+        const Operand::OperandData& words = inst.GetOperand(i).words;
+        data.insert(data.end(), words.begin(), words.end());
       }
       type->AddDecoration(std::move(data));
     } break;


### PR DESCRIPTION
As for some optimization pass, which will get all operands of decoration and add these to type. We assume that these operands are always one word. As for linkage attributes decoration, it's an error because one of operand is literal string, that means that operand is variable length word.