### PR TITLE
spirv-opt: Handle id overflow in strength reduction pass

### DIFF
--- a/source/opt/strength_reduction_pass.h
+++ b/source/opt/strength_reduction_pass.h
@@ -32,7 +32,7 @@ class StrengthReductionPass : public Pass {
  private:
   // Replaces multiple by power of 2 with an equivalent bit shift.
   // Returns true if something changed.
-  bool ReplaceMultiplyByPowerOf2(BasicBlock::iterator*);
+  Status ReplaceMultiplyByPowerOf2(BasicBlock::iterator*);
 
   // Scan the types and constants in the module looking for the integer
   // types that we are
@@ -47,7 +47,7 @@ class StrengthReductionPass : public Pass {
 
   // Replaces certain instructions in function bodies with presumably cheaper
   // ones. Returns true if something changed.
-  bool ScanFunctions();
+  Status ScanFunctions();
 
   // Type ids for the types of interest, or 0 if they do not exist.
   uint32_t int32_type_id_;


### PR DESCRIPTION
The strength reduction pass can fail to create new constants and
instructions if the module runs out of ids. This can lead to a crash.

This change modifies the pass to check if new ids can be created. If
not, the pass will be aborted and return a failure.
