### PR TITLE
spirv-val: Add 11167 VUID label

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -435,6 +435,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
       }
       if (spvIsVulkanEnv(_.context()->target_env)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << _.VkErrorID(11167)
                << "Vulkan requires that data type be specified";
       }
     }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2749,6 +2749,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-UnequalMemorySemantics-10879);
     case 10880:
       return VUID_WRAP(VUID-StandaloneSpirv-TessLevelInner-10880);
+    case 11167:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpUntypedVariableKHR-11167);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -5730,6 +5730,8 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_1);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_1));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpUntypedVariableKHR-11167"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Vulkan requires that data type be specified"));
 }
 


### PR DESCRIPTION
` VUID-RuntimeSpirv-OpUntypedVariableKHR-11167` will be ` VUID-Standalone-OpUntypedVariableKHR-11167` in the 1.4.326 spec