### PR TITLE
Fix dependency folder name for case-sensitive platforms

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -70,7 +70,7 @@ if (DEFINED SPIRV-Headers_SOURCE_DIR)
   # This allows flexible position of the SPIRV-Headers repo.
   set(SPIRV_HEADER_DIR ${SPIRV-Headers_SOURCE_DIR})
 else()
-  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/spirv-headers)
+  set(SPIRV_HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers)
 endif()
 
 if (IS_DIRECTORY ${SPIRV_HEADER_DIR})


### PR DESCRIPTION
SPIRV-Tools is capitalized not all lowercase, therefore IS_DIRECTORY fails to find it and configuration throws an error on some systems