### PR TITLE
ssa-rewrite performance improvements

### DIFF
--- a/source/opt/basic_block.h
+++ b/source/opt/basic_block.h
@@ -231,6 +231,12 @@ class BasicBlock {
   // debuggers.
   void Dump() const;
 
+  // Return the user data for this basic block.
+  void* GetUserData() { return user_data_; }
+
+  // Set the user data for this basic block.
+  void SetUserData(void* data) { user_data_ = data; }
+
  private:
   // The enclosing function.
   Function* function_;
@@ -238,13 +244,15 @@ class BasicBlock {
   std::unique_ptr<Instruction> label_;
   // Instructions inside this basic block, but not the OpLabel.
   InstructionList insts_;
+  // User data pointer, lifetime is managed by the user.
+  void* user_data_;
 };
 
 // Pretty-prints |block| to |str|. Returns |str|.
 std::ostream& operator<<(std::ostream& str, const BasicBlock& block);
 
 inline BasicBlock::BasicBlock(std::unique_ptr<Instruction> label)
-    : function_(nullptr), label_(std::move(label)) {}
+    : function_(nullptr), label_(std::move(label)), user_data_(nullptr) {}
 
 inline void BasicBlock::AddInstruction(std::unique_ptr<Instruction> i) {
   insts_.push_back(std::move(i));

--- a/source/opt/function.h
+++ b/source/opt/function.h
@@ -124,6 +124,7 @@ class Function {
   BasicBlock* tail() { return blocks_.back().get(); }
   const BasicBlock* tail() const { return blocks_.back().get(); }
 
+  size_t size() const { return blocks_.size(); }
   iterator begin() { return iterator(&blocks_, blocks_.begin()); }
   iterator end() { return iterator(&blocks_, blocks_.end()); }
   const_iterator begin() const { return cbegin(); }
@@ -174,6 +175,11 @@ class Function {
   // header in order.
   void ForEachDebugInstructionsInHeader(
       const std::function<void(Instruction*)>& f);
+
+  BasicBlock* GetBlock(unsigned int i) {
+    if (i < blocks_.size()) return blocks_[i].get();
+    return nullptr;
+  }
 
   BasicBlock* InsertBasicBlockAfter(std::unique_ptr<BasicBlock>&& new_block,
                                     BasicBlock* position);


### PR DESCRIPTION
This PR addresses a pair of high-impact performance issues in the hot path of the SSARewrite pass. Together, these improvements achieve an 8-20% (typically ~15%) reduction in the runtime of the default performance recipe (-O) on a variety of real-world game shaders.

While working to understand and optimize the performance of SPIRV-Tools-opt, we observed that a consistently but unexpectedly high fraction of total optimization time was being spent in functions implementing hash table based data structures used by the SSARewrite pass.

To address these issues, this PR adds the ability to assign arbitrary user data to BasicBlocks and takes advantage of this functionality to reduce indirection and improve the performance of the SSARewrite pass. Several other passes also stand to benefit from similar optimizations enabled by leveraging this new BasicBlock user data, though in those passes the impact is less significant as compared to SSARewrite.

One earlier iteration of these changes attempted to optimize SSARewrite in a more self-contained manner, by only using more efficient data structures that didn't require any changes to BasicBlock. However, that approach achieved almost no performance benefit over the baseline as compared to the approach ultimately taken in this PR.

The following graph shows the execution time for optimizing 400 shader variations from a complex, real-world application with the default performance recipe (-O) before and after these changes. These shaders variations generally fell into two categories: those that were trivially optimizable (i.e. most of the shader was already being removed by other passes earlier in the optimization pipeline), and those which were non-trivial and originally took around 1.75 seconds each to optimize in our test environment.

![optimize-ssa-rewrite](https://github.com/user-attachments/assets/368a1a4f-3df4-443d-b243-2ee77ca2b84b)

These changes focused on just a small part of just a single pass in the default recipe, yet they achieved a roughly 15% reduction in compile time for the non-trivial shader variations.

In the future, it may be beneficial to also add user data to other IR constructs, such as Function or Instruction, however it remains to be seen if such functionality would be useful. For example, Instruction user data could possibly be more efficiently stored as a list inside BasicBlock.