### PR TITLE
spirv-opt: add Geometry capability to the trim pass

### DIFF
--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -38,6 +38,7 @@ namespace opt {
 
 namespace {
 constexpr uint32_t kOpTypeFloatSizeIndex = 0;
+constexpr uint32_t kOpEntryPointExecutionModelIndex = 0;
 constexpr uint32_t kOpTypePointerStorageClassIndex = 0;
 constexpr uint32_t kTypeArrayTypeIndex = 0;
 constexpr uint32_t kOpTypeScalarBitWidthIndex = 0;
@@ -166,6 +167,30 @@ static std::optional<spv::Capability> Handler_OpTypeFloat_Float64(
   const uint32_t size =
       instruction->GetSingleWordInOperand(kOpTypeFloatSizeIndex);
   return size == 64 ? std::optional(spv::Capability::Float64) : std::nullopt;
+}
+
+static std::optional<spv::Capability> Handler_OpEntryPoint_Geometry(
+    const Instruction* instruction) {
+  assert(instruction->opcode() == spv::Op::OpEntryPoint &&
+         "This handler only support OpEntryPoint opcodes.");
+
+  auto execution_model = spv::ExecutionModel(
+      instruction->GetSingleWordInOperand(kOpEntryPointExecutionModelIndex));
+  return execution_model == spv::ExecutionModel::Geometry
+             ? std::optional(spv::Capability::Geometry)
+             : std::nullopt;
+}
+
+static std::optional<spv::Capability>
+Handler_OpConditionalEntryPointINTEL_Geometry(const Instruction* instruction) {
+  assert(instruction->opcode() == spv::Op::OpConditionalEntryPointINTEL &&
+         "This handler only support OpConditionalEntryPointINTEL opcodes.");
+
+  auto execution_model =
+      spv::ExecutionModel(instruction->GetSingleWordInOperand(1));
+  return execution_model == spv::ExecutionModel::Geometry
+             ? std::optional(spv::Capability::Geometry)
+             : std::nullopt;
 }
 
 static std::optional<spv::Capability>
@@ -425,22 +450,24 @@ Handler_OpImageSparseRead_StorageImageReadWithoutFormat(
 }
 
 // Opcode of interest to determine capabilities requirements.
-constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 14> kOpcodeHandlers{{
+constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 16> kOpcodeHandlers{{
     // clang-format off
-    {spv::Op::OpImageRead,         Handler_OpImageRead_StorageImageReadWithoutFormat},
-    {spv::Op::OpImageWrite,        Handler_OpImageWrite_StorageImageWriteWithoutFormat},
-    {spv::Op::OpImageSparseRead,   Handler_OpImageSparseRead_StorageImageReadWithoutFormat},
-    {spv::Op::OpTypeFloat,         Handler_OpTypeFloat_Float16 },
-    {spv::Op::OpTypeFloat,         Handler_OpTypeFloat_Float64 },
-    {spv::Op::OpTypeImage,         Handler_OpTypeImage_ImageMSArray},
-    {spv::Op::OpTypeInt,           Handler_OpTypeInt_Int16 },
-    {spv::Op::OpTypeInt,           Handler_OpTypeInt_Int64 },
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageInputOutput16},
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StoragePushConstant16},
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniform16},
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniform16},
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageUniformBufferBlock16},
-    {spv::Op::OpTypePointer,       Handler_OpTypePointer_StorageBuffer16BitAccess},
+    {spv::Op::OpImageRead,                   Handler_OpImageRead_StorageImageReadWithoutFormat},
+    {spv::Op::OpImageWrite,                  Handler_OpImageWrite_StorageImageWriteWithoutFormat},
+    {spv::Op::OpImageSparseRead,             Handler_OpImageSparseRead_StorageImageReadWithoutFormat},
+    {spv::Op::OpTypeFloat,                   Handler_OpTypeFloat_Float16 },
+    {spv::Op::OpTypeFloat,                   Handler_OpTypeFloat_Float64 },
+    {spv::Op::OpTypeImage,                   Handler_OpTypeImage_ImageMSArray},
+    {spv::Op::OpTypeInt,                     Handler_OpTypeInt_Int16 },
+    {spv::Op::OpTypeInt,                     Handler_OpTypeInt_Int64 },
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageInputOutput16},
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StoragePushConstant16},
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageUniform16},
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageUniform16},
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageUniformBufferBlock16},
+    {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageBuffer16BitAccess},
+    {spv::Op::OpEntryPoint,                  Handler_OpEntryPoint_Geometry },
+    {spv::Op::OpConditionalEntryPointINTEL,  Handler_OpConditionalEntryPointINTEL_Geometry },
     // clang-format on
 }};
 

