### PR TITLE
spirv-val: Print SPIR-V version info in error message

### DIFF
--- a/source/val/validate_barriers.cpp
+++ b/source/val/validate_barriers.cpp
@@ -45,10 +45,10 @@ spv_result_t BarriersPass(ValidationState_t& _, const Instruction* inst) {
                       model != spv::ExecutionModel::MeshNV) {
                     if (message) {
                       *message =
-                          "OpControlBarrier requires one of the following "
-                          "Execution "
-                          "Models: TessellationControl, GLCompute, Kernel, "
-                          "MeshNV or TaskNV";
+                          "In SPIR-V 1.2 or earlier, OpControlBarrier requires "
+                          "one of the following "
+                          "Execution Models: TessellationControl, GLCompute, "
+                          "Kernel, MeshNV or TaskNV";
                     }
                     return false;
                   }

--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -572,26 +572,30 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
         if (result_is_pointer && !input_is_pointer && !input_is_int_scalar &&
             !(input_is_int_vector && input_has_int32))
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Expected input to be a pointer, int scalar or 32-bit int "
+                 << "In SPIR-V 1.5 or later, expected input to be a pointer, "
+                    "int scalar or 32-bit int "
                     "vector if Result Type is pointer: "
                  << spvOpcodeString(opcode);
 
         if (input_is_pointer && !result_is_pointer && !result_is_int_scalar &&
             !(result_is_int_vector && result_has_int32))
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Pointer can only be converted to another pointer, int "
+                 << "In SPIR-V 1.5 or later, pointer can only be converted to "
+                    "another pointer, int "
                     "scalar or 32-bit int vector: "
                  << spvOpcodeString(opcode);
       } else {
         if (result_is_pointer && !input_is_pointer && !input_is_int_scalar)
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Expected input to be a pointer or int scalar if Result "
+                 << "In SPIR-V 1.4 or earlier, expected input to be a pointer "
+                    "or int scalar if Result "
                     "Type is pointer: "
                  << spvOpcodeString(opcode);
 
         if (input_is_pointer && !result_is_pointer && !result_is_int_scalar)
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "Pointer can only be converted to another pointer or int "
+                 << "In SPIR-V 1.4 or earlier, pointer can only be converted "
+                    "to another pointer or int "
                     "scalar: "
                  << spvOpcodeString(opcode);
       }

--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -572,7 +572,9 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
         if (result_is_pointer && !input_is_pointer && !input_is_int_scalar &&
             !(input_is_int_vector && input_has_int32))
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "In SPIR-V 1.5 or later, expected input to be a pointer, "
+                 << "In SPIR-V 1.5 or later (or with "
+                    "SPV_KHR_physical_storage_buffer), expected input to be a "
+                    "pointer, "
                     "int scalar or 32-bit int "
                     "vector if Result Type is pointer: "
                  << spvOpcodeString(opcode);
