### PR TITLE
spirv-opt: Handle id overflow in merge return pass

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -58,7 +58,9 @@ Pass::Status MergeReturnPass::Process() {
         failed = true;
       }
     } else {
-      MergeReturnBlocks(function, return_blocks);
+      if (!MergeReturnBlocks(function, return_blocks)) {
+        failed = true;
+      }
     }
     return true;
   };
@@ -171,10 +173,14 @@ bool MergeReturnPass::ProcessStructured(
   return true;
 }
 
-void MergeReturnPass::CreateReturnBlock() {
+bool MergeReturnPass::CreateReturnBlock() {
   // Create a label for the new return block
+  uint32_t label_id = TakeNextId();
+  if (label_id == 0) {
+    return false;
+  }
   std::unique_ptr<Instruction> return_label(
-      new Instruction(context(), spv::Op::OpLabel, 0u, TakeNextId(), {}));
+      new Instruction(context(), spv::Op::OpLabel, 0u, label_id, {}));
 
   // Create the new basic block
   std::unique_ptr<BasicBlock> return_block(
@@ -186,14 +192,18 @@ void MergeReturnPass::CreateReturnBlock() {
                              final_return_block_);
   assert(final_return_block_->GetParent() == function_ &&
          "The function should have been set when the block was created.");
+  return true;
 }
 
-void MergeReturnPass::CreateReturn(BasicBlock* block) {
+bool MergeReturnPass::CreateReturn(BasicBlock* block) {
   AddReturnValue();
 
   if (return_value_) {
     // Load and return the final return value
     uint32_t loadId = TakeNextId();
+    if (loadId == 0) {
+      return false;
+    }
     block->AddInstruction(MakeUnique<Instruction>(
         context(), spv::Op::OpLoad, function_->type_id(), loadId,
         std::initializer_list<Operand>{
@@ -216,6 +226,7 @@ void MergeReturnPass::CreateReturn(BasicBlock* block) {
     context()->AnalyzeDefUse(block->terminator());
     context()->set_instr_block(block->terminator(), block);
   }
+  return true;
 }
 
 void MergeReturnPass::ProcessStructuredBlock(BasicBlock* block) {
@@ -663,14 +674,16 @@ std::vector<BasicBlock*> MergeReturnPass::CollectReturnBlocks(
   return return_blocks;
 }
 
-void MergeReturnPass::MergeReturnBlocks(
+bool MergeReturnPass::MergeReturnBlocks(
     Function* function, const std::vector<BasicBlock*>& return_blocks) {
   if (return_blocks.size() <= 1) {
     // No work to do.
-    return;
+    return true;
   }
 
-  CreateReturnBlock();
+  if (!CreateReturnBlock()) {
+    return false;
+  }
   uint32_t return_id = final_return_block_->id();
   auto ret_block_iter = --function->end();
   // Create the PHI for the merged block (if necessary).
@@ -687,6 +700,9 @@ void MergeReturnPass::MergeReturnBlocks(
   if (!phi_ops.empty()) {
     // Need a PHI node to select the correct return value.
     uint32_t phi_result_id = TakeNextId();
+    if (phi_result_id == 0) {
+      return false;
+    }
     uint32_t phi_type_id = function->type_id();
     std::unique_ptr<Instruction> phi_inst(new Instruction(
         context(), spv::Op::OpPhi, phi_type_id, phi_result_id, phi_ops));
@@ -718,6 +734,7 @@ void MergeReturnPass::MergeReturnBlocks(
   }
 
   get_def_use_mgr()->AnalyzeInstDefUse(ret_block_iter->GetLabelInst());
+  return true;
 }
 
 void MergeReturnPass::AddNewPhiNodes() {
@@ -781,8 +798,12 @@ void MergeReturnPass::InsertAfterElement(BasicBlock* element,
 }
 
 bool MergeReturnPass::AddSingleCaseSwitchAroundFunction() {
-  CreateReturnBlock();
-  CreateReturn(final_return_block_);
+  if (!CreateReturnBlock()) {
+    return false;
+  }
+  if (!CreateReturn(final_return_block_)) {
+    return false;
+  }
 
   if (context()->AreAnalysesValid(IRContext::kAnalysisCFG)) {
     cfg()->RegisterBlock(final_return_block_);

--- a/source/opt/merge_return_pass.h
+++ b/source/opt/merge_return_pass.h
@@ -149,8 +149,9 @@ class MergeReturnPass : public MemPass {
 
   // Creates a new basic block with a single return. If |function| returns a
   // value, a phi node is created to select the correct value to return.
-  // Replaces old returns with an unconditional branch to the new block.
-  void MergeReturnBlocks(Function* function,
+  // Replaces old returns with an unconditional branch to the new block. Returns
+  // true if successful.
+  bool MergeReturnBlocks(Function* function,
                          const std::vector<BasicBlock*>& returnBlocks);
 
   // Generate and push new control flow state if |block| contains a merge.
@@ -231,11 +232,12 @@ class MergeReturnPass : public MemPass {
 
   // Add an |OpReturn| or |OpReturnValue| to the end of |block|.  If an
   // |OpReturnValue| is needed, the return value is loaded from |return_value_|.
-  void CreateReturn(BasicBlock* block);
+  // Returns true if successful.
+  bool CreateReturn(BasicBlock* block);
 
   // Creates a block at the end of the function that will become the single
   // return block at the end of the pass.
-  void CreateReturnBlock();
+  bool CreateReturnBlock();
 
   // Creates a Phi node in |merge_block| for the result of |inst|.
   // Any uses of the result of |inst| that are no longer


### PR DESCRIPTION
The merge return pass can fail to create new basic blocks and
instructions if the module runs out of ids. This can lead to a crash.

This change modifies the pass to check if new ids can be created. If
not, the pass will be aborted for the current function.
