### PR TITLE
[GH Actions] Run wasm build when kokoro:run is removed.

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,10 +2,16 @@ name: Wasm Build
 permissions:
   contents: read
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened, unlabeled]
 
 jobs:
   build:
+    if: github.event.action != 'unlabeled' || github.event.label.name == 'kokoro:run'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I made a change to the bazel build to run when the label was removed:
https://github.com/KhronosGroup/SPIRV-Tools/pull/6230, but I did not
do it for the wasm build.

At the same time, I modified the wasm build to run on a push only if the branch is main. This matches the bazel build, and should run when we need it.