@@ -580,21 +582,27 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
         if (input_is_pointer && !result_is_pointer && !result_is_int_scalar &&
             !(result_is_int_vector && result_has_int32))
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "In SPIR-V 1.5 or later, pointer can only be converted to "
+                 << "In SPIR-V 1.5 or later (or with "
+                    "SPV_KHR_physical_storage_buffer), pointer can only be "
+                    "converted to "
                     "another pointer, int "
                     "scalar or 32-bit int vector: "
                  << spvOpcodeString(opcode);
       } else {
         if (result_is_pointer && !input_is_pointer && !input_is_int_scalar)
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "In SPIR-V 1.4 or earlier, expected input to be a pointer "
+                 << "In SPIR-V 1.4 or earlier (and without "
+                    "SPV_KHR_physical_storage_buffer), expected input to be a "
+                    "pointer "
                     "or int scalar if Result "
                     "Type is pointer: "
                  << spvOpcodeString(opcode);
 
         if (input_is_pointer && !result_is_pointer && !result_is_int_scalar)
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << "In SPIR-V 1.4 or earlier, pointer can only be converted "
+                 << "In SPIR-V 1.4 or earlier (and without "
+                    "SPV_KHR_physical_storage_buffer), pointer can only be "
+                    "converted "
                     "to another pointer or int "
                     "scalar: "
                  << spvOpcodeString(opcode);

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -848,32 +848,35 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
           if (storage_class == spv::StorageClass::TaskPayloadWorkgroupEXT) {
             if (has_task_payload) {
               return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                     << "There can be at most one OpVariable with storage "
+                     << "In SPIR-V 1.4 or later, there can be at most one "
+                        "OpVariable with storage "
                         "class TaskPayloadWorkgroupEXT associated with "
                         "an OpEntryPoint";
             }
             has_task_payload = true;
           }
-        }
-        if (vstate.version() >= SPV_SPIRV_VERSION_WORD(1, 4)) {
+
           // Starting in 1.4, OpEntryPoint must list all global variables
           // it statically uses and those interfaces must be unique.
           if (storage_class == spv::StorageClass::Function) {
             return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                   << "OpEntryPoint interfaces should only list global "
+                   << "In SPIR-V 1.4 or later, OpEntryPoint interfaces should "
+                      "only list global "
                       "variables";
           }
 
           if (!seen_vars.insert(var_instr).second) {
             return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                   << "Non-unique OpEntryPoint interface "
+                   << "In SPIR-V 1.4 or later, non-unique OpEntryPoint "
+                      "interface "
                    << vstate.getIdName(interface) << " is disallowed";
           }
         } else {
           if (storage_class != spv::StorageClass::Input &&
               storage_class != spv::StorageClass::Output) {
             return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                   << "OpEntryPoint interfaces must be OpVariables with "
+                   << "In SPIR-V 1.3 or earlier, OpEntryPoint interfaces must "
+                      "be OpVariables with "
                       "Storage Class of Input(1) or Output(3). Found Storage "
                       "Class "
                    << uint32_t(storage_class) << " for Entry Point id "

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -848,7 +848,7 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
           if (storage_class == spv::StorageClass::TaskPayloadWorkgroupEXT) {
             if (has_task_payload) {
               return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                     << "In SPIR-V 1.4 or later, there can be at most one "
+                     << "There can be at most one "
                         "OpVariable with storage "
                         "class TaskPayloadWorkgroupEXT associated with "
                         "an OpEntryPoint";

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1085,7 +1085,8 @@ spv_result_t ValidateExtInstImport(ValidationState_t& _,
     const std::string name = inst->GetOperandAs<std::string>(name_id);
     if (name.find("NonSemantic.") == 0) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "NonSemantic extended instruction sets cannot be declared "
+             << "In SPIR-V 1.5 or earlier, NonSemantic extended instruction "
+                "sets cannot be declared "
                 "without SPV_KHR_non_semantic_info.";
     }
   }

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1085,9 +1085,10 @@ spv_result_t ValidateExtInstImport(ValidationState_t& _,
     const std::string name = inst->GetOperandAs<std::string>(name_id);
     if (name.find("NonSemantic.") == 0) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "In SPIR-V 1.5 or earlier, NonSemantic extended instruction "
+             << "NonSemantic extended instruction "
                 "sets cannot be declared "
-                "without SPV_KHR_non_semantic_info.";
+                "without SPV_KHR_non_semantic_info. (This can also be fixed "
+                "having SPIR-V 1.6 or later)";
     }
   }
 

--- a/source/val/validate_non_uniform.cpp
+++ b/source/val/validate_non_uniform.cpp
@@ -130,7 +130,7 @@ spv_result_t ValidateGroupNonUniformBroadcastShuffle(ValidationState_t& _,
     if (!spvOpcodeIsConstant(id_op)) {
       std::string operand = GetOperandName(inst->opcode());
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Before SPIR-V 1.5, " << operand
+             << "In SPIR-V 1.4 or earlier, " << operand
              << " must be a constant instruction";
     }
   }

--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -94,7 +94,7 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
 
   // Vulkan specific rules
   if (spvIsVulkanEnv(_.context()->target_env)) {
-    // Vulkan 1.1 specific rules
+    // Subgroups were not added until 1.1
     if (_.context()->target_env != SPV_ENV_VULKAN_1_0) {
       // Scope for Non Uniform Group Operations must be limited to Subgroup
       if ((spvOpcodeIsNonUniformGroupOperation(opcode) &&

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -1515,10 +1515,12 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputType) {
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.4 or earlier, expected input to be a "
-                        "pointer or int scalar if "
-                        "Result Type is pointer: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("In SPIR-V 1.4 or earlier (and without "
+                "SPV_KHR_physical_storage_buffer), expected input to be a "
+                "pointer or int scalar if "
+                "Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongInputTypeSPV1p5) {
@@ -1529,10 +1531,12 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypeSPV1p5) {
   CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
-                        "pointer, int scalar or 32-bit "
-                        "int vector if Result Type is pointer: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("In SPIR-V 1.5 or later (or with "
+                "SPV_KHR_physical_storage_buffer), expected input to be a "
+                "pointer, int scalar or 32-bit "
+                "int vector if Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongInputTypePhysicalStorageBufferKHR) {
@@ -1545,10 +1549,12 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypePhysicalStorageBufferKHR) {
                          "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
-                        "pointer, int scalar or 32-bit "
-                        "int vector if Result Type is pointer: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("In SPIR-V 1.5 or later (or with "
+                "SPV_KHR_physical_storage_buffer), expected input to be a "
+                "pointer, int scalar or 32-bit "
+                "int vector if Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVectorSPV1p5) {
@@ -1559,10 +1565,12 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVectorSPV1p5) {
   CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
-                        "pointer, int scalar or 32-bit "
-                        "int vector if Result Type is pointer: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("In SPIR-V 1.5 or later (or with "
+                "SPV_KHR_physical_storage_buffer), expected input to be a "
+                "pointer, int scalar or 32-bit "
+                "int vector if Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion,
@@ -1576,10 +1584,12 @@ TEST_F(ValidateConversion,
                          "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
-                        "pointer, int scalar or 32-bit "
-                        "int vector if Result Type is pointer: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("In SPIR-V 1.5 or later (or with "
+                "SPV_KHR_physical_storage_buffer), expected input to be a "
+                "pointer, int scalar or 32-bit "
+                "int vector if Result Type is pointer: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
@@ -1590,7 +1600,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.4 or earlier, pointer can only be "
+              HasSubstr("In SPIR-V 1.4 or earlier (and without "
+                        "SPV_KHR_physical_storage_buffer), pointer can only be "
                         "converted to another pointer or "
                         "int scalar: Bitcast"));
 }
@@ -1603,10 +1614,13 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypeSPV1p5) {
   CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
-                        "to another pointer, int "
-                        "scalar or 32-bit int vector: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "In SPIR-V 1.5 or later (or with SPV_KHR_physical_storage_buffer), "
+          "pointer can only be converted "
+          "to another pointer, int "
+          "scalar or 32-bit int vector: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongResultTypePhysicalStorageBufferKHR) {
@@ -1619,10 +1633,13 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypePhysicalStorageBufferKHR) {
                          "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
-                        "to another pointer, int "
-                        "scalar or 32-bit int vector: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "In SPIR-V 1.5 or later (or with SPV_KHR_physical_storage_buffer), "
+          "pointer can only be converted "
+          "to another pointer, int "
+          "scalar or 32-bit int vector: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVectorSPV1p5) {
@@ -1633,10 +1650,13 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVectorSPV1p5) {
   CompileSuccessfully(GenerateKernelCode(body).c_str(), SPV_ENV_UNIVERSAL_1_5);
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
-                        "to another pointer, int "
-                        "scalar or 32-bit int vector: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "In SPIR-V 1.5 or later (or with SPV_KHR_physical_storage_buffer), "
+          "pointer can only be converted "
+          "to another pointer, int "
+          "scalar or 32-bit int vector: Bitcast"));
 }
 
 TEST_F(ValidateConversion,
@@ -1650,10 +1670,13 @@ TEST_F(ValidateConversion,
                          "\nOpExtension \"SPV_KHR_physical_storage_buffer\"")
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
-                        "to another pointer, int "
-                        "scalar or 32-bit int vector: Bitcast"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "In SPIR-V 1.5 or later (or with SPV_KHR_physical_storage_buffer), "
+          "pointer can only be converted "
+          "to another pointer, int "
+          "scalar or 32-bit int vector: Bitcast"));
 }
 
 TEST_F(ValidateConversion, BitcastDifferentTotalBitWidth) {

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -1516,7 +1516,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputType) {
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer or int scalar if "
+              HasSubstr("In SPIR-V 1.4 or earlier, expected input to be a "
+                        "pointer or int scalar if "
                         "Result Type is pointer: Bitcast"));
 }
 
@@ -1529,7 +1530,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypeSPV1p5) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
+                        "pointer, int scalar or 32-bit "
                         "int vector if Result Type is pointer: Bitcast"));
 }
 
