### PR TITLE
fix duplicate constant from libspirv.h

### DIFF
--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -432,7 +432,7 @@ typedef enum spv_binary_to_text_options_t {
 
 // The default id bound is to the minimum value for the id limit
 // in the spir-v specification under the section "Universal Limits".
-const uint32_t kDefaultMaxIdBound = 0x3FFFFF;
+const static uint32_t kDefaultMaxIdBound = 0x3FFFFF;
 
 // Structures
 


### PR DESCRIPTION
in libspirv.h is defined a constant `kDefaultMaxIdBound`. defining constants in headers is a bad practice, as it causes duplicate symbols if you include it in more than 1 compilation unit.

better solution, that will not cause this issue, would be to make it a compile-time macro.