### PR TITLE
spirv-opt: Add robust error handling to AmdExtensionToKhrPass

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -462,7 +462,8 @@ const Constant* ConstantManager::GetNumericVectorConstantWithWords(
 
 uint32_t ConstantManager::GetFloatConstId(float val) {
   const Constant* c = GetFloatConst(val);
-  return GetDefiningInstruction(c)->result_id();
+  Instruction* c_inst = GetDefiningInstruction(c);
+  return c_inst ? c_inst->result_id() : 0;
 }
 
 const Constant* ConstantManager::GetFloatConst(float val) {

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -913,11 +913,12 @@ uint32_t IRContext::GetBuiltinInputVarId(uint32_t builtin) {
         return 0;
       }
     }
+    if (!reg_type) return 0;
     uint32_t type_id = type_mgr->GetTypeInstruction(reg_type);
     uint32_t varTyPtrId =
         type_mgr->FindPointerToType(type_id, spv::StorageClass::Input);
-    // TODO(1841): Handle id overflow.
     var_id = TakeNextId();
+    if (var_id == 0) return 0;
     std::unique_ptr<Instruction> newVarOp(
         new Instruction(this, spv::Op::OpVariable, varTyPtrId, var_id,
                         {{spv_operand_type_t::SPV_OPERAND_TYPE_LITERAL_INTEGER,

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -208,6 +208,9 @@ void TypeManager::RemoveId(uint32_t id) {
 }
 
 uint32_t TypeManager::GetTypeInstruction(const Type* type) {
+  if (!type) {
+    return 0;
+  }
   uint32_t id = GetId(type);
   if (id != 0) return id;
 


### PR DESCRIPTION
The AmdExtensionToKhrPass previously lacked sufficient error checking when
creating new instructions and constants. This could lead to crashes or
undefined behavior when processing invalid or unexpected SPIR-V modules.

This commit introduces comprehensive error handling throughout the pass:

- Folding functions now return a `FoldingRule` and use a boolean flag to signal
  success or failure, allowing the pass to gracefully abort on error.
- Added null checks after creating new instructions, constants, and types to
  ensure validity before use.
- The pass now returns `Status::Failure` if any operation fails, providing a
  clear signal to the optimizer.
- Changed the instruction iteration to `WhileEachInst` to allow early
  termination on failure.

These changes make the AmdExtensionToKhrPass more robust and prevents crashes on
invalid SPIR-V.
