### PR TITLE
[tools/val] fix u8str for real this time

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -60,7 +60,6 @@ def _merge_dicts(dicts):
         merged.update(d)
     return merged
 
-
 def ExtInst(name, target = "", prefix = ""):
     """
     Returns a dictionary specifying the info needed to
@@ -77,7 +76,6 @@ def ExtInst(name, target = "", prefix = ""):
     corresponding values.
     """
     return {"name": name, "target": target, "prefix": prefix}
-
 
 def _extinst_grammar_target(e):
     """

--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -273,7 +273,7 @@ int main(int argc, char** argv) {
       const auto filepath_u8str = filepath.u8string();
       const std::string filepath_str(filepath_u8str.begin(),
                                      filepath_u8str.end());
-      if (!process_single_file(filepath.u8string().c_str(), target_env, options,
+      if (!process_single_file(filepath_str.c_str(), target_env, options,
                                false)) {
         succeed = false;
       }


### PR DESCRIPTION
Really fix the problem from #6336
Actually use the std::string filepath when calling the helper function.

Also, remove spurious blank lines from build_defs.bzl. Google's internal linter complains about them.