### PR TITLE
Skip folding Fmix feeding extract for half type floats

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -1998,6 +1998,13 @@ FoldingRule FMixFeedingExtract() {
     bool use_x = false;
 
     assert(a_const->type()->AsFloat());
+
+    u_int32_t width = ElementWidth(a_const->type());
+    if (width != 32 && width != 64) {
+      // We won't support folding half float values.
+      return false;
+    }
+
     double element_value = a_const->GetValueAsDouble();
     if (element_value == 0.0) {
       use_x = true;


### PR DESCRIPTION
Fix assertion errors when folding Fmix feeding extract half floats.

Resolves https://github.com/microsoft/DirectXShaderCompiler/issues/7710