### PR TITLE
Add the extension check that SPV_QCOM_image_processing and SPV_QCOM_image_processing2 requires SPV 1.4 or later.

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1066,7 +1066,9 @@ spv_result_t ValidateExtension(ValidationState_t& _, const Instruction* inst) {
         extension == ExtensionToString(kSPV_NV_shader_invocation_reorder) ||
         extension ==
             ExtensionToString(kSPV_NV_cluster_acceleration_structure) ||
-        extension == ExtensionToString(kSPV_NV_linear_swept_spheres)) {
+        extension == ExtensionToString(kSPV_NV_linear_swept_spheres) ||
+        extension == ExtensionToString(kSPV_QCOM_image_processing) ||
+        extension == ExtensionToString(kSPV_QCOM_image_processing2)) {
       return _.diag(SPV_ERROR_WRONG_VERSION, inst)
              << extension << " extension requires SPIR-V version 1.4 or later.";
     }


### PR DESCRIPTION
Add the extension check that SPV_QCOM_image_processing and SPV_QCOM_image_processing2 requires SPV 1.4 or later.
