### PR TITLE
spirv-val: Add PrimitiveID check

### DIFF
--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -2383,6 +2383,19 @@ spv_result_t BuiltInsValidator::ValidatePrimitiveIdAtReference(
           referenced_from_inst, std::placeholders::_1));
     }
 
+    if (!_.HasCapability(spv::Capability::MeshShadingEXT) &&
+        !_.HasCapability(spv::Capability::MeshShadingNV) &&
+        !_.HasCapability(spv::Capability::Geometry) &&
+        !_.HasCapability(spv::Capability::Tessellation)) {
+      id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
+          &BuiltInsValidator::ValidateNotCalledWithExecutionModel, this, 4333,
+          "Vulkan spec doesn't allow BuiltIn PrimitiveId to be used for "
+          "variables in the Fragment execution model unless it declares "
+          "Geometry, Tessellation, or MeshShader capabilities.",
+          spv::ExecutionModel::Fragment, decoration, built_in_inst,
+          referenced_from_inst, std::placeholders::_1));
+    }
+
     for (const spv::ExecutionModel execution_model : execution_models_) {
       switch (execution_model) {
         case spv::ExecutionModel::Fragment:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2219,6 +2219,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-Position-Position-04321);
     case 4330:
       return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04330);
+    case 4333:
+      return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04333);
     case 4334:
       return VUID_WRAP(VUID-PrimitiveId-PrimitiveId-04334);
     case 4336:


### PR DESCRIPTION
@alan-baker while looking into `PrimitiveID`, I realize `VUID-PrimitiveId-PrimitiveId-04333` is missing, it is hard to hit, but rather have it complete