### PR TITLE
Fix xcode generation failure due to missing dependency

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -124,9 +124,8 @@ list(APPEND OPCODE_CPP_DEPENDS ${GENERATOR_INC_FILE})
 # We need to wrap the .inc files with a custom target to avoid problems when
 # multiple targets depend on the same custom command.
 add_custom_target(core_tables
-	DEPENDS ${OPCODE_CPP_DEPENDS}
-	        ${CORE_TABLES_BODY_INC_FILE}
-		${CORE_TABLES_HEADER_INC_FILE})
+  DEPENDS ${OPCODE_CPP_DEPENDS}
+          spirv-tools-tables)
 add_custom_target(extinst_tables
   DEPENDS ${EXTINST_CPP_DEPENDS})
 


### PR DESCRIPTION
I am currently running into the following issue when trying to build Vulkan CTS 1.4.3.1 (latest release of CTS) on macOS:
```
CMake Error in external/glslang/src/CMakeLists.txt:
  The custom command generating

    /Users/aitor/LunarG/builds/cts/main/debug/external/spirv-tools/spirv-tools/core_tables_body.inc

  is attached to multiple targets:

    spirv-tools-tables
    core_tables

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

The command I use to run into this is the following:
```
cmake <path/to/cts> -GXcode -DCMAKE_BUILD_TYPE=Debug -DDEQP_TARGET=osx -DCMAKE_C_FLAGS=-m64 -DCMAKE_CXX_FLAGS=-m64
```

OS version is: 15.4.1 (haven't updated to 15.5, but I expect the same issue there too)

This patch fixes the issue, but I am unsure if this is the correct way to do it. Feel free to modify as required!