### PR TITLE
spirv-opt: remove useless code

### DIFF
--- a/source/opt/trim_capabilities_pass.cpp
+++ b/source/opt/trim_capabilities_pass.cpp
@@ -38,7 +38,6 @@ namespace opt {
 
 namespace {
 constexpr uint32_t kOpTypeFloatSizeIndex = 0;
-constexpr uint32_t kOpEntryPointExecutionModelIndex = 0;
 constexpr uint32_t kOpTypePointerStorageClassIndex = 0;
 constexpr uint32_t kTypeArrayTypeIndex = 0;
 constexpr uint32_t kOpTypeScalarBitWidthIndex = 0;
@@ -167,30 +166,6 @@ static std::optional<spv::Capability> Handler_OpTypeFloat_Float64(
   const uint32_t size =
       instruction->GetSingleWordInOperand(kOpTypeFloatSizeIndex);
   return size == 64 ? std::optional(spv::Capability::Float64) : std::nullopt;
-}
-
-static std::optional<spv::Capability> Handler_OpEntryPoint_Geometry(
-    const Instruction* instruction) {
-  assert(instruction->opcode() == spv::Op::OpEntryPoint &&
-         "This handler only support OpEntryPoint opcodes.");
-
-  auto execution_model = spv::ExecutionModel(
-      instruction->GetSingleWordInOperand(kOpEntryPointExecutionModelIndex));
-  return execution_model == spv::ExecutionModel::Geometry
-             ? std::optional(spv::Capability::Geometry)
-             : std::nullopt;
-}
-
-static std::optional<spv::Capability>
-Handler_OpConditionalEntryPointINTEL_Geometry(const Instruction* instruction) {
-  assert(instruction->opcode() == spv::Op::OpConditionalEntryPointINTEL &&
-         "This handler only support OpConditionalEntryPointINTEL opcodes.");
-
-  auto execution_model =
-      spv::ExecutionModel(instruction->GetSingleWordInOperand(1));
-  return execution_model == spv::ExecutionModel::Geometry
-             ? std::optional(spv::Capability::Geometry)
-             : std::nullopt;
 }
 
 static std::optional<spv::Capability>
@@ -466,8 +441,6 @@ constexpr std::array<std::pair<spv::Op, OpcodeHandler>, 16> kOpcodeHandlers{{
     {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageUniform16},
     {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageUniformBufferBlock16},
     {spv::Op::OpTypePointer,                 Handler_OpTypePointer_StorageBuffer16BitAccess},
-    {spv::Op::OpEntryPoint,                  Handler_OpEntryPoint_Geometry },
-    {spv::Op::OpConditionalEntryPointINTEL,  Handler_OpConditionalEntryPointINTEL_Geometry },
     // clang-format on
 }};
 


### PR DESCRIPTION
The grammar links the Geometry capability to the entrypoint operand, meaning the code I previously added is useless. Cleaning this up (tests are still there)