@@ -1544,7 +1546,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypePhysicalStorageBufferKHR) {
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
+                        "pointer, int scalar or 32-bit "
                         "int vector if Result Type is pointer: Bitcast"));
 }
 
@@ -1557,7 +1560,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongInputTypeIntVectorSPV1p5) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
+                        "pointer, int scalar or 32-bit "
                         "int vector if Result Type is pointer: Bitcast"));
 }
 
@@ -1573,7 +1577,8 @@ TEST_F(ValidateConversion,
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Expected input to be a pointer, int scalar or 32-bit "
+              HasSubstr("In SPIR-V 1.5 or later, expected input to be a "
+                        "pointer, int scalar or 32-bit "
                         "int vector if Result Type is pointer: Bitcast"));
 }
 
@@ -1585,7 +1590,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultType) {
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer can only be converted to another pointer or "
+              HasSubstr("In SPIR-V 1.4 or earlier, pointer can only be "
+                        "converted to another pointer or "
                         "int scalar: Bitcast"));
 }
 
@@ -1598,7 +1604,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypeSPV1p5) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer can only be converted to another pointer, int "
+              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
+                        "to another pointer, int "
                         "scalar or 32-bit int vector: Bitcast"));
 }
 
@@ -1613,7 +1620,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypePhysicalStorageBufferKHR) {
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer can only be converted to another pointer, int "
+              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
+                        "to another pointer, int "
                         "scalar or 32-bit int vector: Bitcast"));
 }
 
