### PR TITLE
[GH Actions] Trigger when the `kokoro:run` label is removed

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -7,9 +7,11 @@ on:
     branches:
       - 'main'
   pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
 
 jobs:
   build:
+    if: github.event.action != 'unlabeled' || github.event.label.name == 'kokoro:run'
     timeout-minutes: 120
     strategy:
       matrix:


### PR DESCRIPTION
We have a github action that will create a new PR to udpate the
dependencies. Because this is done by a GH action, it will not trigger
the GH Actions to run the presubmits. To get them to run, I currently
close the PR, and then reopen it.

To make this easier, I'd like to have the presubmits be trigged by the
removal of the `kokoro:run` label. The work flow will become:

1. GH Action to create a new PR, and it adds the `kokoro:run` labal.
2. Kokoro will see the label, remove it and run the kokoro presubmits.
3. When the GH Action bot sees the label is removed, I expect it to run
   the GH action presubmits.
4. Someone reviews the PR, and it will automerge of all of the tests
   have passed.
