### PR TITLE
spirv-dis: Fix missing color on result ID

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -694,12 +694,12 @@ void InstructionDisassembler::EmitInstructionImpl(
   }
 
   if (inst.result_id) {
-    SetBlue();
+    SetBlue(line);
     const std::string id_name = name_mapper_(inst.result_id);
     if (indent_)
       line << std::setw(std::max(0, indent_ - 3 - int(id_name.size())));
     line << "%" << id_name;
-    ResetColor();
+    ResetColor(line);
     line << " = ";
   } else {
     line << std::string(indent_, ' ');


### PR DESCRIPTION
A previous refactoring of the code
(c3178da8eac9bc7d1788e95f8d555918ba483c23) accidentally broke coloring
of result ids, which this change fixes.