### PR TITLE
fix for xcode:

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -124,9 +124,8 @@ list(APPEND OPCODE_CPP_DEPENDS ${GENERATOR_INC_FILE})
 # We need to wrap the .inc files with a custom target to avoid problems when
 # multiple targets depend on the same custom command.
 add_custom_target(core_tables
-	DEPENDS ${OPCODE_CPP_DEPENDS}
-	        ${CORE_TABLES_BODY_INC_FILE}
-		${CORE_TABLES_HEADER_INC_FILE})
+	DEPENDS ${OPCODE_CPP_DEPENDS})
+add_dependencies(core_tables spirv-tools-tables)
 add_custom_target(extinst_tables
   DEPENDS ${EXTINST_CPP_DEPENDS})
 


### PR DESCRIPTION
```
is attached to multiple targets:
core_tables
spirv-tools-tables
but none of these is a common dependency of the other(s).  This is not allowed by the Xcode "new build system".
CMake Error in External/googletest/googlemock/CMakeLists.txt:
```