--- a/source/opt/trim_capabilities_pass.h
+++ b/source/opt/trim_capabilities_pass.h
@@ -82,6 +82,7 @@ class TrimCapabilitiesPass : public Pass {
       spv::Capability::FragmentShaderPixelInterlockEXT,
       spv::Capability::FragmentShaderSampleInterlockEXT,
       spv::Capability::FragmentShaderShadingRateInterlockEXT,
+      spv::Capability::Geometry,
       spv::Capability::GroupNonUniform,
       spv::Capability::GroupNonUniformArithmetic,
       spv::Capability::GroupNonUniformClustered,

--- a/test/opt/trim_capabilities_pass_test.cpp
+++ b/test/opt/trim_capabilities_pass_test.cpp
@@ -3635,6 +3635,148 @@ TEST_F(TrimCapabilitiesPassTest, PhysicalStorageBuffer_RecursiveTypes) {
   EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
 }
 
+TEST_F(TrimCapabilitiesPassTest, Geometry_Remains) {
+  const std::string kTest = R"(
+               OpCapability Geometry
+; CHECK:       OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Geometry %gs_main "gs_main" %gl_Position
+               OpExecutionMode %gs_main OutputVertices 3
+               OpExecutionMode %gs_main Invocations 1
+               OpExecutionMode %gs_main Triangles
+               OpExecutionMode %gs_main OutputTriangleStrip
+               OpSource HLSL 660
+               OpName %gs_main "gs_main"
+               OpDecorate %gl_Position BuiltIn Position
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+          %7 = OpTypeFunction %void
+%gl_Position = OpVariable %_ptr_Output_v4float Output
+    %gs_main = OpFunction %void None %7
+          %8 = OpLabel
+               OpEmitVertex
+               OpReturn
+               OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+}
+
+// FIXME(6277): enable once spirv-opt supports SPV_INTEL_function_variants
+#if 0
+TEST_F(TrimCapabilitiesPassTest, Geometry_RemainsIntel) {
+  const std::string kTest = R"(
+                OpCapability Geometry
+ ; CHECK:       OpCapability Geometry
+                OpCapability SpecConditionalINTEL
+                OpExtension "SPV_INTEL_function_variants"
+                OpMemoryModel Logical GLSL450
+                OpConditionalEntryPointINTEL %false Geometry %gs_main "gs_main"
+                OpExecutionMode %gs_main OutputVertices 3
+                OpExecutionMode %gs_main Invocations 1
+                OpExecutionMode %gs_main Triangles
+                OpExecutionMode %gs_main OutputTriangleStrip
+                OpSource HLSL 660
+                OpName %gs_main "gs_main"
+                OpDecorate %gl_Position BuiltIn Position
+        %bool = OpTypeBool
+       %false = OpSpecConstantFalse %bool
+       %float = OpTypeFloat 32
+     %v4float = OpTypeVector %float 4
+ %_ptr_Output_v4float = OpTypePointer Output %v4float
+        %void = OpTypeVoid
+           %7 = OpTypeFunction %void
+ %gl_Position = OpVariable %_ptr_Output_v4float Output
+     %gs_main = OpFunction %void None %7
+           %8 = OpLabel
+                OpEmitVertex
+                OpReturn
+                OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithoutChange);
+}
+#endif
+
+TEST_F(TrimCapabilitiesPassTest, Geometry_Removed) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability Geometry
+; CHECK-NOT:   OpCapability Geometry
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %ps_main "ps_main" %in_var_POSITION %out_var_SV_Target
+               OpExecutionMode %ps_main OriginUpperLeft
+               OpSource HLSL 660
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %ps_main "ps_main"
+               OpDecorate %in_var_POSITION Location 0
+               OpDecorate %out_var_SV_Target Location 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+    %ps_main = OpFunction %void None %9
+         %10 = OpLabel
+         %11 = OpLoad %v4float %in_var_POSITION
+               OpStore %out_var_SV_Target %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+
+// FIXME(6277): enable once spirv-opt supports SPV_INTEL_function_variants
+#if 0
+TEST_F(TrimCapabilitiesPassTest, Geometry_RemovedIntel) {
+  const std::string kTest = R"(
+               OpCapability Shader
+               OpCapability Geometry
+; CHECK-NOT:   OpCapability Geometry
+               OpCapability SpecConditionalINTEL
+               OpExtension "SPV_INTEL_function_variants"
+               OpMemoryModel Logical GLSL450
+               OpConditionalEntryPointINTEL %false Fragment %ps_main "ps_main" %in_var_POSITION %out_var_SV_Target
+               OpExecutionMode %ps_main OriginUpperLeft
+               OpSource HLSL 660
+               OpName %in_var_POSITION "in.var.POSITION"
+               OpName %out_var_SV_Target "out.var.SV_Target"
+               OpName %ps_main "ps_main"
+               OpDecorate %in_var_POSITION Location 0
+               OpDecorate %out_var_SV_Target Location 0
+       %bool = OpTypeBool
+      %false = OpSpecConstantFalse %bool
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+       %void = OpTypeVoid
+          %9 = OpTypeFunction %void
+%in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+%out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+    %ps_main = OpFunction %void None %9
+         %10 = OpLabel
+         %11 = OpLoad %v4float %in_var_POSITION
+               OpStore %out_var_SV_Target %11
+               OpReturn
+               OpFunctionEnd
+  )";
+  const auto result =
+      SinglePassRunAndMatch<TrimCapabilitiesPass>(kTest, /* skip_nop= */ false);
+  EXPECT_EQ(std::get<1>(result), Pass::Status::SuccessWithChange);
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(
     TrimCapabilitiesPassTestSubgroupClustered_Unsigned_I,
     TrimCapabilitiesPassTestSubgroupClustered_Unsigned,


### PR DESCRIPTION
Adds support to strip Geometry capability from a module when not used. The capability is required by other instructions, but all require the Geometry execution mode, meaning checking OpEntryPoint or OpConditionalEntryPointINTEL is enough.

2 tests are disabled for now: https://github.com/KhronosGroup/SPIRV-Tools/issues/6277

Related to https://github.com/microsoft/DirectXShaderCompiler/issues/7715