@@ -1626,7 +1634,8 @@ TEST_F(ValidateConversion, BitcastPtrWrongResultTypeIntVectorSPV1p5) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA,
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer can only be converted to another pointer, int "
+              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
+                        "to another pointer, int "
                         "scalar or 32-bit int vector: Bitcast"));
 }
 
@@ -1642,7 +1651,8 @@ TEST_F(ValidateConversion,
           .c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer can only be converted to another pointer, int "
+              HasSubstr("In SPIR-V 1.5 or later, pointer can only be converted "
+                        "to another pointer, int "
                         "scalar or 32-bit int vector: Bitcast"));
 }
 

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -21,6 +21,7 @@
 
 #include "gmock/gmock.h"
 #include "source/val/decoration.h"
+#include "spirv-tools/libspirv.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_code_generator.h"
 #include "test/val/val_fixtures.h"
@@ -9538,9 +9539,9 @@ OpFunctionEnd
 
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Non-unique OpEntryPoint interface '2[%var]' is disallowed"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("In SPIR-V 1.4 or later, non-unique OpEntryPoint "
+                        "interface '2[%var]' is disallowed"));
 }
 
 TEST_F(ValidateDecorations, PhysicalStorageBufferMissingOffset) {

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -215,9 +215,9 @@ OpFunctionEnd
 
   CompileSuccessfully(text, SPV_ENV_UNIVERSAL_1_4);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Non-unique OpEntryPoint interface '2[%var]' is disallowed"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("In SPIR-V 1.4 or later, non-unique OpEntryPoint "
+                        "interface '2[%var]' is disallowed"));
 }
 
 TEST_F(ValidateInterfacesTest, MissingGlobalVarSPV1p3) {

--- a/test/val/val_mesh_shading_test.cpp
+++ b/test/val/val_mesh_shading_test.cpp
@@ -488,7 +488,8 @@ TEST_F(ValidateMeshShading, BadMultipleTaskPayloadWorkgroupEXT) {
   CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("There can be at most one OpVariable with storage "
+              HasSubstr("In SPIR-V 1.4 or later, there can be at most one "
+                        "OpVariable with storage "
                         "class TaskPayloadWorkgroupEXT associated with "
                         "an OpEntryPoint"));
 }

--- a/test/val/val_mesh_shading_test.cpp
+++ b/test/val/val_mesh_shading_test.cpp
@@ -488,7 +488,7 @@ TEST_F(ValidateMeshShading, BadMultipleTaskPayloadWorkgroupEXT) {
   CompileSuccessfully(body, SPV_ENV_UNIVERSAL_1_5);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_5));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("In SPIR-V 1.4 or later, there can be at most one "
+              HasSubstr("There can be at most one "
                         "OpVariable with storage "
                         "class TaskPayloadWorkgroupEXT associated with "
                         "an OpEntryPoint"));

--- a/test/val/val_non_uniform_test.cpp
+++ b/test/val/val_non_uniform_test.cpp
@@ -958,7 +958,7 @@ OpFunctionEnd
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Before SPIR-V 1.5, Id must be a constant instruction"));
+      HasSubstr("In SPIR-V 1.4 or earlier, Id must be a constant instruction"));
 }
 
 TEST_F(ValidateGroupNonUniform, BroadcastNonConstantSpv1p5) {
@@ -1028,7 +1028,8 @@ OpFunctionEnd
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("Before SPIR-V 1.5, Index must be a constant instruction"));
+      HasSubstr(
+          "In SPIR-V 1.4 or earlier, Index must be a constant instruction"));
 }
 
 TEST_F(ValidateGroupNonUniform, QuadBroadcastNonConstantSpv1p5) {


### PR DESCRIPTION
basically someone on the Vulkan discord hit this case https://godbolt.org/z/M7n9YMsnG and didn't realize they needed to increase their `apiVersion` so VVL would pass it down

I have made improvements in VVL, but wanted to have all the errors in `spirv-val` that depend on a version, report that in the error message