### PR TITLE
spirv-opt: Fail gracefully on ID overflow during spec constant folding

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -770,7 +770,7 @@ bool Instruction::IsFoldableByFoldScalar() const {
   // Even if the type of the instruction is foldable, its operands may not be
   // foldable (e.g., comparisons of 64bit types).  Check that all operand types
   // are foldable before accepting the instruction.
-  return WhileEachInOperand([&folder, this](const uint32_t* op_id) {
+  return WhileEachInId([&folder, this](const uint32_t* op_id) {
     Instruction* def_inst = context()->get_def_use_mgr()->GetDef(*op_id);
     Instruction* def_inst_type =
         context()->get_def_use_mgr()->GetDef(def_inst->type_id());
@@ -792,7 +792,7 @@ bool Instruction::IsFoldableByFoldVector() const {
   // Even if the type of the instruction is foldable, its operands may not be
   // foldable (e.g., comparisons of 64bit types).  Check that all operand types
   // are foldable before accepting the instruction.
-  return WhileEachInOperand([&folder, this](const uint32_t* op_id) {
+  return WhileEachInId([&folder, this](const uint32_t* op_id) {
     Instruction* def_inst = context()->get_def_use_mgr()->GetDef(*op_id);
     Instruction* def_inst_type =
         context()->get_def_use_mgr()->GetDef(def_inst->type_id());


### PR DESCRIPTION
The instruction folder returns nullptr when it fails to create a new
instruction due to ID overflow. This is ambiguous because it also
returns nullptr when it simply cannot fold an instruction.

This change introduces an `id_overflow_` flag in `IRContext` that is
set by `TakeNextId()` when it runs out of IDs.

The `FoldSpecConstantOpAndCompositePass` is updated to check this flag
after attempting to fold a spec constant. If the flag is set, the pass
returns `Status::Failure`, preventing further processing and providing a
clear error.
