### PR TITLE
spirv-opt: Propagate failures in loop transformations

### DIFF
--- a/source/fuzz/transformation_inline_function.cpp
+++ b/source/fuzz/transformation_inline_function.cpp
@@ -182,6 +182,8 @@ void TransformationInlineFunction::Apply(
     }
 
     auto* cloned_block = block.Clone(ir_context);
+    // TODO: Handle the nullptr.
+    assert(cloned_block);
     cloned_block = caller_function->InsertBasicBlockBefore(
         std::unique_ptr<opt::BasicBlock>(cloned_block), successor_block);
     cloned_block->GetLabel()->SetResultId(result_id_map.at(cloned_block->id()));

--- a/source/fuzz/transformation_outline_function.cpp
+++ b/source/fuzz/transformation_outline_function.cpp
@@ -819,6 +819,8 @@ void TransformationOutlineFunction::PopulateOutlinedFunction(
     // Clone the block so that it can be added to the new function.
     auto cloned_block =
         std::unique_ptr<opt::BasicBlock>(block_it->Clone(ir_context));
+    // TODO: Handle a nullptr.
+    assert(cloned_block);
 
     // If this is the region's exit block, then the cloned block is the outlined
     // region's exit block.

--- a/source/opt/cfg.cpp
+++ b/source/opt/cfg.cpp
@@ -254,12 +254,13 @@ BasicBlock* CFG::SplitLoopHeader(BasicBlock* bb) {
   }
 
   // Adjust the OpPhi instructions as needed.
-  bb->ForEachPhiInst([latch_block, bb, new_header, context](Instruction* phi) {
+  bool ok = bb->WhileEachPhiInst([latch_block, bb, new_header,
+                                  context](Instruction* phi) -> bool {
     std::vector<uint32_t> preheader_phi_ops;
     std::vector<Operand> header_phi_ops;
 
-    // Identify where the original inputs to original OpPhi belong: header or
-    // preheader.
+    // Identify where the original inputs to original OpPhi belong: header
+    // or preheader.
     for (uint32_t i = 0; i < phi->NumInOperands(); i += 2) {
       uint32_t def_id = phi->GetSingleWordInOperand(i);
       uint32_t branch_id = phi->GetSingleWordInOperand(i + 1);
@@ -272,22 +273,24 @@ BasicBlock* CFG::SplitLoopHeader(BasicBlock* bb) {
       }
     }
 
-    // Create a phi instruction if and only if the preheader_phi_ops has more
-    // than one pair.
+    // Create a phi instruction if and only if the preheader_phi_ops has
+    // more than one pair.
     if (preheader_phi_ops.size() > 2) {
       InstructionBuilder builder(
           context, &*bb->begin(),
           IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping);
 
-      // TODO(1841): Handle id overflow.
       Instruction* new_phi = builder.AddPhi(phi->type_id(), preheader_phi_ops);
+      if (!new_phi) {
+        return false;
+      }
 
       // Add the OpPhi to the header bb.
       header_phi_ops.push_back({SPV_OPERAND_TYPE_ID, {new_phi->result_id()}});
       header_phi_ops.push_back({SPV_OPERAND_TYPE_ID, {bb->id()}});
     } else {
-      // An OpPhi with a single entry is just a copy.  In this case use the same
-      // instruction in the new header.
+      // An OpPhi with a single entry is just a copy.  In this case use the
+      // same instruction in the new header.
       header_phi_ops.push_back({SPV_OPERAND_TYPE_ID, {preheader_phi_ops[0]}});
       header_phi_ops.push_back({SPV_OPERAND_TYPE_ID, {bb->id()}});
     }
@@ -298,7 +301,12 @@ BasicBlock* CFG::SplitLoopHeader(BasicBlock* bb) {
     new_header->begin()->InsertBefore(std::move(phi_owner));
     context->set_instr_block(phi, new_header);
     context->AnalyzeUses(phi);
+    return true;
   });
+
+  if (!ok) {
+    return nullptr;
+  }
 
   // Add a branch to the new header.
   InstructionBuilder branch_builder(

--- a/source/opt/function.cpp
+++ b/source/opt/function.cpp
@@ -40,6 +40,10 @@ Function* Function::Clone(IRContext* ctx) const {
   clone->blocks_.reserve(blocks_.size());
   for (const auto& b : blocks_) {
     std::unique_ptr<BasicBlock> bb(b->Clone(ctx));
+    if (!bb) {
+      delete clone;
+      return nullptr;
+    }
     clone->AddBasicBlock(std::move(bb));
   }
 

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -168,7 +168,13 @@ Instruction* Instruction::Clone(IRContext* c) const {
   clone->dbg_line_insts_ = dbg_line_insts_;
   for (auto& i : clone->dbg_line_insts_) {
     i.unique_id_ = c->TakeNextUniqueId();
-    if (i.IsDebugLineInst()) i.SetResultId(c->TakeNextId());
+    if (i.IsDebugLineInst()) {
+      uint32_t new_id = c->TakeNextId();
+      if (new_id == 0) {
+        return nullptr;
+      }
+      i.SetResultId(new_id);
+    }
   }
   clone->dbg_scope_ = dbg_scope_;
   return clone;
@@ -546,27 +552,37 @@ void Instruction::ClearDbgLineInsts() {
   clear_dbg_line_insts();
 }
 
-void Instruction::UpdateDebugInfoFrom(const Instruction* from,
+bool Instruction::UpdateDebugInfoFrom(const Instruction* from,
                                       const Instruction* line) {
-  if (from == nullptr) return;
+  if (from == nullptr) return true;
   ClearDbgLineInsts();
   const Instruction* fromLine = line != nullptr ? line : from;
-  if (!fromLine->dbg_line_insts().empty())
-    AddDebugLine(&fromLine->dbg_line_insts().back());
+  if (!fromLine->dbg_line_insts().empty()) {
+    if (!AddDebugLine(&fromLine->dbg_line_insts().back())) {
+      return false;
+    }
+  }
   SetDebugScope(from->GetDebugScope());
   if (!IsLineInst() &&
       context()->AreAnalysesValid(IRContext::kAnalysisDebugInfo)) {
     context()->get_debug_info_mgr()->AnalyzeDebugInst(this);
   }
+  return true;
 }
 
-void Instruction::AddDebugLine(const Instruction* inst) {
+bool Instruction::AddDebugLine(const Instruction* inst) {
   dbg_line_insts_.push_back(*inst);
   dbg_line_insts_.back().unique_id_ = context()->TakeNextUniqueId();
-  if (inst->IsDebugLineInst())
-    dbg_line_insts_.back().SetResultId(context_->TakeNextId());
+  if (inst->IsDebugLineInst()) {
+    uint32_t new_id = context()->TakeNextId();
+    if (new_id == 0) {
+      return false;
+    }
+    dbg_line_insts_.back().SetResultId(new_id);
+  }
   if (context()->AreAnalysesValid(IRContext::kAnalysisDefUse))
     context()->get_def_use_mgr()->AnalyzeInstDefUse(&dbg_line_insts_.back());
+  return true;
 }
 
 bool Instruction::IsDebugLineInst() const {

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -318,7 +318,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   inline void SetDebugScope(const DebugScope& scope);
   inline const DebugScope& GetDebugScope() const { return dbg_scope_; }
   // Add debug line inst. Renew result id if Debug[No]Line
-  void AddDebugLine(const Instruction* inst);
+  bool AddDebugLine(const Instruction* inst);
   // Updates DebugInlinedAt of DebugScope and OpLine.
   void UpdateDebugInlinedAt(uint32_t new_inlined_at);
   // Clear line-related debug instructions attached to this instruction
@@ -338,7 +338,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
   // Updates lexical scope of DebugScope and OpLine.
   void UpdateLexicalScope(uint32_t scope);
   // Updates OpLine and DebugScope based on the information of |from|.
-  void UpdateDebugInfoFrom(const Instruction* from,
+  bool UpdateDebugInfoFrom(const Instruction* from,
                            const Instruction* line = nullptr);
   // Remove the |index|-th operand
   void RemoveOperand(uint32_t index) {

--- a/source/opt/licm_pass.cpp
+++ b/source/opt/licm_pass.cpp
@@ -118,7 +118,6 @@ bool LICMPass::IsImmediatelyContainedInLoop(Loop* loop, Function* f,
 }
 
 bool LICMPass::HoistInstruction(Loop* loop, Instruction* inst) {
-  // TODO(1841): Handle failure to create pre-header.
   BasicBlock* pre_header_bb = loop->GetOrCreatePreHeaderBlock();
   if (!pre_header_bb) {
     return false;

--- a/source/opt/loop_descriptor.cpp
+++ b/source/opt/loop_descriptor.cpp
@@ -25,6 +25,7 @@
 #include "source/opt/dominator_tree.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/iterator.h"
+#include "source/opt/pass.h"
 #include "source/opt/tree_iterator.h"
 #include "source/util/make_unique.h"
 
@@ -278,6 +279,9 @@ BasicBlock* Loop::GetOrCreatePreHeaderBlock() {
 
   CFG* cfg = context_->cfg();
   loop_header_ = cfg->SplitLoopHeader(loop_header_);
+  if (loop_header_ == nullptr) {
+    return nullptr;
+  }
   return loop_preheader_;
 }
 
@@ -920,18 +924,19 @@ Instruction* Loop::FindConditionVariable(
   return induction;
 }
 
-bool LoopDescriptor::CreatePreHeaderBlocksIfMissing() {
-  auto modified = false;
+LoopDescriptor::Status LoopDescriptor::CreatePreHeaderBlocksIfMissing() {
+  bool modified = false;
 
   for (auto& loop : *this) {
     if (!loop.GetPreHeaderBlock()) {
+      if (!loop.GetOrCreatePreHeaderBlock()) {
+        return Status::kFailure;
+      }
       modified = true;
-      // TODO(1841): Handle failure to create pre-header.
-      loop.GetOrCreatePreHeaderBlock();
     }
   }
 
-  return modified;
+  return modified ? Status::kSuccessWithChange : Status::kSuccessWithoutChange;
 }
 
 // Add and remove loops which have been marked for addition and removal to

--- a/source/opt/loop_descriptor.h
+++ b/source/opt/loop_descriptor.h
@@ -425,6 +425,9 @@ class LoopDescriptor {
   using pre_iterator = TreeDFIterator<Loop>;
   using const_pre_iterator = TreeDFIterator<const Loop>;
 
+  // The status of processing a module.
+  enum class Status { kSuccessWithChange, kSuccessWithoutChange, kFailure };
+
   // Creates a loop object for all loops found in |f|.
   LoopDescriptor(IRContext* context, const Function* f);
 
@@ -506,9 +509,11 @@ class LoopDescriptor {
     loops_to_add_.emplace_back(std::make_pair(parent, std::move(loop_to_add)));
   }
 
-  // Checks all loops in |this| and will create pre-headers for all loops
-  // that don't have one. Returns |true| if any blocks were created.
-  bool CreatePreHeaderBlocksIfMissing();
+  // Creates pre-header blocks for all loops in the function that do not have
+  // one. Returns `LoopDescriptor::Status::kSuccessWithChange` if any change is
+  // made, `LoopDescriptor::Status::kSuccessWithoutChange` if no change is made,
+  // and `LoopDescriptor::Status::kFailure` if it fails to create a pre-header.
+  Status CreatePreHeaderBlocksIfMissing();
 
   // Should be called to preserve the LoopAnalysis after loops have been marked
   // for addition with AddLoop or MarkLoopForRemoval.

--- a/source/opt/loop_fusion_pass.cpp
+++ b/source/opt/loop_fusion_pass.cpp
@@ -22,23 +22,27 @@ namespace spvtools {
 namespace opt {
 
 Pass::Status LoopFusionPass::Process() {
-  bool modified = false;
+  Status status = Status::SuccessWithoutChange;
   Module* module = context()->module();
 
   // Process each function in the module
   for (Function& f : *module) {
-    modified |= ProcessFunction(&f);
+    status = CombineStatus(status, ProcessFunction(&f));
+    if (status == Status::Failure) return Status::Failure;
   }
 
-  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+  return status;
 }
 
-bool LoopFusionPass::ProcessFunction(Function* function) {
+Pass::Status LoopFusionPass::ProcessFunction(Function* function) {
   LoopDescriptor& ld = *context()->GetLoopDescriptor(function);
 
   // If a loop doesn't have a preheader needs then it needs to be created. Make
   // sure to return Status::SuccessWithChange in that case.
-  auto modified = ld.CreatePreHeaderBlocksIfMissing();
+  bool modified = false;
+  auto status = ld.CreatePreHeaderBlocksIfMissing();
+  if (status == LoopDescriptor::Status::kFailure) return Status::Failure;
+  modified = status == LoopDescriptor::Status::kSuccessWithChange;
 
   // TODO(tremmelg): Could the only loop that |loop| could possibly be fused be
   // picked out so don't have to check every loop
@@ -55,13 +59,13 @@ bool LoopFusionPass::ProcessFunction(Function* function) {
           fusion.Fuse();
           // Recurse, as the current iterators will have been invalidated.
           ProcessFunction(function);
-          return true;
+          return Status::SuccessWithChange;
         }
       }
     }
   }
 
-  return modified;
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
 }  // namespace opt

--- a/source/opt/loop_fusion_pass.h
+++ b/source/opt/loop_fusion_pass.h
@@ -39,7 +39,7 @@ class LoopFusionPass : public Pass {
  private:
   // Fuse loops in |function| if compatible, legal and the fused loop won't use
   // too many registers.
-  bool ProcessFunction(Function* function);
+  Status ProcessFunction(Function* function);
 
   // The maximum number of registers a fused loop is allowed to use.
   size_t max_registers_per_loop_;

--- a/source/opt/loop_peeling.cpp
+++ b/source/opt/loop_peeling.cpp
@@ -181,7 +181,6 @@ bool LoopPeeling::InsertCanonicalInductionVariable(
   // Create the increment.
   // Note that we do "1 + 1" here, one of the operand should the phi
   // value but we don't have it yet. The operand will be set latter.
-  // TODO(1841): Handle id overflow.
   Instruction* iv_inc = builder.AddIAdd(
       uint_1_cst->type_id(), uint_1_cst->result_id(), uint_1_cst->result_id());
   if (!iv_inc) return false;
@@ -459,7 +458,6 @@ bool LoopPeeling::PeelBefore(uint32_t peel_factor) {
       builder.GetIntConstant(peel_factor, int_type_->IsSigned());
   if (!factor) return false;
 
-  // TODO(1841): Handle id overflow.
   Instruction* has_remaining_iteration = builder.AddLessThan(
       factor->result_id(), loop_iteration_count_->result_id());
   if (!has_remaining_iteration) return false;
@@ -536,7 +534,6 @@ bool LoopPeeling::PeelAfter(uint32_t peel_factor) {
       builder.GetIntConstant(peel_factor, int_type_->IsSigned());
   if (!factor) return false;
 
-  // TODO(1841): Handle id overflow.
   Instruction* has_remaining_iteration = builder.AddLessThan(
       factor->result_id(), loop_iteration_count_->result_id());
   if (!has_remaining_iteration) return false;
@@ -567,11 +564,15 @@ bool LoopPeeling::PeelAfter(uint32_t peel_factor) {
   // factor < loop_iteration_count_.
 
   // The original loop's pre-header was the cloned loop merge block.
-  GetClonedLoop()->SetMergeBlock(
-      CreateBlockBefore(GetOriginalLoop()->GetPreHeaderBlock()));
-  if (!GetClonedLoop()->GetMergeBlock()) {
+  BasicBlock* pre_header = GetOriginalLoop()->GetPreHeaderBlock();
+  if (!pre_header) {
     return false;
   }
+  BasicBlock* new_merge_block = CreateBlockBefore(pre_header);
+  if (!new_merge_block) {
+    return false;
+  }
+  GetClonedLoop()->SetMergeBlock(new_merge_block);
   // Use the second loop preheader as if merge block.
 
   // Prevent the first loop if only the peeled loop needs it.
@@ -668,7 +669,9 @@ Pass::Status LoopPeelingPass::ProcessFunction(Function* f) {
     auto try_peel = [&loop_size, &modified, this](
                         Loop* loop_to_peel) -> std::pair<Pass::Status, Loop*> {
       if (!loop_to_peel->IsLCSSA()) {
-        LoopUtils(context(), loop_to_peel).MakeLoopClosedSSA();
+        if (!LoopUtils(context(), loop_to_peel).MakeLoopClosedSSA()) {
+          return {Pass::Status::Failure, nullptr};
+        }
       }
 
       Pass::Status status;

--- a/source/opt/loop_unroller.cpp
+++ b/source/opt/loop_unroller.cpp
@@ -178,7 +178,7 @@ class LoopUnrollerUtilsImpl {
 
   // Unroll the |loop| by given |factor| by copying the whole body |factor|
   // times. The resulting basicblock structure will remain a loop.
-  void PartiallyUnroll(Loop*, size_t factor);
+  bool PartiallyUnroll(Loop*, size_t factor);
 
   // If partially unrolling the |loop| would leave the loop with too many bodies
   // for its number of iterations then this method should be used. This method
@@ -186,12 +186,12 @@ class LoopUnrollerUtilsImpl {
   // successor of the original's merge block. The original loop will have its
   // condition changed to loop over the residual part and the duplicate will be
   // partially unrolled. The resulting structure will be two loops.
-  void PartiallyUnrollResidualFactor(Loop* loop, size_t factor);
+  bool PartiallyUnrollResidualFactor(Loop* loop, size_t factor);
 
   // Fully unroll the |loop| by copying the full body by the total number of
   // loop iterations, folding all conditions, and removing the backedge from the
   // continue block to the header.
-  void FullyUnroll(Loop* loop);
+  bool FullyUnroll(Loop* loop);
 
   // Get the ID of the variable in the |phi| paired with |label|.
   uint32_t GetPhiDefID(const Instruction* phi, uint32_t label) const;
@@ -203,7 +203,7 @@ class LoopUnrollerUtilsImpl {
   // Remove the OpConditionalBranch instruction inside |conditional_block| used
   // to branch to either exit or continue the loop and replace it with an
   // unconditional OpBranch to block |new_target|.
-  void FoldConditionBlock(BasicBlock* condtion_block, uint32_t new_target);
+  bool FoldConditionBlock(BasicBlock* condtion_block, uint32_t new_target);
 
   // Add all blocks_to_add_ to function_ at the |insert_point|.
   void AddBlocksToFunction(const BasicBlock* insert_point);
@@ -211,7 +211,7 @@ class LoopUnrollerUtilsImpl {
   // Duplicates the |old_loop|, cloning each body and remapping the ids without
   // removing instructions or changing relative structure. Result will be stored
   // in |new_loop|.
-  void DuplicateLoop(Loop* old_loop, Loop* new_loop);
+  bool DuplicateLoop(Loop* old_loop, Loop* new_loop);
 
   inline size_t GetLoopIterationCount() const {
     return number_of_loop_iterations_;
@@ -241,7 +241,7 @@ class LoopUnrollerUtilsImpl {
   // to old
   // ids. |loop| is used to identify special loop blocks (header, continue,
   // etc).
-  void AssignNewResultIds(BasicBlock* basic_block);
+  bool AssignNewResultIds(BasicBlock* basic_block);
 
   // Using the map built by AssignNewResultIds, replace the uses in |inst|
   // by the id that the use maps to.
@@ -258,18 +258,18 @@ class LoopUnrollerUtilsImpl {
   // the old |loop| continue block and the new body will link to the |loop|
   // header via the new continue block. |eliminate_conditions| is used to decide
   // whether or not to fold all the condition blocks other than the last one.
-  void CopyBody(Loop* loop, bool eliminate_conditions);
+  bool CopyBody(Loop* loop, bool eliminate_conditions);
 
   // Copy a given |block_to_copy| in the |loop| and record the mapping of the
   // old/new ids. |preserve_instructions| determines whether or not the method
   // will modify (other than result_id) instructions which are copied.
-  void CopyBasicBlock(Loop* loop, const BasicBlock* block_to_copy,
+  bool CopyBasicBlock(Loop* loop, const BasicBlock* block_to_copy,
                       bool preserve_instructions);
 
   // The actual implementation of the unroll step. Unrolls |loop| by given
   // |factor| by copying the body by |factor| times. Also propagates the
   // induction variable value throughout the copies.
-  void Unroll(Loop* loop, size_t factor);
+  bool Unroll(Loop* loop, size_t factor);
 
   // Fills the loop_blocks_inorder_ field with the ordered list of basic blocks
   // as computed by the method ComputeLoopOrderedBlocks.
@@ -376,11 +376,12 @@ void LoopUnrollerUtilsImpl::Init(Loop* loop) {
 // loop it creates two loops and unrolls one and adjusts the condition on the
 // other. The end result being that the new loop pair iterates over the correct
 // number of bodies.
-void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
+bool LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
                                                           size_t factor) {
-  // TODO(1841): Handle id overflow.
-  std::unique_ptr<Instruction> new_label{new Instruction(
-      context_, spv::Op::OpLabel, 0, context_->TakeNextId(), {})};
+  uint32_t new_label_id = context_->TakeNextId();
+  if (new_label_id == 0) return false;
+  std::unique_ptr<Instruction> new_label{
+      new Instruction(context_, spv::Op::OpLabel, 0, new_label_id, {})};
   std::unique_ptr<BasicBlock> new_exit_bb{new BasicBlock(std::move(new_label))};
   new_exit_bb->SetParent(&function_);
 
@@ -401,7 +402,9 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
   // Clear the basic blocks of the new loop.
   new_loop->ClearBlocks();
 
-  DuplicateLoop(loop, new_loop.get());
+  if (!DuplicateLoop(loop, new_loop.get())) {
+    return false;
+  }
 
   // Add the blocks to the function.
   AddBlocksToFunction(loop->GetMergeBlock());
@@ -416,7 +419,9 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
   loop_induction_variable_ = state_.new_phi;
   // Unroll the new loop by the factor with the usual -1 to account for the
   // existing block iteration.
-  Unroll(new_loop.get(), factor);
+  if (!Unroll(new_loop.get(), factor)) {
+    return false;
+  }
 
   LinkLastPhisToStart(new_loop.get());
   AddBlocksToLoop(new_loop.get());
@@ -460,6 +465,10 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
     new_constant = builder.GetUintConstant(static_cast<int32_t>(remainder));
   }
 
+  if (!new_constant) {
+    return false;
+  }
+
   uint32_t constant_id = new_constant->result_id();
 
   // Update the condition check.
@@ -477,6 +486,9 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
   for (size_t index = 0; index < new_inductions.size(); ++index) {
     Instruction* new_induction = new_inductions[index];
     Instruction* old_induction = old_inductions[index];
+    if (!new_induction || !old_induction) {
+      return false;
+    }
     // Get the index of the loop initalizer, the value coming in from the
     // preheader.
     uint32_t initalizer_index =
@@ -512,6 +524,7 @@ void LoopUnrollerUtilsImpl::PartiallyUnrollResidualFactor(Loop* loop,
   loop_descriptor.AddLoop(std::move(new_loop), loop->GetParent());
 
   RemoveDeadInstructions();
+  return true;
 }
 
 // Mark this loop as DontUnroll as it will already be unrolled and it may not
@@ -528,7 +541,7 @@ void LoopUnrollerUtilsImpl::MarkLoopControlAsDontUnroll(Loop* loop) const {
 // Duplicate the |loop| body |factor| - 1 number of times while keeping the loop
 // backedge intact. This will leave the loop with |factor| number of bodies
 // after accounting for the initial body.
-void LoopUnrollerUtilsImpl::Unroll(Loop* loop, size_t factor) {
+bool LoopUnrollerUtilsImpl::Unroll(Loop* loop, size_t factor) {
   // If we unroll a loop partially it will not be safe to unroll it further.
   // This is due to the current method of calculating the number of loop
   // iterations.
@@ -539,8 +552,11 @@ void LoopUnrollerUtilsImpl::Unroll(Loop* loop, size_t factor) {
   state_ = LoopUnrollState{loop_induction_variable_, loop->GetLatchBlock(),
                            loop_condition_block_, std::move(inductions)};
   for (size_t i = 0; i < factor - 1; ++i) {
-    CopyBody(loop, true);
+    if (!CopyBody(loop, true)) {
+      return false;
+    }
   }
+  return true;
 }
 
 void LoopUnrollerUtilsImpl::RemoveDeadInstructions() {
@@ -573,12 +589,16 @@ void LoopUnrollerUtilsImpl::ReplaceInductionUseWithFinalValue(Loop* loop) {
 
 // Fully unroll the loop by partially unrolling it by the number of loop
 // iterations minus one for the body already accounted for.
-void LoopUnrollerUtilsImpl::FullyUnroll(Loop* loop) {
+bool LoopUnrollerUtilsImpl::FullyUnroll(Loop* loop) {
   // We unroll the loop by number of iterations in the loop.
-  Unroll(loop, number_of_loop_iterations_);
+  if (!Unroll(loop, number_of_loop_iterations_)) {
+    return false;
+  }
 
   // The first condition block is preserved until now so it can be copied.
-  FoldConditionBlock(loop_condition_block_, 1);
+  if (!FoldConditionBlock(loop_condition_block_, 1)) {
+    return false;
+  }
 
   // Delete the OpLoopMerge and remove the backedge to the header.
   CloseUnrolledLoop(loop);
@@ -602,6 +622,7 @@ void LoopUnrollerUtilsImpl::FullyUnroll(Loop* loop) {
   context_->InvalidateAnalysesExceptFor(
       IRContext::Analysis::kAnalysisLoopAnalysis |
       IRContext::Analysis::kAnalysisDefUse);
+  return true;
 }
 
 void LoopUnrollerUtilsImpl::KillDebugDeclares(BasicBlock* bb) {
@@ -622,10 +643,11 @@ void LoopUnrollerUtilsImpl::KillDebugDeclares(BasicBlock* bb) {
 // and the id mapping in the state. |preserve_instructions| is used to determine
 // whether or not this function should edit instructions other than the
 // |result_id|.
-void LoopUnrollerUtilsImpl::CopyBasicBlock(Loop* loop, const BasicBlock* itr,
+bool LoopUnrollerUtilsImpl::CopyBasicBlock(Loop* loop, const BasicBlock* itr,
                                            bool preserve_instructions) {
   // Clone the block exactly, including the IDs.
   BasicBlock* basic_block = itr->Clone(context_);
+  if (!basic_block) return false;
   basic_block->SetParent(itr->GetParent());
 
   // We do not want to duplicate DebugDeclare.
@@ -633,7 +655,9 @@ void LoopUnrollerUtilsImpl::CopyBasicBlock(Loop* loop, const BasicBlock* itr,
 
   // Assign each result a new unique ID and keep a mapping of the old ids to
   // the new ones.
-  AssignNewResultIds(basic_block);
+  if (!AssignNewResultIds(basic_block)) {
+    return false;
+  }
 
   // If this is the continue block we are copying.
   if (itr == loop->GetContinueBlock()) {
@@ -672,13 +696,16 @@ void LoopUnrollerUtilsImpl::CopyBasicBlock(Loop* loop, const BasicBlock* itr,
 
   // Keep tracking the old block via a map.
   state_.new_blocks[itr->id()] = basic_block;
+  return true;
 }
 
-void LoopUnrollerUtilsImpl::CopyBody(Loop* loop, bool eliminate_conditions) {
+bool LoopUnrollerUtilsImpl::CopyBody(Loop* loop, bool eliminate_conditions) {
   // Copy each basic block in the loop, give them new ids, and save state
   // information.
   for (const BasicBlock* itr : loop_blocks_inorder_) {
-    CopyBasicBlock(loop, itr, false);
+    if (!CopyBasicBlock(loop, itr, false)) {
+      return false;
+    }
   }
 
   // Set the previous latch block to point to the new header.
@@ -717,7 +744,9 @@ void LoopUnrollerUtilsImpl::CopyBody(Loop* loop, bool eliminate_conditions) {
 
   if (eliminate_conditions &&
       state_.new_condition_block != loop_condition_block_) {
-    FoldConditionBlock(state_.new_condition_block, 1);
+    if (!FoldConditionBlock(state_.new_condition_block, 1)) {
+      return false;
+    }
   }
 
   // Only reference to the header block is the backedge in the latch block,
@@ -733,6 +762,7 @@ void LoopUnrollerUtilsImpl::CopyBody(Loop* loop, bool eliminate_conditions) {
 
   // Swap the state so the new is now the previous.
   state_.NextIterationState();
+  return true;
 }
 
 uint32_t LoopUnrollerUtilsImpl::GetPhiDefID(const Instruction* phi,
@@ -746,7 +776,7 @@ uint32_t LoopUnrollerUtilsImpl::GetPhiDefID(const Instruction* phi,
   return 0;
 }
 
-void LoopUnrollerUtilsImpl::FoldConditionBlock(BasicBlock* condition_block,
+bool LoopUnrollerUtilsImpl::FoldConditionBlock(BasicBlock* condition_block,
                                                uint32_t operand_label) {
   // Remove the old conditional branch to the merge and continue blocks.
   Instruction& old_branch = *condition_block->tail();
@@ -763,8 +793,13 @@ void LoopUnrollerUtilsImpl::FoldConditionBlock(BasicBlock* condition_block,
           IRContext::Analysis::kAnalysisInstrToBlockMapping);
   Instruction* new_branch = builder.AddBranch(new_target);
 
-  if (!lines.empty()) new_branch->AddDebugLine(&lines.back());
+  if (!lines.empty()) {
+    if (!new_branch->AddDebugLine(&lines.back())) {
+      return false;
+    }
+  }
   new_branch->SetDebugScope(scope);
+  return true;
 }
 
 void LoopUnrollerUtilsImpl::CloseUnrolledLoop(Loop* loop) {
@@ -811,19 +846,24 @@ void LoopUnrollerUtilsImpl::CloseUnrolledLoop(Loop* loop) {
 }
 
 // Uses the first loop to create a copy of the loop with new IDs.
-void LoopUnrollerUtilsImpl::DuplicateLoop(Loop* old_loop, Loop* new_loop) {
+bool LoopUnrollerUtilsImpl::DuplicateLoop(Loop* old_loop, Loop* new_loop) {
   std::vector<BasicBlock*> new_block_order;
 
   // Copy every block in the old loop.
   for (const BasicBlock* itr : loop_blocks_inorder_) {
-    CopyBasicBlock(old_loop, itr, true);
+    if (!CopyBasicBlock(old_loop, itr, true)) {
+      return false;
+    }
     new_block_order.push_back(blocks_to_add_.back().get());
   }
 
   // Clone the merge block, give it a new id and record it in the state.
   BasicBlock* new_merge = old_loop->GetMergeBlock()->Clone(context_);
+  if (!new_merge) return false;
   new_merge->SetParent(old_loop->GetMergeBlock()->GetParent());
-  AssignNewResultIds(new_merge);
+  if (!AssignNewResultIds(new_merge)) {
+    return false;
+  }
   state_.new_blocks[old_loop->GetMergeBlock()->id()] = new_merge;
 
   // Remap the operands of every instruction in the loop to point to the new
@@ -840,6 +880,7 @@ void LoopUnrollerUtilsImpl::DuplicateLoop(Loop* old_loop, Loop* new_loop) {
   new_loop->SetContinueBlock(state_.new_continue_block);
   new_loop->SetLatchBlock(state_.new_latch_block);
   new_loop->SetMergeBlock(new_merge);
+  return true;
 }
 
 // Whenever the utility copies a block it stores it in a temporary buffer, this
@@ -862,13 +903,15 @@ void LoopUnrollerUtilsImpl::AddBlocksToFunction(
 
 // Assign all result_ids in |basic_block| instructions to new IDs and preserve
 // the mapping of new ids to old ones.
-void LoopUnrollerUtilsImpl::AssignNewResultIds(BasicBlock* basic_block) {
+bool LoopUnrollerUtilsImpl::AssignNewResultIds(BasicBlock* basic_block) {
   analysis::DefUseManager* def_use_mgr = context_->get_def_use_mgr();
 
   // Label instructions aren't covered by normal traversal of the
   // instructions.
-  // TODO(1841): Handle id overflow.
   uint32_t new_label_id = context_->TakeNextId();
+  if (new_label_id == 0) {
+    return false;
+  }
 
   // Assign a new id to the label.
   state_.new_inst[basic_block->GetLabelInst()->result_id()] = new_label_id;
@@ -888,8 +931,11 @@ void LoopUnrollerUtilsImpl::AssignNewResultIds(BasicBlock* basic_block) {
     }
 
     // Give the instruction a new id.
-    // TODO(1841): Handle id overflow.
-    inst.SetResultId(context_->TakeNextId());
+    uint32_t new_id = context_->TakeNextId();
+    if (new_id == 0) {
+      return false;
+    }
+    inst.SetResultId(new_id);
     def_use_mgr->AnalyzeInstDef(&inst);
 
     // Save the mapping of old_id -> new_id.
@@ -901,6 +947,7 @@ void LoopUnrollerUtilsImpl::AssignNewResultIds(BasicBlock* basic_block) {
     }
     state_.ids_to_new_inst[inst.result_id()] = &inst;
   }
+  return true;
 }
 
 void LoopUnrollerUtilsImpl::RemapOperands(Instruction* inst) {
@@ -961,12 +1008,13 @@ void LoopUnrollerUtilsImpl::LinkLastPhisToStart(Loop* loop) const {
 
 // Duplicate the |loop| body |factor| number of times while keeping the loop
 // backedge intact.
-void LoopUnrollerUtilsImpl::PartiallyUnroll(Loop* loop, size_t factor) {
-  Unroll(loop, factor);
+bool LoopUnrollerUtilsImpl::PartiallyUnroll(Loop* loop, size_t factor) {
+  if (!Unroll(loop, factor)) return false;
   LinkLastPhisToStart(loop);
   AddBlocksToLoop(loop);
   AddBlocksToFunction(loop->GetMergeBlock());
   RemoveDeadInstructions();
+  return true;
 }
 
 /*
@@ -1071,7 +1119,9 @@ bool LoopUtils::PartiallyUnroll(size_t factor) {
   // If the unrolling factor is larger than or the same size as the loop just
   // fully unroll the loop.
   if (factor >= unroller.GetLoopIterationCount()) {
-    unroller.FullyUnroll(loop_);
+    if (!unroller.FullyUnroll(loop_)) {
+      return false;
+    }
     return true;
   }
 
@@ -1080,9 +1130,13 @@ bool LoopUtils::PartiallyUnroll(size_t factor) {
   // remaining part. We add one when calucating the remainder to take into
   // account the one iteration already in the loop.
   if (unroller.GetLoopIterationCount() % factor != 0) {
-    unroller.PartiallyUnrollResidualFactor(loop_, factor);
+    if (!unroller.PartiallyUnrollResidualFactor(loop_, factor)) {
+      return false;
+    }
   } else {
-    unroller.PartiallyUnroll(loop_, factor);
+    if (!unroller.PartiallyUnroll(loop_, factor)) {
+      return false;
+    }
   }
 
   return true;
@@ -1098,7 +1152,9 @@ bool LoopUtils::FullyUnroll() {
                                  loop_->GetHeaderBlock()->GetParent()};
 
   unroller.Init(loop_);
-  unroller.FullyUnroll(loop_);
+  if (!unroller.FullyUnroll(loop_)) {
+    return false;
+  }
 
   return true;
 }
@@ -1131,13 +1187,23 @@ Pass::Status LoopUnroller::Process() {
       }
 
       if (fully_unroll_) {
-        loop_utils.FullyUnroll();
+        if (!loop_utils.FullyUnroll()) {
+          return Status::Failure;
+        }
+        changed = true;
       } else {
-        loop_utils.PartiallyUnroll(unroll_factor_);
+        if (!loop_utils.PartiallyUnroll(unroll_factor_)) {
+          return Status::Failure;
+        }
+        changed = true;
       }
-      changed = true;
     }
     LD->PostModificationCleanup();
+  }
+
+  if (changed) {
+    context()->InvalidateAnalysesExceptFor(
+        IRContext::Analysis::kAnalysisLoopAnalysis);
   }
 
   return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/loop_unswitch_pass.cpp
+++ b/source/opt/loop_unswitch_pass.cpp
@@ -623,7 +623,9 @@ Pass::Status LoopUnswitchPass::ProcessFunction(Function* f) {
       LoopUnswitch unswitcher(context(), f, &loop, &loop_descriptor);
       while (unswitcher.CanUnswitchLoop()) {
         if (!loop.IsLCSSA()) {
-          LoopUtils(context(), &loop).MakeLoopClosedSSA();
+          if (!LoopUtils(context(), &loop).MakeLoopClosedSSA()) {
+            return Status::Failure;
+          }
         }
         if (!unswitcher.PerformUnswitch()) {
           return Status::Failure;

--- a/source/opt/loop_utils.cpp
+++ b/source/opt/loop_utils.cpp
@@ -68,7 +68,7 @@ class LCSSARewriter {
     // block. This operation does not update the def/use manager, instead it
     // records what needs to be updated. The actual update is performed by
     // UpdateManagers.
-    void RewriteUse(BasicBlock* bb, Instruction* user, uint32_t operand_index) {
+    bool RewriteUse(BasicBlock* bb, Instruction* user, uint32_t operand_index) {
       assert(
           (user->opcode() != spv::Op::OpPhi || bb != GetParent(user)) &&
           "The root basic block must be the incoming edge if |user| is a phi "
@@ -79,9 +79,13 @@ class LCSSARewriter {
              "phi instruction");
 
       Instruction* new_def = GetOrBuildIncoming(bb->id());
+      if (!new_def) {
+        return false;
+      }
 
       user->SetOperand(operand_index, {new_def->result_id()});
       rewritten_.insert(user);
+      return true;
     }
 
     // In-place update of some managers (avoid full invalidation).
@@ -118,9 +122,11 @@ class LCSSARewriter {
       }
       InstructionBuilder builder(base_->context_, &*bb->begin(),
                                  IRContext::kAnalysisInstrToBlockMapping);
-      // TODO(1841): Handle id overflow.
       Instruction* incoming_phi =
           builder.AddPhi(def_insn_.type_id(), incomings);
+      if (!incoming_phi) {
+        return nullptr;
+      }
 
       rewritten_.insert(incoming_phi);
       return incoming_phi;
@@ -138,9 +144,11 @@ class LCSSARewriter {
       }
       InstructionBuilder builder(base_->context_, &*bb->begin(),
                                  IRContext::kAnalysisInstrToBlockMapping);
-      // TODO(1841): Handle id overflow.
       Instruction* incoming_phi =
           builder.AddPhi(def_insn_.type_id(), incomings);
+      if (!incoming_phi) {
+        return nullptr;
+      }
 
       rewritten_.insert(incoming_phi);
       return incoming_phi;
@@ -272,7 +280,7 @@ class LCSSARewriter {
 // Make the set |blocks| closed SSA. The set is closed SSA if all the uses
 // outside the set are phi instructions in exiting basic block set (hold by
 // |lcssa_rewriter|).
-inline void MakeSetClosedSSA(IRContext* context, Function* function,
+inline bool MakeSetClosedSSA(IRContext* context, Function* function,
                              const std::unordered_set<uint32_t>& blocks,
                              const std::unordered_set<BasicBlock*>& exit_bb,
                              LCSSARewriter* lcssa_rewriter) {
@@ -287,18 +295,18 @@ inline void MakeSetClosedSSA(IRContext* context, Function* function,
     if (!DominatesAnExit(bb, exit_bb, dom_tree)) continue;
     for (Instruction& inst : *bb) {
       LCSSARewriter::UseRewriter rewriter(lcssa_rewriter, inst);
-      def_use_manager->ForEachUse(
+      bool success = def_use_manager->WhileEachUse(
           &inst, [&blocks, &rewriter, &exit_bb, context](
                      Instruction* use, uint32_t operand_index) {
             BasicBlock* use_parent = context->get_instr_block(use);
             assert(use_parent);
-            if (blocks.count(use_parent->id())) return;
+            if (blocks.count(use_parent->id())) return true;
 
             if (use->opcode() == spv::Op::OpPhi) {
               // If the use is a Phi instruction and the incoming block is
               // coming from the loop, then that's consistent with LCSSA form.
               if (exit_bb.count(use_parent)) {
-                return;
+                return true;
               } else {
                 // That's not an exit block, but the user is a phi instruction.
                 // Consider the incoming branch only.
@@ -308,16 +316,20 @@ inline void MakeSetClosedSSA(IRContext* context, Function* function,
             }
             // Rewrite the use. Note that this call does not invalidate the
             // def/use manager. So this operation is safe.
-            rewriter.RewriteUse(use_parent, use, operand_index);
+            return rewriter.RewriteUse(use_parent, use, operand_index);
           });
+      if (!success) {
+        return false;
+      }
       rewriter.UpdateManagers();
     }
   }
+  return true;
 }
 
 }  // namespace
 
-void LoopUtils::CreateLoopDedicatedExits() {
+bool LoopUtils::CreateLoopDedicatedExits() {
   Function* function = loop_->GetHeaderBlock()->GetParent();
   LoopDescriptor& loop_desc = *context_->GetLoopDescriptor(function);
   CFG& cfg = *context_->cfg();
@@ -353,10 +365,13 @@ void LoopUtils::CreateLoopDedicatedExits() {
     assert(insert_pt != function->end() && "Basic Block not found");
 
     // Create the dedicate exit basic block.
-    // TODO(1841): Handle id overflow.
-    BasicBlock& exit = *insert_pt.InsertBefore(std::unique_ptr<BasicBlock>(
-        new BasicBlock(std::unique_ptr<Instruction>(new Instruction(
-            context_, spv::Op::OpLabel, 0, context_->TakeNextId(), {})))));
+    uint32_t exit_id = context_->TakeNextId();
+    if (exit_id == 0) {
+      return false;
+    }
+    BasicBlock& exit = *insert_pt.InsertBefore(
+        std::unique_ptr<BasicBlock>(new BasicBlock(std::unique_ptr<Instruction>(
+            new Instruction(context_, spv::Op::OpLabel, 0, exit_id, {})))));
     exit.SetParent(function);
 
     // Redirect in loop predecessors to |exit| block.
@@ -382,7 +397,7 @@ void LoopUtils::CreateLoopDedicatedExits() {
     // We also reset the insert point so all instructions are inserted before
     // the branch.
     builder.SetInsertPoint(builder.AddBranch(non_dedicate->id()));
-    non_dedicate->ForEachPhiInst(
+    bool succeeded = non_dedicate->WhileEachPhiInst(
         [&builder, &exit, def_use_mgr, this](Instruction* phi) {
           // New phi operands for this instruction.
           std::vector<uint32_t> new_phi_op;
@@ -401,8 +416,10 @@ void LoopUtils::CreateLoopDedicatedExits() {
           }
 
           // Build the new phi instruction dedicated exit block.
-          // TODO(1841): Handle id overflow.
           Instruction* exit_phi = builder.AddPhi(phi->type_id(), exit_phi_op);
+          if (!exit_phi) {
+            return false;
+          }
           // Build the new incoming branch.
           new_phi_op.push_back(exit_phi->result_id());
           new_phi_op.push_back(exit.id());
@@ -415,7 +432,9 @@ void LoopUtils::CreateLoopDedicatedExits() {
             phi->RemoveInOperand(j);
           // Update the def/use manager for this |phi|.
           def_use_mgr->AnalyzeInstUse(phi);
+          return true;
         });
+    if (!succeeded) return false;
     // Update the CFG.
     cfg.RegisterBlock(&exit);
     cfg.RemoveNonExistingEdges(non_dedicate->id());
@@ -434,10 +453,13 @@ void LoopUtils::CreateLoopDedicatedExits() {
         PreservedAnalyses | IRContext::kAnalysisCFG |
         IRContext::Analysis::kAnalysisLoopAnalysis);
   }
+  return true;
 }
 
-void LoopUtils::MakeLoopClosedSSA() {
-  CreateLoopDedicatedExits();
+bool LoopUtils::MakeLoopClosedSSA() {
+  if (!CreateLoopDedicatedExits()) {
+    return false;
+  }
 
   Function* function = loop_->GetHeaderBlock()->GetParent();
   CFG& cfg = *context_->cfg();
@@ -455,8 +477,10 @@ void LoopUtils::MakeLoopClosedSSA() {
 
   LCSSARewriter lcssa_rewriter(context_, dom_tree, exit_bb,
                                loop_->GetMergeBlock());
-  MakeSetClosedSSA(context_, function, loop_->GetBlocks(), exit_bb,
-                   &lcssa_rewriter);
+  if (!MakeSetClosedSSA(context_, function, loop_->GetBlocks(), exit_bb,
+                        &lcssa_rewriter)) {
+    return false;
+  }
 
   // Make sure all defs post-dominated by the merge block have their last use no
   // further than the merge block.
@@ -469,14 +493,17 @@ void LoopUtils::MakeLoopClosedSSA() {
     exit_bb.insert(loop_->GetMergeBlock());
     // LCSSARewriter is reusable here only because it forces the creation of a
     // phi instruction in the merge block.
-    MakeSetClosedSSA(context_, function, merging_bb_id, exit_bb,
-                     &lcssa_rewriter);
+    if (!MakeSetClosedSSA(context_, function, merging_bb_id, exit_bb,
+                          &lcssa_rewriter)) {
+      return false;
+    }
   }
 
   context_->InvalidateAnalysesExceptFor(
       IRContext::Analysis::kAnalysisCFG |
       IRContext::Analysis::kAnalysisDominatorAnalysis |
       IRContext::Analysis::kAnalysisLoopAnalysis);
+  return true;
 }
 
 Loop* LoopUtils::CloneLoop(LoopCloningResult* cloning_result) const {
@@ -572,6 +599,7 @@ Loop* LoopUtils::CloneLoop(
     // For each basic block in the loop, we clone it and register the mapping
     // between old and new ids.
     BasicBlock* new_bb = old_bb->Clone(context_);
+    if (!new_bb) return nullptr;
     new_bb->SetParent(&function_);
     uint32_t new_label_id = context_->TakeNextId();
     if (new_label_id == 0) {

--- a/source/opt/loop_utils.h
+++ b/source/opt/loop_utils.h
@@ -95,14 +95,14 @@ class LoopUtils {
   //
   // This makes some loop transformations (such as loop unswitch) simpler
   // (removes the needs to take care of exiting variables).
-  void MakeLoopClosedSSA();
+  bool MakeLoopClosedSSA();
 
   // Create dedicate exit basic block. This ensure all exit basic blocks has the
   // loop as sole predecessors.
   // By construction, structured control flow already has a dedicated exit
   // block.
   // Preserves: CFG, def/use and instruction to block mapping.
-  void CreateLoopDedicatedExits();
+  bool CreateLoopDedicatedExits();
 
   // Clone |loop_| and remap its instructions. Newly created blocks
   // will be added to the |cloning_result.cloned_bb_| list, correctly ordered to

--- a/test/opt/loop_optimizations/fusion_legal.cpp
+++ b/test/opt/loop_optimizations/fusion_legal.cpp
@@ -3415,7 +3415,8 @@ TEST_F(FusionLegalTest, DifferentArraysInLoopsNoPreheader) {
       EXPECT_FALSE(fusion.AreCompatible());
     }
 
-    ld.CreatePreHeaderBlocksIfMissing();
+    auto status = ld.CreatePreHeaderBlocksIfMissing();
+    EXPECT_NE(status, LoopDescriptor::Status::kFailure);
 
     {
       LoopFusion fusion(context.get(), loops[0], loops[1]);
@@ -3588,7 +3589,8 @@ TEST_F(FusionLegalTest, AdjacentLoopsNoPreheaders) {
       EXPECT_FALSE(fusion.AreCompatible());
     }
 
-    ld.CreatePreHeaderBlocksIfMissing();
+    auto status = ld.CreatePreHeaderBlocksIfMissing();
+    EXPECT_NE(status, LoopDescriptor::Status::kFailure);
 
     {
       LoopFusion fusion(context.get(), loops[0], loops[1]);


### PR DESCRIPTION
This CL modifies several loop transformation passes and their utility
functions to propagate failures, primarily caused by ID overflows when
creating new instructions or basic blocks.

Many functions that previously had a void return type now return a bool
or a status enum to indicate success or failure. The callers are updated
to check these return values and abort the transformation if a failure
occurs.

This affects loop unrolling, peeling, fusion, unswitching, and LICM,
as well as core IR cloning and manipulation functions.

The fuzzer transformations for inlining and outlining also get assertions
to detect cloning failures.
