### PR TITLE
spirv-val: fix MSVC warning C4146 (minus on unsigned)

### DIFF
--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -16,6 +16,8 @@
 
 // Validates correctness of composite SPIR-V instructions.
 
+#include <climits>
+
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"


### PR DESCRIPTION
DXC is building with -Werror, and doing `-1u` to get an all ones yiels a `unary minus operator applied to unsigned type, result still unsigned` warning.