### PR TITLE
Fix compile error when compiling with whole program optimization enabled

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -853,7 +853,7 @@ void Parser::recordNumberType(size_t inst_offset,
       info.type = SPV_NUMBER_FLOATING;
       info.bit_width = peekAt(inst_offset + 2);
       if (inst->num_words >= 4) {
-        const spvtools::OperandDesc* desc;
+        const spvtools::OperandDesc* desc = nullptr;
         spv_result_t status = spvtools::LookupOperand(
             SPV_OPERAND_TYPE_FPENCODING, peekAt(inst_offset + 3), &desc);
         if (status == SPV_SUCCESS) {

--- a/source/text_handler.cpp
+++ b/source/text_handler.cpp
@@ -336,7 +336,7 @@ spv_result_t AssemblyContext::recordTypeDefinition(
       return diagnostic() << "Invalid OpTypeFloat instruction";
     spv_fp_encoding_t enc = SPV_FP_ENCODING_UNKNOWN;
     if (pInst->words.size() >= 4) {
-      const spvtools::OperandDesc* desc;
+      const spvtools::OperandDesc* desc = nullptr;
       spv_result_t status = spvtools::LookupOperand(SPV_OPERAND_TYPE_FPENCODING,
                                                     pInst->words[3], &desc);
       if (status == SPV_SUCCESS) {

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -140,7 +140,7 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "8-bit floating point type requires an encoding.";
     }
-    const spvtools::OperandDesc* desc;
+    const spvtools::OperandDesc* desc = nullptr;
     const std::set<spv::FPEncoding> known_encodings{
         spv::FPEncoding::Float8E4M3EXT, spv::FPEncoding::Float8E5M2EXT};
     spv_result_t status = spvtools::LookupOperand(SPV_OPERAND_TYPE_FPENCODING,


### PR DESCRIPTION
Compiling with `/GL` (Whole program optimization) and `/LTCG` (Link-time code generation) flags on MSVC 2022 causes an error/warning (depends if `/sdl` flag is also used) to be issued:
```
C:\Users\runneradmin\.conan2\p\b\spirvddae0a8fde618\b\src\source\val\validate_type.cpp(148): error C4703: potentially uninitialized local pointer variable 'desc' used [C:\Users\runneradmin\.conan2\p\b\spirvddae0a8fde618\b\build\source\SPIRV-Tools-shared.vcxproj]
LINK : fatal error LNK1257: code generation failed [C:\Users\runneradmin\.conan2\p\b\spirvddae0a8fde618\b\build\source\SPIRV-Tools-shared.vcxproj]
```

In most places the output parameter of this function is already initialized to `nullptr`, this PR initializes it on the remaining call sites.