### PR TITLE
spirv-opt: Run tests second time with lower max id bound

### DIFF
--- a/test/opt/pass_fixture.h
+++ b/test/opt/pass_fixture.h
@@ -75,6 +75,78 @@ class PassTest : public TestT {
         disassemble_options_(SpirvTools::kDefaultDisassembleOption),
         env_(SPV_ENV_UNIVERSAL_1_3) {}
 
+  // Runs the given |pass| on the given |context|. Returns a tuple of the
+  // optimized binary and the boolean value returned from pass Process()
+  // function.
+  std::tuple<std::vector<uint32_t>, Pass::Status> RunPassAndGetBinary(
+      Pass* pass, IRContext* context, bool skip_nop) {
+    context->set_preserve_bindings(OptimizerOptions()->preserve_bindings_);
+    context->set_preserve_spec_constants(
+        OptimizerOptions()->preserve_spec_constants_);
+
+    const auto status = pass->Run(context);
+
+    std::vector<uint32_t> binary;
+    if (status != Pass::Status::Failure) {
+      context->module()->ToBinary(&binary, skip_nop);
+    }
+    return std::make_tuple(binary, status);
+  }
+
+  // Runs a single pass of class |PassT| on the binary assembled from the
+  // |assembly|. Returns a tuple of the optimized binary and the boolean value
+  // from the pass Process() function.
+  template <typename PassT, typename... Args>
+  std::tuple<std::vector<uint32_t>, Pass::Status> SinglePassRunToBinary(
+      const std::string& assembly, bool skip_nop, Args&&... args) {
+    // Copy the arguments so they can be used to create two instances of the
+    // pass.
+    std::tuple<std::decay_t<Args>...> copied_args(std::forward<Args>(args)...);
+
+    auto pass = std::apply(
+        [&](const auto&... an_arg) { return MakeUnique<PassT>(an_arg...); },
+        copied_args);
+    pass->SetMessageConsumer(consumer_);
+
+    context_ = BuildModule(env_, consumer_, assembly, assemble_options_);
+    EXPECT_NE(nullptr, context()) << "Assembling failed for shader:\n"
+                                  << assembly << std::endl;
+    if (!context()) {
+      return std::make_tuple(std::vector<uint32_t>(), Pass::Status::Failure);
+    }
+
+    const uint32_t original_id_bound = context()->module()->id_bound();
+
+    auto result = RunPassAndGetBinary(pass.get(), context_.get(), skip_nop);
+
+    const uint32_t optimized_id_bound = context()->module()->id_bound();
+
+    // Second run (if needed) to test for id overflow.
+    if (std::get<1>(result) == Pass::Status::SuccessWithChange &&
+        original_id_bound < optimized_id_bound) {
+      auto null_message_consumer = [](spv_message_level_t, const char*,
+                                      const spv_position_t&, const char*) {};
+      std::unique_ptr<IRContext> context2 =
+          BuildModule(env_, null_message_consumer, assembly, assemble_options_);
+      EXPECT_NE(nullptr, context2)
+          << "Assembling failed for shader (2nd run):\n"
+          << assembly << std::endl;
+      if (context2) {
+        auto pass2 = std::apply(
+            [&](const auto&... an_arg) { return MakeUnique<PassT>(an_arg...); },
+            copied_args);
+        pass2->SetMessageConsumer(null_message_consumer);
+
+        const uint32_t new_bound = (original_id_bound + optimized_id_bound) / 2;
+        context2->set_max_id_bound(new_bound);
+
+        // We don't care about the status, just that it doesn't crash.
+        (void)RunPassAndGetBinary(pass2.get(), context2.get(), skip_nop);
+      }
+    }
+    return result;
+  }
+
   // Runs the given |pass| on the binary assembled from the |original|.
   // Returns a tuple of the optimized binary and the boolean value returned
   // from pass Process() function.
@@ -86,29 +158,7 @@ class PassTest : public TestT {
     if (!context()) {
       return std::make_tuple(std::vector<uint32_t>(), Pass::Status::Failure);
     }
-
-    context()->set_preserve_bindings(OptimizerOptions()->preserve_bindings_);
-    context()->set_preserve_spec_constants(
-        OptimizerOptions()->preserve_spec_constants_);
-
-    const auto status = pass->Run(context());
-
-    std::vector<uint32_t> binary;
-    if (status != Pass::Status::Failure) {
-      context()->module()->ToBinary(&binary, skip_nop);
-    }
-    return std::make_tuple(binary, status);
-  }
-
-  // Runs a single pass of class |PassT| on the binary assembled from the
-  // |assembly|. Returns a tuple of the optimized binary and the boolean value
-  // from the pass Process() function.
-  template <typename PassT, typename... Args>
-  std::tuple<std::vector<uint32_t>, Pass::Status> SinglePassRunToBinary(
-      const std::string& assembly, bool skip_nop, Args&&... args) {
-    auto pass = MakeUnique<PassT>(std::forward<Args>(args)...);
-    pass->SetMessageConsumer(consumer_);
-    return OptimizeToBinary(pass.get(), assembly, skip_nop);
+    return RunPassAndGetBinary(pass, context_.get(), skip_nop);
   }
 
   // Runs a single pass of class |PassT| on the binary assembled from the
@@ -152,31 +202,15 @@ class PassTest : public TestT {
   void SinglePassRunAndCheck(const std::string& original,
                              const std::string& expected, bool skip_nop,
                              bool do_validation, Args&&... args) {
-    std::vector<uint32_t> optimized_bin;
-    auto status = Pass::Status::SuccessWithoutChange;
-    std::tie(optimized_bin, status) = SinglePassRunToBinary<PassT>(
-        original, skip_nop, std::forward<Args>(args)...);
+    std::string optimized_asm;
+    Pass::Status status;
+    std::tie(optimized_asm, status) = SinglePassRunAndDisassemble<PassT>(
+        original, skip_nop, do_validation, std::forward<Args>(args)...);
+
     // Check whether the pass returns the correct modification indication.
     EXPECT_NE(Pass::Status::Failure, status);
     EXPECT_EQ(original == expected,
               status == Pass::Status::SuccessWithoutChange);
-    if (do_validation) {
-      spv_context spvContext = spvContextCreate(env_);
-      spv_diagnostic diagnostic = nullptr;
-      spv_const_binary_t binary = {optimized_bin.data(), optimized_bin.size()};
-      spv_result_t error = spvValidateWithOptions(
-          spvContext, ValidatorOptions(), &binary, &diagnostic);
-      EXPECT_EQ(error, 0);
-      if (error != 0) spvDiagnosticPrint(diagnostic);
-      spvDiagnosticDestroy(diagnostic);
-      spvContextDestroy(spvContext);
-    }
-    std::string optimized_asm;
-    SpirvTools tools(env_);
-    EXPECT_TRUE(
-        tools.Disassemble(optimized_bin, &optimized_asm, disassemble_options_))
-        << "Disassembling failed for shader:\n"
-        << original << std::endl;
     EXPECT_EQ(expected, optimized_asm);
   }
 


### PR DESCRIPTION
The SinglePassRunAndCheck function duplicated logic from
SinglePassRunAndDisassemble. This change refactors the former to call the
latter, simplifying the implementation and improving maintainability.

This allows us to have a central place where we can run tests a second
time with a lower id bound that will guarentee an id overflow. We can
test that the pass does not crash.

This does not necessarily cover all code paths, but should cover most.
