### PR TITLE
Add validation for SPV_INTEL_inline_assembly

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -144,6 +144,8 @@ int32_t spvOpcodeIsConstant(const spv::Op opcode) {
     case spv::Op::OpSpecConstantCompositeReplicateEXT:
     case spv::Op::OpSpecConstantOp:
     case spv::Op::OpSpecConstantStringAMDX:
+    case spv::Op::OpAsmTargetINTEL:
+    case spv::Op::OpAsmINTEL:
       return true;
     default:
       return false;

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -122,6 +122,7 @@ bool InstructionCanHaveTypeOperand(const Instruction* inst) {
       spv::Op::OpCooperativeMatrixLengthKHR,
       spv::Op::OpUntypedArrayLengthKHR,
       spv::Op::OpFunction,
+      spv::Op::OpAsmINTEL,
   };
   const auto opcode = inst->opcode();
   bool type_instruction = spvOpcodeGeneratesType(opcode);
@@ -149,6 +150,7 @@ bool InstructionRequiresTypeOperand(const Instruction* inst) {
       spv::Op::OpCooperativeMatrixLengthKHR,
       spv::Op::OpPhi,
       spv::Op::OpUntypedArrayLengthKHR,
+      spv::Op::OpAsmINTEL,
   };
   const auto opcode = inst->opcode();
   bool debug_instruction = spvOpcodeIsDebug(opcode) || inst->IsDebugInfo();

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -433,10 +433,9 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
              << "Structure <id> " << _.getIdName(member_type_id)
              << " contains members with BuiltIn decoration. Therefore this "
              << "structure may not be contained as a member of another "
-             << "structure "
-             << "type. Structure <id> " << _.getIdName(struct_id)
-             << " contains structure <id> " << _.getIdName(member_type_id)
-             << ".";
+             << "structure " << "type. Structure <id> "
+             << _.getIdName(struct_id) << " contains structure <id> "
+             << _.getIdName(member_type_id) << ".";
     }
 
     if (spvIsVulkanEnv(_.context()->target_env) &&
@@ -617,6 +616,7 @@ spv_result_t ValidateTypeFunction(ValidationState_t& _,
   for (auto& pair : inst->uses()) {
     const auto* use = pair.first;
     if (use->opcode() != spv::Op::OpFunction &&
+        use->opcode() != spv::Op::OpAsmINTEL &&
         !spvOpcodeIsDebug(use->opcode()) && !use->IsNonSemantic() &&
         !spvOpcodeIsDecoration(use->opcode())) {
       return _.diag(SPV_ERROR_INVALID_ID, use)

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -48,6 +48,7 @@ add_spvtools_unittest(TARGET val_abcde
        val_extension_spv_khr_terminate_invocation_test.cpp
        val_extension_spv_khr_subgroup_rotate_test.cpp
        val_extension_spv_nv_raw_access_chains.cpp
+       val_extension_spv_intel_inline_assembly.cpp
        val_ext_inst_test.cpp
        val_ext_inst_debug_test.cpp
        ${VAL_TEST_COMMON_SRCS}

--- a/test/val/val_extension_spv_intel_inline_assembly.cpp
+++ b/test/val/val_extension_spv_intel_inline_assembly.cpp
@@ -1,0 +1,109 @@
+// Copyright 2025 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for SPV_INTEL_inline_assembly
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "test/val/val_fixtures.h"
+
+namespace spvtools {
+namespace val {
+namespace {
+
+using ::testing::HasSubstr;
+
+using ValidateSpvINTELInlineAssembly = spvtest::ValidateBase<bool>;
+
+TEST_F(ValidateSpvINTELInlineAssembly, Valid) {
+  const std::string str = R"(
+         OpCapability Kernel
+         OpCapability Addresses
+         OpCapability Linkage
+         OpCapability AsmINTEL
+         OpExtension "SPV_INTEL_inline_assembly"
+         OpMemoryModel Physical32 OpenCL
+         OpDecorate %1 SideEffectsINTEL
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+    %4 = OpAsmTargetINTEL "spirv64-unknown-unknown"
+    %1 = OpAsmINTEL %2 %3 %4 "nop" ""
+    %5 = OpFunction %2 None %3
+    %6 = OpLabel
+    %7 = OpAsmCallINTEL %2 %1
+         OpReturn
+         OpFunctionEnd
+  )";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateSpvINTELInlineAssembly, RequiresExtension) {
+  const std::string str = R"(
+         OpCapability Kernel
+         OpCapability Addresses
+         OpCapability Linkage
+         OpCapability AsmINTEL
+         OpMemoryModel Physical32 OpenCL
+         OpDecorate %1 SideEffectsINTEL
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+    %4 = OpAsmTargetINTEL "spirv64-unknown-unknown"
+    %1 = OpAsmINTEL %2 %3 %4 "nop" ""
+    %5 = OpFunction %2 None %3
+    %6 = OpLabel
+    %7 = OpAsmCallINTEL %2 %1
+         OpReturn
+         OpFunctionEnd
+  )";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  const std::string diag = getDiagnosticString();
+  EXPECT_THAT(
+      diag,
+      HasSubstr("1st operand of Capability: operand AsmINTEL(5606) requires "
+                "one of these extensions: SPV_INTEL_inline_assembly"));
+  EXPECT_THAT(diag, HasSubstr("OpCapability AsmINTEL"));
+}
+
+TEST_F(ValidateSpvINTELInlineAssembly, RequiresCapability) {
+  const std::string str = R"(
+         OpCapability Kernel
+         OpCapability Addresses
+         OpCapability Linkage
+         OpExtension "SPV_INTEL_inline_assembly"
+         OpMemoryModel Physical32 OpenCL
+         OpDecorate %1 SideEffectsINTEL
+    %2 = OpTypeVoid
+    %3 = OpTypeFunction %2
+    %4 = OpAsmTargetINTEL "spirv64-unknown-unknown"
+    %1 = OpAsmINTEL %2 %3 %4 "nop" ""
+    %5 = OpFunction %2 None %3
+    %6 = OpLabel
+    %7 = OpAsmCallINTEL %2 %1
+         OpReturn
+         OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  const std::string diag = getDiagnosticString();
+  EXPECT_THAT(diag, HasSubstr("Operand 2 of Decorate requires one of these "
+                              "capabilities: AsmINTEL"));
+  EXPECT_THAT(diag, HasSubstr("OpDecorate %1 SideEffectsINTEL"));
+}
+
+}  // namespace
+}  // namespace val
+}  // namespace spvtools


### PR DESCRIPTION
Previously, validating a module using the [SPV_INTEL_inline_assembly](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/spirv-extensions/SPV_INTEL_inline_assembly.asciidoc) extension would fail. This PR fixes it.