### PR TITLE
Extra restrictions for accesses of block arrays

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1914,9 +1914,9 @@ spv_result_t ValidatePtrAccessChain(ValidationState_t& _,
   uint64_t element_val = 0;
   if (_.EvalConstantValUint64(element->id(), &element_val)) {
     if (element_val != 0) {
-      const auto interp_type = untyped_pointer
-                              ? _.FindDef(inst->GetOperandAs<uint32_t>(2))
-                              : _.FindDef(base_type->GetOperandAs<uint32_t>(2));
+      const auto interp_type =
+          untyped_pointer ? _.FindDef(inst->GetOperandAs<uint32_t>(2))
+                          : _.FindDef(base_type->GetOperandAs<uint32_t>(2));
       if (interp_type->opcode() == spv::Op::OpTypeStruct &&
           (_.HasDecoration(interp_type->id(), spv::Decoration::Block) ||
            _.HasDecoration(interp_type->id(), spv::Decoration::BufferBlock))) {

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1566,6 +1566,8 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
       return false;
     };
 
+    // Block (and BufferBlock) arrays cannot be reinterpreted via untyped access
+    // chains.
     const bool base_type_block_array =
         base_type->opcode() == spv::Op::OpTypeArray &&
         _.ContainsType(base_type->id(), ContainsBlock,
@@ -1574,6 +1576,9 @@ spv_result_t ValidateAccessChain(ValidationState_t& _,
     const auto base_index = untyped_pointer ? 3 : 2;
     const auto base_id = inst->GetOperandAs<uint32_t>(base_index);
     auto base = _.FindDef(base_id);
+    // Strictly speaking this misses trivial access chains and function
+    // parameter chasing, but that would be a significant complication in the
+    // traversal.
     while (base->opcode() == spv::Op::OpCopyObject) {
       base = _.FindDef(base->GetOperandAs<uint32_t>(2));
     }

--- a/test/opt/eliminate_dead_member_test.cpp
+++ b/test/opt/eliminate_dead_member_test.cpp
@@ -958,7 +958,7 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberPtrAccessChain) {
 ; CHECK: OpMemberDecorate %type__Globals 1 Offset 16
 ; CHECK: %type__Globals = OpTypeStruct %float %float
 ; CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-; CHECK: OpPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_1 %uint_0
+; CHECK: OpPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_0 %uint_0
 ; CHECK: OpPtrAccessChain %_ptr_Uniform_float [[ac]] %uint_0 %uint_1
                OpCapability Shader
                OpCapability VariablePointersStorageBuffer
@@ -995,7 +995,7 @@ TEST_F(EliminateDeadMemberTest, RemoveMemberPtrAccessChain) {
        %main = OpFunction %void None %14
          %16 = OpLabel
          %17 = OpAccessChain %_ptr_Uniform_type__Globals %_Globals %uint_0
-         %18 = OpPtrAccessChain %_ptr_Uniform_float %17 %uint_1 %uint_0
+         %18 = OpPtrAccessChain %_ptr_Uniform_float %17 %uint_0 %uint_0
          %19 = OpPtrAccessChain %_ptr_Uniform_float %17 %uint_0 %uint_2
                OpReturn
                OpFunctionEnd

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10368,7 +10368,8 @@ OpDecorate %ptr ArrayStride 16
 %struct = OpTypeStruct %int %int
 %ptr = OpTypeUntypedPointerKHR )" +
                             sc + R"(
-%var = OpUntypedVariableKHR %ptr )" + sc + R"( %struct
+%var = OpUntypedVariableKHR %ptr )" +
+                            sc + R"( %struct
 %void_fn = OpTypeFunction %void
 %main = OpFunction %void None %void_fn
 %entry = OpLabel

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10304,6 +10304,7 @@ OpMemberDecorate %struct 0 Offset 0
 OpMemberDecorate %struct 1 Offset 4
 )" + set + R"(OpMemberDecorate %test_type 0 Offset 0
 OpMemberDecorate %test_type 1 Offset 1
+OpDecorate %ptr ArrayStride 16
 %void = OpTypeVoid
 %int = OpTypeInt 32 0
 %int_0 = OpConstant %int 0
@@ -10355,6 +10356,7 @@ OpDecorate %struct Block
 OpMemberDecorate %struct 0 Offset 0
 OpMemberDecorate %struct 1 Offset 4
 )" + set + R"(OpDecorate %test_type ArrayStride 4
+OpDecorate %ptr ArrayStride 16
 %void = OpTypeVoid
 %int = OpTypeInt 32 0
 %int_0 = OpConstant %int 0

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -10313,7 +10313,8 @@ OpDecorate %ptr ArrayStride 16
 %test_val = OpConstantNull %test_type
 %ptr = OpTypeUntypedPointerKHR )" +
                             sc + R"(
-%var = OpUntypedVariableKHR %ptr )" + sc + R"( %struct
+%var = OpUntypedVariableKHR %ptr )" +
+                            sc + R"( %struct
 %void_fn = OpTypeFunction %void
 %main = OpFunction %void None %void_fn
 %entry = OpLabel

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -7460,6 +7460,309 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
 }
 
+TEST_F(ValidateMemory, PtrAccessChainElementNotInteger) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability VariablePointers
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %ptr_int ArrayStride 4
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%float = OpTypeFloat 32
+%float_0 = OpConstant %float 0
+%array = OpTypeArray %int %int_4
+%ptr_array = OpTypePointer Workgroup %array
+%ptr_int = OpTypePointer Workgroup %int
+%var = OpVariable %ptr_array Workgroup
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpAccessChain %ptr_int %var %int_0
+%ptr_gep = OpPtrAccessChain %ptr_int %gep %float_0
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Element must be an integer"));
+}
+
+TEST_F(ValidateMemory, PtrAccessChainElementNotIntegerUntyped) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability VariablePointers
+OpCapability UntypedPointersKHR
+OpCapability WorkgroupMemoryExplicitLayoutKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main" %var
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %ptr_int ArrayStride 4
+OpDecorate %array ArrayStride 4
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%float = OpTypeFloat 32
+%float_0 = OpConstant %float 0
+%array = OpTypeArray %int %int_4
+%block = OpTypeStruct %array
+%ptr_block = OpTypeUntypedPointerKHR Workgroup
+%ptr_int = OpTypeUntypedPointerKHR Workgroup
+%var = OpUntypedVariableKHR %ptr_block Workgroup %block
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpUntypedAccessChainKHR %ptr_int %block %var %int_0 %int_0
+%ptr_gep = OpUntypedPtrAccessChainKHR %ptr_int %int %gep %float_0
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Element must be an integer"));
+}
+
+TEST_F(ValidateMemory, PtrAccessChainElementBlockArrayNonZeroConstant) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability VariablePointers
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%int_1 = OpConstant %int 1
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array = OpTypeArray %block %int_4
+%ptr_array = OpTypePointer StorageBuffer %array
+%ptr_block = OpTypePointer StorageBuffer %block
+%var = OpVariable %ptr_array StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpAccessChain %ptr_block %var %int_0
+%ptr_gep = OpPtrAccessChain %ptr_block %gep %int_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Element must be 0 if the interpretation type is a "
+                        "Block- or BufferBlock-decorated structure"));
+}
+
+TEST_F(ValidateMemory, PtrAccessChainElementBlockArrayNonZeroConstantUntyped) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability VariablePointers
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_4 = OpConstant %int 4
+%int_1 = OpConstant %int 1
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array = OpTypeArray %block %int_4
+%ptr_array = OpTypeUntypedPointerKHR StorageBuffer
+%ptr_block = OpTypeUntypedPointerKHR StorageBuffer
+%var = OpUntypedVariableKHR %ptr_array StorageBuffer %array
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpUntypedAccessChainKHR %ptr_block %array %var %int_0
+%ptr_gep = OpUntypedPtrAccessChainKHR %ptr_block %block %gep %int_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Element must be 0 if the interpretation type is a "
+                        "Block- or BufferBlock-decorated structure"));
+}
+
+TEST_F(ValidateMemory, UntypedAccessChainBlockArrayMismatch1) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpCapability VariablePointers
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_1 = OpConstant %int 1
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array1 = OpTypeArray %block %int_4
+%array2 = OpTypeArray %block %int_4
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%var = OpUntypedVariableKHR %ptr StorageBuffer %array1
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpUntypedAccessChainKHR %ptr %array2 %var
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("If Base or Base Type is a Block or BufferBlock array, "
+                        "the other must also be the same array"));
+}
+
+TEST_F(ValidateMemory, UntypedAccessChainBlockArrayMismatch2) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpCapability VariablePointers
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_1 = OpConstant %int 1
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array1 = OpTypeArray %block %int_4
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%var = OpUntypedVariableKHR %ptr StorageBuffer %array1
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpUntypedAccessChainKHR %ptr %block %var
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Both Base Type and Base must be Block or BufferBlock "
+                        "arrays or neither can be"));
+}
+
+TEST_F(ValidateMemory, UntypedAccessChainBlockArrayMismatch3) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpCapability VariablePointers
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_1 = OpConstant %int 1
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array1 = OpTypeArray %block %int_4
+%array2 = OpTypeArray %block %int_4
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%ptr_block_array = OpTypePointer StorageBuffer %array1
+%var = OpVariable %ptr_block_array StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%copy1 = OpCopyObject %ptr_block_array %var
+%copy2 = OpCopyObject %ptr_block_array %copy1
+%gep = OpUntypedAccessChainKHR %ptr %array2 %copy2
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("If Base or Base Type is a Block or BufferBlock array, "
+                        "the other must also be the same array"));
+}
+
+TEST_F(ValidateMemory, UntypedAccessChainBlockArrayMismatch4) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpCapability VariablePointers
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 0
+%int_1 = OpConstant %int 1
+%int_4 = OpConstant %int 4
+%int_0 = OpConstant %int 0
+%block = OpTypeStruct %int
+%array1 = OpTypeArray %block %int_4
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%ptr_block_array = OpTypePointer StorageBuffer %array1
+%var = OpVariable %ptr_block_array StorageBuffer
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%copy = OpCopyObject %ptr_block_array %var
+%gep = OpUntypedAccessChainKHR %ptr %block %copy
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Both Base Type and Base must be Block or BufferBlock "
+                        "arrays or neither can be"));
+}
+
 std::string GenCoopMat2Shader(const std::string& extra_types,
                               const std::string& main_body,
                               const std::string& after_main = "",

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -6148,6 +6148,7 @@ TEST_P(ValidateMemoryUntypedAccessChain, GoodTypedPointerBase) {
   const bool ptr = opcode == "OpUntypedPtrAccessChainKHR" ||
                    opcode == "OpUntypedInBoundsPtrAccessChainKHR";
   const std::string extra_param = ptr ? "%int_0" : "";
+  const std::string deco = ptr ? "OpDecorate %ptr_ssbo ArrayStride 4" : "";
 
   const std::string spirv = R"(
 OpCapability Shader
@@ -6158,6 +6159,7 @@ OpExtension "SPV_KHR_storage_buffer_storage_class"
 OpExtension "SPV_KHR_untyped_pointers"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
+)" + deco + R"(
 %void = OpTypeVoid
 %int = OpTypeInt 32 0
 %int_0 = OpConstant %int 0
@@ -6183,6 +6185,7 @@ TEST_P(ValidateMemoryUntypedAccessChain, GoodUntypedPointerBase) {
   const bool ptr = opcode == "OpUntypedPtrAccessChainKHR" ||
                    opcode == "OpUntypedInBoundsPtrAccessChainKHR";
   const std::string extra_param = ptr ? "%int_0" : "";
+  const std::string deco = ptr ? "OpDecorate %ptr ArrayStride 4" : "";
 
   const std::string spirv = R"(
 OpCapability Shader
@@ -6193,6 +6196,7 @@ OpExtension "SPV_KHR_storage_buffer_storage_class"
 OpExtension "SPV_KHR_untyped_pointers"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
+)" + deco + R"(
 %void = OpTypeVoid
 %int = OpTypeInt 32 0
 %int_0 = OpConstant %int 0


### PR DESCRIPTION
* If a PtrAccessChain is rooted on a block, element (if constant) must
  be zero
* UntypedAccessChains check that block arrays must not be reinterpreted
* Basic element operand checks for ptr access chains