### PR TITLE
spirv-val: validate DescriptorSet and Binding decorations for all relevant variables

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1198,6 +1198,12 @@ spv_result_t CheckDecorationsOfVariables(ValidationState_t& vstate) {
       // storage classes are decorated with DescriptorSet and Binding
       // (VUID-06677).
       if (uniform_constant || storage_buffer || uniform) {
+        // Skip validation if the variable is not used and we're looking
+        // at a module coming from HLSL that has not been legalized yet.
+        if (vstate.options()->before_hlsl_legalization &&
+            vstate.EntryPointReferences(var_id).empty()) {
+          continue;
+        }
         if (!hasDecoration(var_id, spv::Decoration::DescriptorSet, vstate)) {
           return vstate.diag(SPV_ERROR_INVALID_ID, vstate.FindDef(var_id))
                  << vstate.VkErrorID(6677) << sc_str << " id '" << var_id

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -898,6 +898,8 @@ TEST_F(ValidateData, vulkan_RTA_array_at_end_of_struct) {
               OpMemberDecorate %struct_t 0 Offset 0
               OpMemberDecorate %struct_t 1 Offset 4
               OpDecorate %struct_t Block
+              OpDecorate %2 DescriptorSet 0
+              OpDecorate %2 Binding 0
      %uint_t = OpTypeInt 32 0
    %array_t = OpTypeRuntimeArray %uint_t
   %struct_t = OpTypeStruct %uint_t %array_t

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -1863,6 +1863,8 @@ TEST_F(ValidateDecorations, BlockStandardUniformBufferLayout) {
                OpMemberDecorate %Output 6 MatrixStride 16
                OpMemberDecorate %Output 7 Offset 128
                OpDecorate %Output Block
+               OpDecorate %dataOutput DescriptorSet 0
+               OpDecorate %dataOutput Binding 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32
@@ -2549,6 +2551,10 @@ TEST_F(ValidateDecorations, BufferBlock16bitStandardStorageBufferLayout) {
              OpMemberDecorate %SSBO16 0 Offset 0
              OpDecorate %SSBO32 BufferBlock
              OpDecorate %SSBO16 BufferBlock
+             OpDecorate %varSSBO32 DescriptorSet 0
+             OpDecorate %varSSBO32 Binding 0
+             OpDecorate %varSSBO16 DescriptorSet 0
+             OpDecorate %varSSBO16 Binding 1
      %void = OpTypeVoid
     %voidf = OpTypeFunction %void
       %u32 = OpTypeInt 32 0
@@ -3476,6 +3482,7 @@ TEST_F(ValidateDecorations, VulkanStorageBufferMissingDescriptorSetBad) {
             OpExecutionMode %1 OriginUpperLeft
 
             OpDecorate %struct Block
+            OpMemberDecorate %struct 0 Offset 0
             OpDecorate %var Binding 0
 
     %void = OpTypeVoid
@@ -3518,6 +3525,7 @@ TEST_F(ValidateDecorations, VulkanStorageBufferMissingBindingBad) {
             OpExecutionMode %1 OriginUpperLeft
 
             OpDecorate %struct Block
+            OpMemberDecorate %struct 0 Offset 0
             OpDecorate %var DescriptorSet 0
 
     %void = OpTypeVoid
@@ -3560,6 +3568,7 @@ TEST_F(ValidateDecorations,
             OpExecutionMode %1 OriginUpperLeft
 
             OpDecorate %struct Block
+            OpMemberDecorate %struct 0 Offset 0
             OpDecorate %var Binding 0
 
     %void = OpTypeVoid
@@ -3596,35 +3605,6 @@ TEST_F(ValidateDecorations,
                 "From Vulkan spec:\n"
                 "These variables must have DescriptorSet and Binding "
                 "decorations specified"));
-}
-
-TEST_F(ValidateDecorations,
-       VulkanStorageBufferMissingDescriptorAndBindingUnusedGood) {
-  std::string spirv = R"(
-            OpCapability Shader
-            OpExtension "SPV_KHR_storage_buffer_storage_class"
-            OpMemoryModel Logical GLSL450
-            OpEntryPoint Fragment %1 "main"
-            OpExecutionMode %1 OriginUpperLeft
-            OpDecorate %struct Block
-            OpMemberDecorate %struct 0 Offset 0
-
-    %void = OpTypeVoid
-  %voidfn = OpTypeFunction %void
-   %float = OpTypeFloat 32
-  %struct = OpTypeStruct %float
-     %ptr = OpTypePointer StorageBuffer %struct
-     %var = OpVariable %ptr StorageBuffer
-
-       %1 = OpFunction %void None %voidfn
-   %label = OpLabel
-            OpReturn
-            OpFunctionEnd
-)";
-
-  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
-  EXPECT_EQ(SPV_SUCCESS,
-            ValidateAndRetrieveValidationState(SPV_ENV_VULKAN_1_1));
 }
 
 TEST_F(ValidateDecorations, UniformMissingDescriptorSetGood) {
@@ -3903,6 +3883,8 @@ TEST_F(ValidateDecorations, BufferBlockStandardStorageBufferLayout) {
                OpMemberDecorate %Output 6 MatrixStride 16
                OpMemberDecorate %Output 7 Offset 96
                OpDecorate %Output BufferBlock
+               OpDecorate %dataOutput DescriptorSet 0
+               OpDecorate %dataOutput Binding 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32
@@ -4036,6 +4018,8 @@ TEST_F(ValidateDecorations,
                OpMemberDecorate %Output 6 MatrixStride 16
                OpMemberDecorate %Output 7 Offset 128
                OpDecorate %Output Block
+               OpDecorate %dataOutput DescriptorSet 0
+               OpDecorate %dataOutput Binding 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32
@@ -4104,6 +4088,8 @@ TEST_F(ValidateDecorations,
                OpMemberDecorate %Output 6 MatrixStride 16
                OpMemberDecorate %Output 7 Offset 128
                OpDecorate %Output Block
+               OpDecorate %dataOutput DescriptorSet 0
+               OpDecorate %dataOutput Binding 0
        %void = OpTypeVoid
           %3 = OpTypeFunction %void
       %float = OpTypeFloat 32
@@ -7595,6 +7581,8 @@ OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 OpDecorate %struct Block
 OpMemberDecorate %struct 0 Offset 0
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
 %void = OpTypeVoid
 %uint = OpTypeInt 32 0
 %struct = OpTypeStruct %uint
@@ -7708,6 +7696,8 @@ OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 OpDecorate %struct Block
 OpMemberDecorate %struct 0 Offset 0
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
 %void = OpTypeVoid
 %uint = OpTypeInt 32 0
 %struct = OpTypeStruct %uint
@@ -7732,6 +7722,8 @@ OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 OpDecorate %struct BufferBlock
 OpMemberDecorate %struct 0 Offset 0
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
 %void = OpTypeVoid
 %uint = OpTypeInt 32 0
 %struct = OpTypeStruct %uint

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -116,6 +116,8 @@ OpDecorate %uniform_image_f32_2d_0002 DescriptorSet 1
 OpDecorate %uniform_image_f32_2d_0002 Binding 3
 OpDecorate %uniform_image_s32_2d_0002 DescriptorSet 1
 OpDecorate %uniform_image_s32_2d_0002 Binding 4
+OpDecorate %uniform_image_u32_3d_0001 DescriptorSet 1
+OpDecorate %uniform_image_u32_3d_0001 Binding 5
 OpDecorate %uniform_image_f32_spd_0002 DescriptorSet 2
 OpDecorate %uniform_image_f32_spd_0002 Binding 0
 OpDecorate %uniform_image_f32_3d_0111 DescriptorSet 2
@@ -124,6 +126,8 @@ OpDecorate %uniform_image_f32_cube_0101 DescriptorSet 2
 OpDecorate %uniform_image_f32_cube_0101 Binding 2
 OpDecorate %uniform_image_f32_cube_0102_rgba32f DescriptorSet 2
 OpDecorate %uniform_image_f32_cube_0102_rgba32f Binding 3
+OpDecorate %uniform_image_f32_3d_0001 DescriptorSet 2
+OpDecorate %uniform_image_f32_3d_0001 Binding 4
 OpDecorate %uniform_sampler DescriptorSet 3
 OpDecorate %uniform_sampler Binding 0
 OpDecorate %input_flat_u32 Flat

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -2902,6 +2902,10 @@ OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
 OpDecorate %struct Block
 OpMemberDecorate %struct 0 Offset 0
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %3 Binding 1
 %sampler_t = OpTypeSampler
 %uint = OpTypeInt 32 0
 %array_t = OpTypeRuntimeArray %sampler_t
@@ -2966,6 +2970,8 @@ OpExecutionMode %func OriginUpperLeft
 OpDecorate %array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
 %uint_t = OpTypeInt 32 0
 %array_t = OpTypeRuntimeArray %uint_t
 %struct_t = OpTypeStruct %array_t
@@ -3057,6 +3063,8 @@ OpExecutionMode %func OriginUpperLeft
 OpDecorate %array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t BufferBlock
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
 %uint_t = OpTypeInt 32 0
 %array_t = OpTypeRuntimeArray %uint_t
 %struct_t = OpTypeStruct %array_t
@@ -3182,6 +3190,8 @@ OpEntryPoint Fragment %func "func"
 OpExecutionMode %func OriginUpperLeft
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
 %uint_t = OpTypeInt 32 0
 %struct_t = OpTypeStruct %uint_t
 %array_t = OpTypeRuntimeArray %struct_t
@@ -3427,6 +3437,8 @@ OpExecutionMode %func OriginUpperLeft
 OpDecorate %inner_array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
 %uint_t = OpTypeInt 32 0
 %inner_array_t = OpTypeRuntimeArray %uint_t
 %struct_t = OpTypeStruct %inner_array_t
@@ -3456,6 +3468,8 @@ OpExecutionMode %func OriginUpperLeft
 OpDecorate %inner_array_t ArrayStride 4
 OpMemberDecorate %struct_t 0 Offset 0
 OpDecorate %struct_t Block
+OpDecorate %2 DescriptorSet 0
+OpDecorate %2 Binding 0
 %uint_t = OpTypeInt 32 0
 %inner_array_t = OpTypeRuntimeArray %uint_t
 %struct_t = OpTypeStruct %inner_array_t

--- a/test/val/val_tensor_test.cpp
+++ b/test/val/val_tensor_test.cpp
@@ -41,6 +41,8 @@ std::string GenerateModule(const std::string& body) {
                      OpDecorate %tensor_var Binding 0
                      OpDecorate %tensor_var_float_unranked DescriptorSet 0
                      OpDecorate %tensor_var_float_unranked Binding 1
+                     OpDecorate %tensor_var_spec_rank DescriptorSet 0
+                     OpDecorate %tensor_var_spec_rank Binding 2
              %void = OpTypeVoid
              %uint = OpTypeInt 32 0
             %float = OpTypeFloat 32


### PR DESCRIPTION
Extract the check out of buffer checks and make it generic so it matches VUID-6677 a bit better and applies to other variable types (e.g. OpTypeTensorARM).

Change-Id: I7ef7830ae55b3b402a20d9f786e8bd8a64e2263f