### PR TITLE
linker: Fix BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -657,7 +657,12 @@ static_library("spvtools_opt") {
 }
 
 static_library("spvtools_link") {
-  sources = [ "source/link/linker.cpp" ]
+  sources = [
+    "source/link/linker.cpp",
+    "source/link/linker.h",
+    "source/link/fnvar.cpp",
+    "source/link/fnvar.h"
+  ]
   deps = [
     ":spvtools",
     ":spvtools_opt",


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Tools/commit/bf98dd7287a5081f8c1a88b2dd003aa4e9487d05#diff-61d4552092a400db7dcdb41c965fc08429b58881fc86bc8f7e4e15c664490355 seems to never added the new file to BUILD.gn and causing VVL to fail to pull it in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10533