### PR TITLE
spirv-val: Break up the 3000 line ValidateExtInst function

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1118,1536 +1118,1741 @@ spv_result_t ValidateExtInstImport(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
+spv_result_t ValidateExtInstGlslStd450(ValidationState_t& _,
+                                       const Instruction* inst) {
   const uint32_t result_type = inst->type_id();
   const uint32_t num_operands = static_cast<uint32_t>(inst->operands().size());
 
   const uint32_t ext_inst_index = inst->word(4);
-  const spv_ext_inst_type_t ext_inst_type =
-      spv_ext_inst_type_t(inst->ext_inst_type());
+  const GLSLstd450 ext_inst_key = GLSLstd450(ext_inst_index);
+  switch (ext_inst_key) {
+    case GLSLstd450Round:
+    case GLSLstd450RoundEven:
+    case GLSLstd450FAbs:
+    case GLSLstd450Trunc:
+    case GLSLstd450FSign:
+    case GLSLstd450Floor:
+    case GLSLstd450Ceil:
+    case GLSLstd450Fract:
+    case GLSLstd450Sqrt:
+    case GLSLstd450InverseSqrt:
+    case GLSLstd450FMin:
+    case GLSLstd450FMax:
+    case GLSLstd450FClamp:
+    case GLSLstd450FMix:
+    case GLSLstd450Step:
+    case GLSLstd450SmoothStep:
+    case GLSLstd450Fma:
+    case GLSLstd450Normalize:
+    case GLSLstd450FaceForward:
+    case GLSLstd450Reflect:
+    case GLSLstd450NMin:
+    case GLSLstd450NMax:
+    case GLSLstd450NClamp: {
+      bool supportsCoopVec =
+          (ext_inst_key == GLSLstd450FMin || ext_inst_key == GLSLstd450FMax ||
+           ext_inst_key == GLSLstd450FClamp || ext_inst_key == GLSLstd450NMin ||
+           ext_inst_key == GLSLstd450NMax || ext_inst_key == GLSLstd450NClamp ||
+           ext_inst_key == GLSLstd450Step || ext_inst_key == GLSLstd450Fma);
 
-  if (ext_inst_type == SPV_EXT_INST_TYPE_GLSL_STD_450) {
-    const GLSLstd450 ext_inst_key = GLSLstd450(ext_inst_index);
-    switch (ext_inst_key) {
-      case GLSLstd450Round:
-      case GLSLstd450RoundEven:
-      case GLSLstd450FAbs:
-      case GLSLstd450Trunc:
-      case GLSLstd450FSign:
-      case GLSLstd450Floor:
-      case GLSLstd450Ceil:
-      case GLSLstd450Fract:
-      case GLSLstd450Sqrt:
-      case GLSLstd450InverseSqrt:
-      case GLSLstd450FMin:
-      case GLSLstd450FMax:
-      case GLSLstd450FClamp:
-      case GLSLstd450FMix:
-      case GLSLstd450Step:
-      case GLSLstd450SmoothStep:
-      case GLSLstd450Fma:
-      case GLSLstd450Normalize:
-      case GLSLstd450FaceForward:
-      case GLSLstd450Reflect:
-      case GLSLstd450NMin:
-      case GLSLstd450NMax:
-      case GLSLstd450NClamp: {
-        bool supportsCoopVec =
-            (ext_inst_key == GLSLstd450FMin || ext_inst_key == GLSLstd450FMax ||
-             ext_inst_key == GLSLstd450FClamp ||
-             ext_inst_key == GLSLstd450NMin || ext_inst_key == GLSLstd450NMax ||
-             ext_inst_key == GLSLstd450NClamp ||
-             ext_inst_key == GLSLstd450Step || ext_inst_key == GLSLstd450Fma);
-
-        if (!_.IsFloatScalarOrVectorType(result_type) &&
-            !(supportsCoopVec &&
-              _.IsFloatCooperativeVectorNVType(result_type))) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
-          }
-        }
-        break;
+      if (!_.IsFloatScalarOrVectorType(result_type) &&
+          !(supportsCoopVec && _.IsFloatCooperativeVectorNVType(result_type))) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
       }
 
-      case GLSLstd450SAbs:
-      case GLSLstd450SSign:
-      case GLSLstd450UMin:
-      case GLSLstd450SMin:
-      case GLSLstd450UMax:
-      case GLSLstd450SMax:
-      case GLSLstd450UClamp:
-      case GLSLstd450SClamp:
-      case GLSLstd450FindILsb:
-      case GLSLstd450FindUMsb:
-      case GLSLstd450FindSMsb: {
-        bool supportsCoopVec =
-            (ext_inst_key == GLSLstd450UMin || ext_inst_key == GLSLstd450UMax ||
-             ext_inst_key == GLSLstd450UClamp ||
-             ext_inst_key == GLSLstd450SMin || ext_inst_key == GLSLstd450SMax ||
-             ext_inst_key == GLSLstd450SClamp);
-
-        if (!_.IsIntScalarOrVectorType(result_type) &&
-            !(supportsCoopVec && _.IsIntCooperativeVectorNVType(result_type))) {
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int scalar or vector type";
-        }
-
-        const uint32_t result_type_bit_width = _.GetBitWidth(result_type);
-        const uint32_t result_type_dimension = _.GetDimension(result_type);
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (!operand_type ||
-              (!_.IsIntScalarOrVectorType(operand_type) &&
-               !(supportsCoopVec &&
-                 _.IsIntCooperativeVectorNVType(operand_type)))) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected all operands to be int scalars or vectors";
-          }
-
-          if (result_type_dimension != _.GetDimension(operand_type)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected all operands to have the same dimension as "
-                   << "Result Type";
-          }
-
-          if (result_type_bit_width != _.GetBitWidth(operand_type)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected all operands to have the same bit width as "
-                   << "Result Type";
-          }
-
-          if (ext_inst_key == GLSLstd450FindUMsb ||
-              ext_inst_key == GLSLstd450FindSMsb) {
-            if (result_type_bit_width != 32) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": "
-                     << "this instruction is currently limited to 32-bit width "
-                     << "components";
-            }
-          }
-        }
-        break;
-      }
-
-      case GLSLstd450Radians:
-      case GLSLstd450Degrees:
-      case GLSLstd450Sin:
-      case GLSLstd450Cos:
-      case GLSLstd450Tan:
-      case GLSLstd450Asin:
-      case GLSLstd450Acos:
-      case GLSLstd450Atan:
-      case GLSLstd450Sinh:
-      case GLSLstd450Cosh:
-      case GLSLstd450Tanh:
-      case GLSLstd450Asinh:
-      case GLSLstd450Acosh:
-      case GLSLstd450Atanh:
-      case GLSLstd450Exp:
-      case GLSLstd450Exp2:
-      case GLSLstd450Log:
-      case GLSLstd450Log2:
-      case GLSLstd450Atan2:
-      case GLSLstd450Pow: {
-        bool supportsCoopVec =
-            (ext_inst_key == GLSLstd450Atan || ext_inst_key == GLSLstd450Tanh ||
-             ext_inst_key == GLSLstd450Exp || ext_inst_key == GLSLstd450Log);
-
-        if (!_.IsFloatScalarOrVectorType(result_type) &&
-            !(supportsCoopVec &&
-              _.IsFloatCooperativeVectorNVType(result_type))) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 16 or 32-bit scalar or "
-                    "vector float type";
-        }
-
-        const uint32_t result_type_bit_width = _.GetBitWidth(result_type);
-        if (result_type_bit_width != 16 && result_type_bit_width != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 16 or 32-bit scalar or "
-                    "vector float type";
-        }
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
-          }
-        }
-        break;
-      }
-
-      case GLSLstd450Determinant: {
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        uint32_t num_rows = 0;
-        uint32_t num_cols = 0;
-        uint32_t col_type = 0;
-        uint32_t component_type = 0;
-        if (!_.GetMatrixTypeInfo(x_type, &num_rows, &num_cols, &col_type,
-                                 &component_type) ||
-            num_rows != num_cols) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to be a square matrix";
-        }
-
-        if (result_type != component_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X component type to be equal to "
-                 << "Result Type";
-        }
-        break;
-      }
-
-      case GLSLstd450MatrixInverse: {
-        uint32_t num_rows = 0;
-        uint32_t num_cols = 0;
-        uint32_t col_type = 0;
-        uint32_t component_type = 0;
-        if (!_.GetMatrixTypeInfo(result_type, &num_rows, &num_cols, &col_type,
-                                 &component_type) ||
-            num_rows != num_cols) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a square matrix";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (result_type != x_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-        break;
-      }
-
-      case GLSLstd450Modf: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or vector float type";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t i_type = _.GetOperandTypeId(inst, 5);
-
-        if (x_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-
-        spv::StorageClass i_storage_class;
-        uint32_t i_data_type = 0;
-        if (!_.GetPointerTypeInfo(i_type, &i_data_type, &i_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand I to be a pointer";
-        }
-
-        if (i_data_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand I data type to be equal to Result Type";
-        }
-
-        break;
-      }
-
-      case GLSLstd450ModfStruct: {
-        std::vector<uint32_t> result_types;
-        if (!_.GetStructMemberTypes(result_type, &result_types) ||
-            result_types.size() != 2 ||
-            !_.IsFloatScalarOrVectorType(result_types[0]) ||
-            result_types[1] != result_types[0]) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a struct with two identical "
-                 << "scalar or vector float type members";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (x_type != result_types[0]) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to members of "
-                 << "Result Type struct";
-        }
-        break;
-      }
-
-      case GLSLstd450Frexp: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or vector float type";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
-
-        if (x_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-
-        spv::StorageClass exp_storage_class;
-        uint32_t exp_data_type = 0;
-        if (!_.GetPointerTypeInfo(exp_type, &exp_data_type,
-                                  &exp_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Exp to be a pointer";
-        }
-
-        if (!_.IsIntScalarOrVectorType(exp_data_type) ||
-            (!_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
-             _.GetBitWidth(exp_data_type) != 32) ||
-            (_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
-             _.GetBitWidth(exp_data_type) != 16 &&
-             _.GetBitWidth(exp_data_type) != 32)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Exp data type to be a "
-                 << (_.HasExtension(kSPV_AMD_gpu_shader_int16)
-                         ? "16-bit or 32-bit "
-                         : "32-bit ")
-                 << "int scalar or vector type";
-        }
-
-        if (_.GetDimension(result_type) != _.GetDimension(exp_data_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Exp data type to have the same component "
-                 << "number as Result Type";
-        }
-
-        break;
-      }
-
-      case GLSLstd450Ldexp: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or vector float type";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
-
-        if (x_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-
-        if (!_.IsIntScalarOrVectorType(exp_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Exp to be a 32-bit int scalar "
-                 << "or vector type";
-        }
-
-        if (_.GetDimension(result_type) != _.GetDimension(exp_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Exp to have the same component "
-                 << "number as Result Type";
-        }
-
-        break;
-      }
-
-      case GLSLstd450FrexpStruct: {
-        std::vector<uint32_t> result_types;
-        if (!_.GetStructMemberTypes(result_type, &result_types) ||
-            result_types.size() != 2 ||
-            !_.IsFloatScalarOrVectorType(result_types[0]) ||
-            !_.IsIntScalarOrVectorType(result_types[1]) ||
-            (!_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
-             _.GetBitWidth(result_types[1]) != 32) ||
-            (_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
-             _.GetBitWidth(result_types[1]) != 16 &&
-             _.GetBitWidth(result_types[1]) != 32) ||
-            _.GetDimension(result_types[0]) !=
-                _.GetDimension(result_types[1])) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a struct with two members, "
-                 << "first member a float scalar or vector, second member a "
-                 << (_.HasExtension(kSPV_AMD_gpu_shader_int16)
-                         ? "16-bit or 32-bit "
-                         : "32-bit ")
-                 << "int scalar or vector with the same number of "
-                 << "components as the first member";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (x_type != result_types[0]) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to the first member "
-                 << "of Result Type struct";
-        }
-        break;
-      }
-
-      case GLSLstd450PackSnorm4x8:
-      case GLSLstd450PackUnorm4x8: {
-        if (!_.IsIntScalarType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be 32-bit int scalar type";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatVectorType(v_type) || _.GetDimension(v_type) != 4 ||
-            _.GetBitWidth(v_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand V to be a 32-bit float vector of size 4";
-        }
-        break;
-      }
-
-      case GLSLstd450PackSnorm2x16:
-      case GLSLstd450PackUnorm2x16:
-      case GLSLstd450PackHalf2x16: {
-        if (!_.IsIntScalarType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be 32-bit int scalar type";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatVectorType(v_type) || _.GetDimension(v_type) != 2 ||
-            _.GetBitWidth(v_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand V to be a 32-bit float vector of size 2";
-        }
-        break;
-      }
-
-      case GLSLstd450PackDouble2x32: {
-        if (!_.IsFloatScalarType(result_type) ||
-            _.GetBitWidth(result_type) != 64) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be 64-bit float scalar type";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsIntVectorType(v_type) || _.GetDimension(v_type) != 2 ||
-            _.GetBitWidth(v_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand V to be a 32-bit int vector of size 2";
-        }
-        break;
-      }
-
-      case GLSLstd450UnpackSnorm4x8:
-      case GLSLstd450UnpackUnorm4x8: {
-        if (!_.IsFloatVectorType(result_type) ||
-            _.GetDimension(result_type) != 4 ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit float vector of size "
-                    "4";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsIntScalarType(v_type) || _.GetBitWidth(v_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a 32-bit int scalar";
-        }
-        break;
-      }
-
-      case GLSLstd450UnpackSnorm2x16:
-      case GLSLstd450UnpackUnorm2x16:
-      case GLSLstd450UnpackHalf2x16: {
-        if (!_.IsFloatVectorType(result_type) ||
-            _.GetDimension(result_type) != 2 ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit float vector of size "
-                    "2";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsIntScalarType(v_type) || _.GetBitWidth(v_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a 32-bit int scalar";
-        }
-        break;
-      }
-
-      case GLSLstd450UnpackDouble2x32: {
-        if (!_.IsIntVectorType(result_type) ||
-            _.GetDimension(result_type) != 2 ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit int vector of size "
-                    "2";
-        }
-
-        const uint32_t v_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarType(v_type) || _.GetBitWidth(v_type) != 64) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand V to be a 64-bit float scalar";
-        }
-        break;
-      }
-
-      case GLSLstd450Length: {
-        if (!_.IsFloatScalarType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar type";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarOrVectorType(x_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to be of float scalar or vector type";
-        }
-
-        if (result_type != _.GetComponentType(x_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X component type to be equal to Result "
+                 << "expected types of all operands to be equal to Result "
                     "Type";
         }
-        break;
       }
-
-      case GLSLstd450Distance: {
-        if (!_.IsFloatScalarType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar type";
-        }
-
-        const uint32_t p0_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarOrVectorType(p0_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P0 to be of float scalar or vector type";
-        }
-
-        if (result_type != _.GetComponentType(p0_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P0 component type to be equal to "
-                 << "Result Type";
-        }
-
-        const uint32_t p1_type = _.GetOperandTypeId(inst, 5);
-        if (!_.IsFloatScalarOrVectorType(p1_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P1 to be of float scalar or vector type";
-        }
-
-        if (result_type != _.GetComponentType(p1_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P1 component type to be equal to "
-                 << "Result Type";
-        }
-
-        if (_.GetDimension(p0_type) != _.GetDimension(p1_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operands P0 and P1 to have the same number of "
-                 << "components";
-        }
-        break;
-      }
-
-      case GLSLstd450Cross: {
-        if (!_.IsFloatVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float vector type";
-        }
-
-        if (_.GetDimension(result_type) != 3) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have 3 components";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t y_type = _.GetOperandTypeId(inst, 5);
-
-        if (x_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-
-        if (y_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Y type to be equal to Result Type";
-        }
-        break;
-      }
-
-      case GLSLstd450Refract: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        const uint32_t i_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t n_type = _.GetOperandTypeId(inst, 5);
-        const uint32_t eta_type = _.GetOperandTypeId(inst, 6);
-
-        if (result_type != i_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand I to be of type equal to Result Type";
-        }
-
-        if (result_type != n_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand N to be of type equal to Result Type";
-        }
-
-        if (!_.IsFloatScalarType(eta_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Eta to be a float scalar";
-        }
-        break;
-      }
-
-      case GLSLstd450InterpolateAtCentroid:
-      case GLSLstd450InterpolateAtSample:
-      case GLSLstd450InterpolateAtOffset: {
-        if (!_.HasCapability(spv::Capability::InterpolationFunction)) {
-          return _.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
-                 << GetExtInstName(_, inst)
-                 << " requires capability InterpolationFunction";
-        }
-
-        if (!_.IsFloatScalarOrVectorType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit float scalar "
-                 << "or vector type";
-        }
-
-        // If HLSL legalization and first operand is an OpLoad, use load
-        // pointer as the interpolant lvalue. Else use interpolate first
-        // operand.
-        uint32_t interp_id = inst->GetOperandAs<uint32_t>(4);
-        auto* interp_inst = _.FindDef(interp_id);
-        uint32_t interpolant_type = (_.options()->before_hlsl_legalization &&
-                                     interp_inst->opcode() == spv::Op::OpLoad)
-                                        ? _.GetOperandTypeId(interp_inst, 2)
-                                        : _.GetOperandTypeId(inst, 4);
-
-        spv::StorageClass interpolant_storage_class;
-        uint32_t interpolant_data_type = 0;
-        if (!_.GetPointerTypeInfo(interpolant_type, &interpolant_data_type,
-                                  &interpolant_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Interpolant to be a pointer";
-        }
-
-        if (result_type != interpolant_data_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Interpolant data type to be equal to Result Type";
-        }
-
-        if (interpolant_storage_class != spv::StorageClass::Input) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Interpolant storage class to be Input";
-        }
-
-        if (ext_inst_key == GLSLstd450InterpolateAtSample) {
-          const uint32_t sample_type = _.GetOperandTypeId(inst, 5);
-          if (!_.IsIntScalarType(sample_type) ||
-              _.GetBitWidth(sample_type) != 32) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Sample to be 32-bit integer";
-          }
-        }
-
-        if (ext_inst_key == GLSLstd450InterpolateAtOffset) {
-          const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
-          if (!_.IsFloatVectorType(offset_type) ||
-              _.GetDimension(offset_type) != 2 ||
-              _.GetBitWidth(offset_type) != 32) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Offset to be a vector of 2 32-bit floats";
-          }
-        }
-
-        _.function(inst->function()->id())
-            ->RegisterExecutionModelLimitation(
-                spv::ExecutionModel::Fragment,
-                GetExtInstName(_, inst) +
-                    std::string(" requires Fragment execution model"));
-        break;
-      }
-
-      case GLSLstd450IMix: {
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Extended instruction GLSLstd450IMix is not supported";
-      }
-
-      case GLSLstd450Bad: {
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Encountered extended instruction GLSLstd450Bad";
-      }
-
-      case GLSLstd450Count: {
-        assert(0);
-        break;
-      }
+      break;
     }
-  } else if (ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_STD) {
-    const OpenCLLIB::Entrypoints ext_inst_key =
-        OpenCLLIB::Entrypoints(ext_inst_index);
-    switch (ext_inst_key) {
-      case OpenCLLIB::Acos:
-      case OpenCLLIB::Acosh:
-      case OpenCLLIB::Acospi:
-      case OpenCLLIB::Asin:
-      case OpenCLLIB::Asinh:
-      case OpenCLLIB::Asinpi:
-      case OpenCLLIB::Atan:
-      case OpenCLLIB::Atan2:
-      case OpenCLLIB::Atanh:
-      case OpenCLLIB::Atanpi:
-      case OpenCLLIB::Atan2pi:
-      case OpenCLLIB::Cbrt:
-      case OpenCLLIB::Ceil:
-      case OpenCLLIB::Copysign:
-      case OpenCLLIB::Cos:
-      case OpenCLLIB::Cosh:
-      case OpenCLLIB::Cospi:
-      case OpenCLLIB::Erfc:
-      case OpenCLLIB::Erf:
-      case OpenCLLIB::Exp:
-      case OpenCLLIB::Exp2:
-      case OpenCLLIB::Exp10:
-      case OpenCLLIB::Expm1:
-      case OpenCLLIB::Fabs:
-      case OpenCLLIB::Fdim:
-      case OpenCLLIB::Floor:
-      case OpenCLLIB::Fma:
-      case OpenCLLIB::Fmax:
-      case OpenCLLIB::Fmin:
-      case OpenCLLIB::Fmod:
-      case OpenCLLIB::Hypot:
-      case OpenCLLIB::Lgamma:
-      case OpenCLLIB::Log:
-      case OpenCLLIB::Log2:
-      case OpenCLLIB::Log10:
-      case OpenCLLIB::Log1p:
-      case OpenCLLIB::Logb:
-      case OpenCLLIB::Mad:
-      case OpenCLLIB::Maxmag:
-      case OpenCLLIB::Minmag:
-      case OpenCLLIB::Nextafter:
-      case OpenCLLIB::Pow:
-      case OpenCLLIB::Powr:
-      case OpenCLLIB::Remainder:
-      case OpenCLLIB::Rint:
-      case OpenCLLIB::Round:
-      case OpenCLLIB::Rsqrt:
-      case OpenCLLIB::Sin:
-      case OpenCLLIB::Sinh:
-      case OpenCLLIB::Sinpi:
-      case OpenCLLIB::Sqrt:
-      case OpenCLLIB::Tan:
-      case OpenCLLIB::Tanh:
-      case OpenCLLIB::Tanpi:
-      case OpenCLLIB::Tgamma:
-      case OpenCLLIB::Trunc:
-      case OpenCLLIB::Half_cos:
-      case OpenCLLIB::Half_divide:
-      case OpenCLLIB::Half_exp:
-      case OpenCLLIB::Half_exp2:
-      case OpenCLLIB::Half_exp10:
-      case OpenCLLIB::Half_log:
-      case OpenCLLIB::Half_log2:
-      case OpenCLLIB::Half_log10:
-      case OpenCLLIB::Half_powr:
-      case OpenCLLIB::Half_recip:
-      case OpenCLLIB::Half_rsqrt:
-      case OpenCLLIB::Half_sin:
-      case OpenCLLIB::Half_sqrt:
-      case OpenCLLIB::Half_tan:
-      case OpenCLLIB::Native_cos:
-      case OpenCLLIB::Native_divide:
-      case OpenCLLIB::Native_exp:
-      case OpenCLLIB::Native_exp2:
-      case OpenCLLIB::Native_exp10:
-      case OpenCLLIB::Native_log:
-      case OpenCLLIB::Native_log2:
-      case OpenCLLIB::Native_log10:
-      case OpenCLLIB::Native_powr:
-      case OpenCLLIB::Native_recip:
-      case OpenCLLIB::Native_rsqrt:
-      case OpenCLLIB::Native_sin:
-      case OpenCLLIB::Native_sqrt:
-      case OpenCLLIB::Native_tan:
-      case OpenCLLIB::FClamp:
-      case OpenCLLIB::Degrees:
-      case OpenCLLIB::FMax_common:
-      case OpenCLLIB::FMin_common:
-      case OpenCLLIB::Mix:
-      case OpenCLLIB::Radians:
-      case OpenCLLIB::Step:
-      case OpenCLLIB::Smoothstep:
-      case OpenCLLIB::Sign: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
 
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
+    case GLSLstd450SAbs:
+    case GLSLstd450SSign:
+    case GLSLstd450UMin:
+    case GLSLstd450SMin:
+    case GLSLstd450UMax:
+    case GLSLstd450SMax:
+    case GLSLstd450UClamp:
+    case GLSLstd450SClamp:
+    case GLSLstd450FindILsb:
+    case GLSLstd450FindUMsb:
+    case GLSLstd450FindSMsb: {
+      bool supportsCoopVec =
+          (ext_inst_key == GLSLstd450UMin || ext_inst_key == GLSLstd450UMax ||
+           ext_inst_key == GLSLstd450UClamp || ext_inst_key == GLSLstd450SMin ||
+           ext_inst_key == GLSLstd450SMax || ext_inst_key == GLSLstd450SClamp);
 
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
-          }
-        }
-        break;
+      if (!_.IsIntScalarOrVectorType(result_type) &&
+          !(supportsCoopVec && _.IsIntCooperativeVectorNVType(result_type))) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int scalar or vector type";
       }
 
-      case OpenCLLIB::Fract:
-      case OpenCLLIB::Modf:
-      case OpenCLLIB::Sincos: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
+      const uint32_t result_type_bit_width = _.GetBitWidth(result_type);
+      const uint32_t result_type_dimension = _.GetDimension(result_type);
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (!operand_type ||
+            (!_.IsIntScalarOrVectorType(operand_type) &&
+             !(supportsCoopVec &&
+               _.IsIntCooperativeVectorNVType(operand_type)))) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
+                 << "expected all operands to be int scalars or vectors";
         }
 
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
+        if (result_type_dimension != _.GetDimension(operand_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (result_type != x_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected type of operand X to be equal to Result Type";
-        }
-
-        const uint32_t p_type = _.GetOperandTypeId(inst, 5);
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected the last operand to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected storage class of the pointer to be Generic, "
-                    "CrossWorkgroup, Workgroup or Function";
-        }
-
-        if (!_.ContainsUntypedPointer(p_type) && result_type != p_data_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected data type of the pointer to be equal to Result "
-                    "Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Frexp:
-      case OpenCLLIB::Lgamma_r:
-      case OpenCLLIB::Remquo: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        uint32_t operand_index = 4;
-        const uint32_t x_type = _.GetOperandTypeId(inst, operand_index++);
-        if (result_type != x_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected type of operand X to be equal to Result Type";
-        }
-
-        if (ext_inst_key == OpenCLLIB::Remquo) {
-          const uint32_t y_type = _.GetOperandTypeId(inst, operand_index++);
-          if (result_type != y_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected type of operand Y to be equal to Result Type";
-          }
-        }
-
-        const uint32_t p_type = _.GetOperandTypeId(inst, operand_index++);
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected the last operand to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected storage class of the pointer to be Generic, "
-                    "CrossWorkgroup, Workgroup or Function";
-        }
-
-        if ((!_.IsIntScalarOrVectorType(p_data_type) ||
-             _.GetBitWidth(p_data_type) != 32) &&
-            !_.ContainsUntypedPointer(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected data type of the pointer to be a 32-bit int "
-                    "scalar or vector type";
-        }
-
-        if (!_.ContainsUntypedPointer(p_type) &&
-            _.GetDimension(p_data_type) != num_components) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected data type of the pointer to have the same number "
-                    "of components as Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Ilogb: {
-        if (!_.IsIntScalarOrVectorType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit int scalar or vector "
-                    "type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarOrVectorType(x_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to be a float scalar or vector";
-        }
-
-        if (_.GetDimension(x_type) != num_components) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to have the same number of components "
-                    "as Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Ldexp:
-      case OpenCLLIB::Pown:
-      case OpenCLLIB::Rootn: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        if (result_type != x_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected type of operand X to be equal to Result Type";
-        }
-
-        const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
-        if (!_.IsIntScalarOrVectorType(exp_type) ||
-            _.GetBitWidth(exp_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected the exponent to be a 32-bit int scalar or vector";
-        }
-
-        if (_.GetDimension(exp_type) != num_components) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected the exponent to have the same number of "
-                    "components as Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Nan: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t nancode_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsIntScalarOrVectorType(nancode_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Nancode to be an int scalar or vector type";
-        }
-
-        if (_.GetDimension(nancode_type) != num_components) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Nancode to have the same number of components as "
-                    "Result Type";
-        }
-
-        if (_.GetBitWidth(result_type) != _.GetBitWidth(nancode_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Nancode to have the same bit width as Result "
-                    "Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::SAbs:
-      case OpenCLLIB::SAbs_diff:
-      case OpenCLLIB::SAdd_sat:
-      case OpenCLLIB::UAdd_sat:
-      case OpenCLLIB::SHadd:
-      case OpenCLLIB::UHadd:
-      case OpenCLLIB::SRhadd:
-      case OpenCLLIB::URhadd:
-      case OpenCLLIB::SClamp:
-      case OpenCLLIB::UClamp:
-      case OpenCLLIB::Clz:
-      case OpenCLLIB::Ctz:
-      case OpenCLLIB::SMad_hi:
-      case OpenCLLIB::UMad_sat:
-      case OpenCLLIB::SMad_sat:
-      case OpenCLLIB::SMax:
-      case OpenCLLIB::UMax:
-      case OpenCLLIB::SMin:
-      case OpenCLLIB::UMin:
-      case OpenCLLIB::SMul_hi:
-      case OpenCLLIB::Rotate:
-      case OpenCLLIB::SSub_sat:
-      case OpenCLLIB::USub_sat:
-      case OpenCLLIB::Popcount:
-      case OpenCLLIB::UAbs:
-      case OpenCLLIB::UAbs_diff:
-      case OpenCLLIB::UMul_hi:
-      case OpenCLLIB::UMad_hi: {
-        if (!_.IsIntScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
-          }
-        }
-        break;
-      }
-
-      case OpenCLLIB::U_Upsample:
-      case OpenCLLIB::S_Upsample: {
-        if (!_.IsIntScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int scalar or vector "
-                    "type";
-        }
-
-        const uint32_t result_num_components = _.GetDimension(result_type);
-        if (result_num_components > 4 && result_num_components != 8 &&
-            result_num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t result_bit_width = _.GetBitWidth(result_type);
-        if (result_bit_width != 16 && result_bit_width != 32 &&
-            result_bit_width != 64) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected bit width of Result Type components to be 16, 32 "
-                    "or 64";
-        }
-
-        const uint32_t hi_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t lo_type = _.GetOperandTypeId(inst, 5);
-
-        if (hi_type != lo_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Hi and Lo operands to have the same type";
-        }
-
-        if (result_num_components != _.GetDimension(hi_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Hi and Lo operands to have the same number of "
-                    "components as Result Type";
-        }
-
-        if (result_bit_width != 2 * _.GetBitWidth(hi_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected bit width of components of Hi and Lo operands to "
-                    "be half of the bit width of components of Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::SMad24:
-      case OpenCLLIB::UMad24:
-      case OpenCLLIB::SMul24:
-      case OpenCLLIB::UMul24: {
-        if (!_.IsIntScalarOrVectorType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit int scalar or vector "
-                    "type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
-          }
-        }
-        break;
-      }
-
-      case OpenCLLIB::Cross: {
-        if (!_.IsFloatVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components != 3 && num_components != 4) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have 3 or 4 components";
-        }
-
-        const uint32_t x_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t y_type = _.GetOperandTypeId(inst, 5);
-
-        if (x_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X type to be equal to Result Type";
-        }
-
-        if (y_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Y type to be equal to Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Distance:
-      case OpenCLLIB::Fast_distance: {
-        if (!_.IsFloatScalarType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar type";
-        }
-
-        const uint32_t p0_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarOrVectorType(p0_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P0 to be of float scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(p0_type);
-        if (num_components > 4) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P0 to have no more than 4 components";
-        }
-
-        if (result_type != _.GetComponentType(p0_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P0 component type to be equal to "
+                 << "expected all operands to have the same dimension as "
                  << "Result Type";
         }
 
-        const uint32_t p1_type = _.GetOperandTypeId(inst, 5);
-        if (p0_type != p1_type) {
+        if (result_type_bit_width != _.GetBitWidth(operand_type)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected operands P0 and P1 to be of the same type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Length:
-      case OpenCLLIB::Fast_length: {
-        if (!_.IsFloatScalarType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar type";
+                 << "expected all operands to have the same bit width as "
+                 << "Result Type";
         }
 
-        const uint32_t p_type = _.GetOperandTypeId(inst, 4);
-        if (!_.IsFloatScalarOrVectorType(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a float scalar or vector";
-        }
-
-        const uint32_t num_components = _.GetDimension(p_type);
-        if (num_components > 4) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to have no more than 4 components";
-        }
-
-        if (result_type != _.GetComponentType(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P component type to be equal to Result "
-                    "Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Normalize:
-      case OpenCLLIB::Fast_normalize: {
-        if (!_.IsFloatScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar or vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have no more than 4 components";
-        }
-
-        const uint32_t p_type = _.GetOperandTypeId(inst, 4);
-        if (p_type != result_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P type to be equal to Result Type";
-        }
-        break;
-      }
-
-      case OpenCLLIB::Bitselect: {
-        if (!_.IsFloatScalarOrVectorType(result_type) &&
-            !_.IsIntScalarOrVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int or float scalar or "
-                    "vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        for (uint32_t operand_index = 4; operand_index < num_operands;
-             ++operand_index) {
-          const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
-          if (result_type != operand_type) {
+        if (ext_inst_key == GLSLstd450FindUMsb ||
+            ext_inst_key == GLSLstd450FindSMsb) {
+          if (result_type_bit_width != 32) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << GetExtInstName(_, inst) << ": "
-                   << "expected types of all operands to be equal to Result "
-                      "Type";
+                   << "this instruction is currently limited to 32-bit width "
+                   << "components";
           }
         }
-        break;
+      }
+      break;
+    }
+
+    case GLSLstd450Radians:
+    case GLSLstd450Degrees:
+    case GLSLstd450Sin:
+    case GLSLstd450Cos:
+    case GLSLstd450Tan:
+    case GLSLstd450Asin:
+    case GLSLstd450Acos:
+    case GLSLstd450Atan:
+    case GLSLstd450Sinh:
+    case GLSLstd450Cosh:
+    case GLSLstd450Tanh:
+    case GLSLstd450Asinh:
+    case GLSLstd450Acosh:
+    case GLSLstd450Atanh:
+    case GLSLstd450Exp:
+    case GLSLstd450Exp2:
+    case GLSLstd450Log:
+    case GLSLstd450Log2:
+    case GLSLstd450Atan2:
+    case GLSLstd450Pow: {
+      bool supportsCoopVec =
+          (ext_inst_key == GLSLstd450Atan || ext_inst_key == GLSLstd450Tanh ||
+           ext_inst_key == GLSLstd450Exp || ext_inst_key == GLSLstd450Log);
+
+      if (!_.IsFloatScalarOrVectorType(result_type) &&
+          !(supportsCoopVec && _.IsFloatCooperativeVectorNVType(result_type))) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 16 or 32-bit scalar or "
+                  "vector float type";
       }
 
-      case OpenCLLIB::Select: {
-        if (!_.IsFloatScalarOrVectorType(result_type) &&
-            !_.IsIntScalarOrVectorType(result_type)) {
+      const uint32_t result_type_bit_width = _.GetBitWidth(result_type);
+      if (result_type_bit_width != 16 && result_type_bit_width != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 16 or 32-bit scalar or "
+                  "vector float type";
+      }
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int or float scalar or "
-                    "vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t a_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t b_type = _.GetOperandTypeId(inst, 5);
-        const uint32_t c_type = _.GetOperandTypeId(inst, 6);
-
-        if (result_type != a_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand A type to be equal to Result Type";
-        }
-
-        if (result_type != b_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand B type to be equal to Result Type";
-        }
-
-        if (!_.IsIntScalarOrVectorType(c_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand C to be an int scalar or vector";
-        }
-
-        if (num_components != _.GetDimension(c_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand C to have the same number of components "
-                    "as Result Type";
-        }
-
-        if (_.GetBitWidth(result_type) != _.GetBitWidth(c_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand C to have the same bit width as Result "
+                 << "expected types of all operands to be equal to Result "
                     "Type";
         }
-        break;
+      }
+      break;
+    }
+
+    case GLSLstd450Determinant: {
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      uint32_t num_rows = 0;
+      uint32_t num_cols = 0;
+      uint32_t col_type = 0;
+      uint32_t component_type = 0;
+      if (!_.GetMatrixTypeInfo(x_type, &num_rows, &num_cols, &col_type,
+                               &component_type) ||
+          num_rows != num_cols) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to be a square matrix";
       }
 
-      case OpenCLLIB::Vloadn: {
-        if (!_.IsFloatVectorType(result_type) &&
-            !_.IsIntVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int or float vector type";
-        }
+      if (result_type != component_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X component type to be equal to "
+               << "Result Type";
+      }
+      break;
+    }
 
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have 2, 3, 4, 8 or 16 components";
-        }
-
-        const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t p_type = _.GetOperandTypeId(inst, 5);
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(offset_type) ||
-            _.GetBitWidth(offset_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Offset to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::UniformConstant &&
-            p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P storage class to be UniformConstant, "
-                    "Generic, CrossWorkgroup, Workgroup or Function";
-        }
-
-        if (_.GetComponentType(result_type) != p_data_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P data type to be equal to component "
-                    "type of Result Type";
-        }
-
-        const uint32_t n_value = inst->word(7);
-        if (num_components != n_value) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected literal N to be equal to the number of "
-                    "components of Result Type";
-        }
-        break;
+    case GLSLstd450MatrixInverse: {
+      uint32_t num_rows = 0;
+      uint32_t num_cols = 0;
+      uint32_t col_type = 0;
+      uint32_t component_type = 0;
+      if (!_.GetMatrixTypeInfo(result_type, &num_rows, &num_cols, &col_type,
+                               &component_type) ||
+          num_rows != num_cols) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a square matrix";
       }
 
-      case OpenCLLIB::Vstoren: {
-        if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << ": expected Result Type to be void";
-        }
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (result_type != x_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+      break;
+    }
 
-        const uint32_t data_type = _.GetOperandTypeId(inst, 4);
+    case GLSLstd450Modf: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or vector float type";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t i_type = _.GetOperandTypeId(inst, 5);
+
+      if (x_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+
+      spv::StorageClass i_storage_class;
+      uint32_t i_data_type = 0;
+      if (!_.GetPointerTypeInfo(i_type, &i_data_type, &i_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand I to be a pointer";
+      }
+
+      if (i_data_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand I data type to be equal to Result Type";
+      }
+
+      break;
+    }
+
+    case GLSLstd450ModfStruct: {
+      std::vector<uint32_t> result_types;
+      if (!_.GetStructMemberTypes(result_type, &result_types) ||
+          result_types.size() != 2 ||
+          !_.IsFloatScalarOrVectorType(result_types[0]) ||
+          result_types[1] != result_types[0]) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a struct with two identical "
+               << "scalar or vector float type members";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (x_type != result_types[0]) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to members of "
+               << "Result Type struct";
+      }
+      break;
+    }
+
+    case GLSLstd450Frexp: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or vector float type";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
+
+      if (x_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+
+      spv::StorageClass exp_storage_class;
+      uint32_t exp_data_type = 0;
+      if (!_.GetPointerTypeInfo(exp_type, &exp_data_type, &exp_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Exp to be a pointer";
+      }
+
+      if (!_.IsIntScalarOrVectorType(exp_data_type) ||
+          (!_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
+           _.GetBitWidth(exp_data_type) != 32) ||
+          (_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
+           _.GetBitWidth(exp_data_type) != 16 &&
+           _.GetBitWidth(exp_data_type) != 32)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Exp data type to be a "
+               << (_.HasExtension(kSPV_AMD_gpu_shader_int16)
+                       ? "16-bit or 32-bit "
+                       : "32-bit ")
+               << "int scalar or vector type";
+      }
+
+      if (_.GetDimension(result_type) != _.GetDimension(exp_data_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Exp data type to have the same component "
+               << "number as Result Type";
+      }
+
+      break;
+    }
+
+    case GLSLstd450Ldexp: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or vector float type";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
+
+      if (x_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+
+      if (!_.IsIntScalarOrVectorType(exp_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Exp to be a 32-bit int scalar "
+               << "or vector type";
+      }
+
+      if (_.GetDimension(result_type) != _.GetDimension(exp_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Exp to have the same component "
+               << "number as Result Type";
+      }
+
+      break;
+    }
+
+    case GLSLstd450FrexpStruct: {
+      std::vector<uint32_t> result_types;
+      if (!_.GetStructMemberTypes(result_type, &result_types) ||
+          result_types.size() != 2 ||
+          !_.IsFloatScalarOrVectorType(result_types[0]) ||
+          !_.IsIntScalarOrVectorType(result_types[1]) ||
+          (!_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
+           _.GetBitWidth(result_types[1]) != 32) ||
+          (_.HasExtension(kSPV_AMD_gpu_shader_int16) &&
+           _.GetBitWidth(result_types[1]) != 16 &&
+           _.GetBitWidth(result_types[1]) != 32) ||
+          _.GetDimension(result_types[0]) != _.GetDimension(result_types[1])) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a struct with two members, "
+               << "first member a float scalar or vector, second member a "
+               << (_.HasExtension(kSPV_AMD_gpu_shader_int16)
+                       ? "16-bit or 32-bit "
+                       : "32-bit ")
+               << "int scalar or vector with the same number of "
+               << "components as the first member";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (x_type != result_types[0]) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to the first member "
+               << "of Result Type struct";
+      }
+      break;
+    }
+
+    case GLSLstd450PackSnorm4x8:
+    case GLSLstd450PackUnorm4x8: {
+      if (!_.IsIntScalarType(result_type) || _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be 32-bit int scalar type";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatVectorType(v_type) || _.GetDimension(v_type) != 4 ||
+          _.GetBitWidth(v_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand V to be a 32-bit float vector of size 4";
+      }
+      break;
+    }
+
+    case GLSLstd450PackSnorm2x16:
+    case GLSLstd450PackUnorm2x16:
+    case GLSLstd450PackHalf2x16: {
+      if (!_.IsIntScalarType(result_type) || _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be 32-bit int scalar type";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatVectorType(v_type) || _.GetDimension(v_type) != 2 ||
+          _.GetBitWidth(v_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand V to be a 32-bit float vector of size 2";
+      }
+      break;
+    }
+
+    case GLSLstd450PackDouble2x32: {
+      if (!_.IsFloatScalarType(result_type) ||
+          _.GetBitWidth(result_type) != 64) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be 64-bit float scalar type";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsIntVectorType(v_type) || _.GetDimension(v_type) != 2 ||
+          _.GetBitWidth(v_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand V to be a 32-bit int vector of size 2";
+      }
+      break;
+    }
+
+    case GLSLstd450UnpackSnorm4x8:
+    case GLSLstd450UnpackUnorm4x8: {
+      if (!_.IsFloatVectorType(result_type) ||
+          _.GetDimension(result_type) != 4 ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit float vector of size "
+                  "4";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsIntScalarType(v_type) || _.GetBitWidth(v_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a 32-bit int scalar";
+      }
+      break;
+    }
+
+    case GLSLstd450UnpackSnorm2x16:
+    case GLSLstd450UnpackUnorm2x16:
+    case GLSLstd450UnpackHalf2x16: {
+      if (!_.IsFloatVectorType(result_type) ||
+          _.GetDimension(result_type) != 2 ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit float vector of size "
+                  "2";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsIntScalarType(v_type) || _.GetBitWidth(v_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a 32-bit int scalar";
+      }
+      break;
+    }
+
+    case GLSLstd450UnpackDouble2x32: {
+      if (!_.IsIntVectorType(result_type) || _.GetDimension(result_type) != 2 ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit int vector of size "
+                  "2";
+      }
+
+      const uint32_t v_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarType(v_type) || _.GetBitWidth(v_type) != 64) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand V to be a 64-bit float scalar";
+      }
+      break;
+    }
+
+    case GLSLstd450Length: {
+      if (!_.IsFloatScalarType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar type";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarOrVectorType(x_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to be of float scalar or vector type";
+      }
+
+      if (result_type != _.GetComponentType(x_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X component type to be equal to Result "
+                  "Type";
+      }
+      break;
+    }
+
+    case GLSLstd450Distance: {
+      if (!_.IsFloatScalarType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar type";
+      }
+
+      const uint32_t p0_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarOrVectorType(p0_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P0 to be of float scalar or vector type";
+      }
+
+      if (result_type != _.GetComponentType(p0_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P0 component type to be equal to "
+               << "Result Type";
+      }
+
+      const uint32_t p1_type = _.GetOperandTypeId(inst, 5);
+      if (!_.IsFloatScalarOrVectorType(p1_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P1 to be of float scalar or vector type";
+      }
+
+      if (result_type != _.GetComponentType(p1_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P1 component type to be equal to "
+               << "Result Type";
+      }
+
+      if (_.GetDimension(p0_type) != _.GetDimension(p1_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operands P0 and P1 to have the same number of "
+               << "components";
+      }
+      break;
+    }
+
+    case GLSLstd450Cross: {
+      if (!_.IsFloatVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float vector type";
+      }
+
+      if (_.GetDimension(result_type) != 3) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have 3 components";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t y_type = _.GetOperandTypeId(inst, 5);
+
+      if (x_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+
+      if (y_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Y type to be equal to Result Type";
+      }
+      break;
+    }
+
+    case GLSLstd450Refract: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t i_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t n_type = _.GetOperandTypeId(inst, 5);
+      const uint32_t eta_type = _.GetOperandTypeId(inst, 6);
+
+      if (result_type != i_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand I to be of type equal to Result Type";
+      }
+
+      if (result_type != n_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand N to be of type equal to Result Type";
+      }
+
+      if (!_.IsFloatScalarType(eta_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Eta to be a float scalar";
+      }
+      break;
+    }
+
+    case GLSLstd450InterpolateAtCentroid:
+    case GLSLstd450InterpolateAtSample:
+    case GLSLstd450InterpolateAtOffset: {
+      if (!_.HasCapability(spv::Capability::InterpolationFunction)) {
+        return _.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
+               << GetExtInstName(_, inst)
+               << " requires capability InterpolationFunction";
+      }
+
+      if (!_.IsFloatScalarOrVectorType(result_type) ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit float scalar "
+               << "or vector type";
+      }
+
+      // If HLSL legalization and first operand is an OpLoad, use load
+      // pointer as the interpolant lvalue. Else use interpolate first
+      // operand.
+      uint32_t interp_id = inst->GetOperandAs<uint32_t>(4);
+      auto* interp_inst = _.FindDef(interp_id);
+      uint32_t interpolant_type = (_.options()->before_hlsl_legalization &&
+                                   interp_inst->opcode() == spv::Op::OpLoad)
+                                      ? _.GetOperandTypeId(interp_inst, 2)
+                                      : _.GetOperandTypeId(inst, 4);
+
+      spv::StorageClass interpolant_storage_class;
+      uint32_t interpolant_data_type = 0;
+      if (!_.GetPointerTypeInfo(interpolant_type, &interpolant_data_type,
+                                &interpolant_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Interpolant to be a pointer";
+      }
+
+      if (result_type != interpolant_data_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Interpolant data type to be equal to Result Type";
+      }
+
+      if (interpolant_storage_class != spv::StorageClass::Input) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Interpolant storage class to be Input";
+      }
+
+      if (ext_inst_key == GLSLstd450InterpolateAtSample) {
+        const uint32_t sample_type = _.GetOperandTypeId(inst, 5);
+        if (!_.IsIntScalarType(sample_type) ||
+            _.GetBitWidth(sample_type) != 32) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected Sample to be 32-bit integer";
+        }
+      }
+
+      if (ext_inst_key == GLSLstd450InterpolateAtOffset) {
         const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
-        const uint32_t p_type = _.GetOperandTypeId(inst, 6);
-
-        if (!_.IsFloatVectorType(data_type) && !_.IsIntVectorType(data_type)) {
+        if (!_.IsFloatVectorType(offset_type) ||
+            _.GetDimension(offset_type) != 2 ||
+            _.GetBitWidth(offset_type) != 32) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Data to be an int or float vector";
+                 << "expected Offset to be a vector of 2 32-bit floats";
+        }
+      }
+
+      _.function(inst->function()->id())
+          ->RegisterExecutionModelLimitation(
+              spv::ExecutionModel::Fragment,
+              GetExtInstName(_, inst) +
+                  std::string(" requires Fragment execution model"));
+      break;
+    }
+
+    case GLSLstd450IMix: {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Extended instruction GLSLstd450IMix is not supported";
+    }
+
+    case GLSLstd450Bad: {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Encountered extended instruction GLSLstd450Bad";
+    }
+
+    case GLSLstd450Count: {
+      assert(0);
+      break;
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateExtInstOpenClStd(ValidationState_t& _,
+                                      const Instruction* inst) {
+  const uint32_t result_type = inst->type_id();
+  const uint32_t num_operands = static_cast<uint32_t>(inst->operands().size());
+  const uint32_t ext_inst_index = inst->word(4);
+  const OpenCLLIB::Entrypoints ext_inst_key =
+      OpenCLLIB::Entrypoints(ext_inst_index);
+  switch (ext_inst_key) {
+    case OpenCLLIB::Acos:
+    case OpenCLLIB::Acosh:
+    case OpenCLLIB::Acospi:
+    case OpenCLLIB::Asin:
+    case OpenCLLIB::Asinh:
+    case OpenCLLIB::Asinpi:
+    case OpenCLLIB::Atan:
+    case OpenCLLIB::Atan2:
+    case OpenCLLIB::Atanh:
+    case OpenCLLIB::Atanpi:
+    case OpenCLLIB::Atan2pi:
+    case OpenCLLIB::Cbrt:
+    case OpenCLLIB::Ceil:
+    case OpenCLLIB::Copysign:
+    case OpenCLLIB::Cos:
+    case OpenCLLIB::Cosh:
+    case OpenCLLIB::Cospi:
+    case OpenCLLIB::Erfc:
+    case OpenCLLIB::Erf:
+    case OpenCLLIB::Exp:
+    case OpenCLLIB::Exp2:
+    case OpenCLLIB::Exp10:
+    case OpenCLLIB::Expm1:
+    case OpenCLLIB::Fabs:
+    case OpenCLLIB::Fdim:
+    case OpenCLLIB::Floor:
+    case OpenCLLIB::Fma:
+    case OpenCLLIB::Fmax:
+    case OpenCLLIB::Fmin:
+    case OpenCLLIB::Fmod:
+    case OpenCLLIB::Hypot:
+    case OpenCLLIB::Lgamma:
+    case OpenCLLIB::Log:
+    case OpenCLLIB::Log2:
+    case OpenCLLIB::Log10:
+    case OpenCLLIB::Log1p:
+    case OpenCLLIB::Logb:
+    case OpenCLLIB::Mad:
+    case OpenCLLIB::Maxmag:
+    case OpenCLLIB::Minmag:
+    case OpenCLLIB::Nextafter:
+    case OpenCLLIB::Pow:
+    case OpenCLLIB::Powr:
+    case OpenCLLIB::Remainder:
+    case OpenCLLIB::Rint:
+    case OpenCLLIB::Round:
+    case OpenCLLIB::Rsqrt:
+    case OpenCLLIB::Sin:
+    case OpenCLLIB::Sinh:
+    case OpenCLLIB::Sinpi:
+    case OpenCLLIB::Sqrt:
+    case OpenCLLIB::Tan:
+    case OpenCLLIB::Tanh:
+    case OpenCLLIB::Tanpi:
+    case OpenCLLIB::Tgamma:
+    case OpenCLLIB::Trunc:
+    case OpenCLLIB::Half_cos:
+    case OpenCLLIB::Half_divide:
+    case OpenCLLIB::Half_exp:
+    case OpenCLLIB::Half_exp2:
+    case OpenCLLIB::Half_exp10:
+    case OpenCLLIB::Half_log:
+    case OpenCLLIB::Half_log2:
+    case OpenCLLIB::Half_log10:
+    case OpenCLLIB::Half_powr:
+    case OpenCLLIB::Half_recip:
+    case OpenCLLIB::Half_rsqrt:
+    case OpenCLLIB::Half_sin:
+    case OpenCLLIB::Half_sqrt:
+    case OpenCLLIB::Half_tan:
+    case OpenCLLIB::Native_cos:
+    case OpenCLLIB::Native_divide:
+    case OpenCLLIB::Native_exp:
+    case OpenCLLIB::Native_exp2:
+    case OpenCLLIB::Native_exp10:
+    case OpenCLLIB::Native_log:
+    case OpenCLLIB::Native_log2:
+    case OpenCLLIB::Native_log10:
+    case OpenCLLIB::Native_powr:
+    case OpenCLLIB::Native_recip:
+    case OpenCLLIB::Native_rsqrt:
+    case OpenCLLIB::Native_sin:
+    case OpenCLLIB::Native_sqrt:
+    case OpenCLLIB::Native_tan:
+    case OpenCLLIB::FClamp:
+    case OpenCLLIB::Degrees:
+    case OpenCLLIB::FMax_common:
+    case OpenCLLIB::FMin_common:
+    case OpenCLLIB::Mix:
+    case OpenCLLIB::Radians:
+    case OpenCLLIB::Step:
+    case OpenCLLIB::Smoothstep:
+    case OpenCLLIB::Sign: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected types of all operands to be equal to Result "
+                    "Type";
+        }
+      }
+      break;
+    }
+
+    case OpenCLLIB::Fract:
+    case OpenCLLIB::Modf:
+    case OpenCLLIB::Sincos: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (result_type != x_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected type of operand X to be equal to Result Type";
+      }
+
+      const uint32_t p_type = _.GetOperandTypeId(inst, 5);
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected the last operand to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected storage class of the pointer to be Generic, "
+                  "CrossWorkgroup, Workgroup or Function";
+      }
+
+      if (!_.ContainsUntypedPointer(p_type) && result_type != p_data_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected data type of the pointer to be equal to Result "
+                  "Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Frexp:
+    case OpenCLLIB::Lgamma_r:
+    case OpenCLLIB::Remquo: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      uint32_t operand_index = 4;
+      const uint32_t x_type = _.GetOperandTypeId(inst, operand_index++);
+      if (result_type != x_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected type of operand X to be equal to Result Type";
+      }
+
+      if (ext_inst_key == OpenCLLIB::Remquo) {
+        const uint32_t y_type = _.GetOperandTypeId(inst, operand_index++);
+        if (result_type != y_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected type of operand Y to be equal to Result Type";
+        }
+      }
+
+      const uint32_t p_type = _.GetOperandTypeId(inst, operand_index++);
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected the last operand to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected storage class of the pointer to be Generic, "
+                  "CrossWorkgroup, Workgroup or Function";
+      }
+
+      if ((!_.IsIntScalarOrVectorType(p_data_type) ||
+           _.GetBitWidth(p_data_type) != 32) &&
+          !_.ContainsUntypedPointer(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected data type of the pointer to be a 32-bit int "
+                  "scalar or vector type";
+      }
+
+      if (!_.ContainsUntypedPointer(p_type) &&
+          _.GetDimension(p_data_type) != num_components) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected data type of the pointer to have the same number "
+                  "of components as Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Ilogb: {
+      if (!_.IsIntScalarOrVectorType(result_type) ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit int scalar or vector "
+                  "type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarOrVectorType(x_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to be a float scalar or vector";
+      }
+
+      if (_.GetDimension(x_type) != num_components) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to have the same number of components "
+                  "as Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Ldexp:
+    case OpenCLLIB::Pown:
+    case OpenCLLIB::Rootn: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      if (result_type != x_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected type of operand X to be equal to Result Type";
+      }
+
+      const uint32_t exp_type = _.GetOperandTypeId(inst, 5);
+      if (!_.IsIntScalarOrVectorType(exp_type) ||
+          _.GetBitWidth(exp_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected the exponent to be a 32-bit int scalar or vector";
+      }
+
+      if (_.GetDimension(exp_type) != num_components) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected the exponent to have the same number of "
+                  "components as Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Nan: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t nancode_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsIntScalarOrVectorType(nancode_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Nancode to be an int scalar or vector type";
+      }
+
+      if (_.GetDimension(nancode_type) != num_components) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Nancode to have the same number of components as "
+                  "Result Type";
+      }
+
+      if (_.GetBitWidth(result_type) != _.GetBitWidth(nancode_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Nancode to have the same bit width as Result "
+                  "Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::SAbs:
+    case OpenCLLIB::SAbs_diff:
+    case OpenCLLIB::SAdd_sat:
+    case OpenCLLIB::UAdd_sat:
+    case OpenCLLIB::SHadd:
+    case OpenCLLIB::UHadd:
+    case OpenCLLIB::SRhadd:
+    case OpenCLLIB::URhadd:
+    case OpenCLLIB::SClamp:
+    case OpenCLLIB::UClamp:
+    case OpenCLLIB::Clz:
+    case OpenCLLIB::Ctz:
+    case OpenCLLIB::SMad_hi:
+    case OpenCLLIB::UMad_sat:
+    case OpenCLLIB::SMad_sat:
+    case OpenCLLIB::SMax:
+    case OpenCLLIB::UMax:
+    case OpenCLLIB::SMin:
+    case OpenCLLIB::UMin:
+    case OpenCLLIB::SMul_hi:
+    case OpenCLLIB::Rotate:
+    case OpenCLLIB::SSub_sat:
+    case OpenCLLIB::USub_sat:
+    case OpenCLLIB::Popcount:
+    case OpenCLLIB::UAbs:
+    case OpenCLLIB::UAbs_diff:
+    case OpenCLLIB::UMul_hi:
+    case OpenCLLIB::UMad_hi: {
+      if (!_.IsIntScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected types of all operands to be equal to Result "
+                    "Type";
+        }
+      }
+      break;
+    }
+
+    case OpenCLLIB::U_Upsample:
+    case OpenCLLIB::S_Upsample: {
+      if (!_.IsIntScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int scalar or vector "
+                  "type";
+      }
+
+      const uint32_t result_num_components = _.GetDimension(result_type);
+      if (result_num_components > 4 && result_num_components != 8 &&
+          result_num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t result_bit_width = _.GetBitWidth(result_type);
+      if (result_bit_width != 16 && result_bit_width != 32 &&
+          result_bit_width != 64) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected bit width of Result Type components to be 16, 32 "
+                  "or 64";
+      }
+
+      const uint32_t hi_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t lo_type = _.GetOperandTypeId(inst, 5);
+
+      if (hi_type != lo_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Hi and Lo operands to have the same type";
+      }
+
+      if (result_num_components != _.GetDimension(hi_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Hi and Lo operands to have the same number of "
+                  "components as Result Type";
+      }
+
+      if (result_bit_width != 2 * _.GetBitWidth(hi_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected bit width of components of Hi and Lo operands to "
+                  "be half of the bit width of components of Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::SMad24:
+    case OpenCLLIB::UMad24:
+    case OpenCLLIB::SMul24:
+    case OpenCLLIB::UMul24: {
+      if (!_.IsIntScalarOrVectorType(result_type) ||
+          _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit int scalar or vector "
+                  "type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected types of all operands to be equal to Result "
+                    "Type";
+        }
+      }
+      break;
+    }
+
+    case OpenCLLIB::Cross: {
+      if (!_.IsFloatVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components != 3 && num_components != 4) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have 3 or 4 components";
+      }
+
+      const uint32_t x_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t y_type = _.GetOperandTypeId(inst, 5);
+
+      if (x_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X type to be equal to Result Type";
+      }
+
+      if (y_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Y type to be equal to Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Distance:
+    case OpenCLLIB::Fast_distance: {
+      if (!_.IsFloatScalarType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar type";
+      }
+
+      const uint32_t p0_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarOrVectorType(p0_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P0 to be of float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(p0_type);
+      if (num_components > 4) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P0 to have no more than 4 components";
+      }
+
+      if (result_type != _.GetComponentType(p0_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P0 component type to be equal to "
+               << "Result Type";
+      }
+
+      const uint32_t p1_type = _.GetOperandTypeId(inst, 5);
+      if (p0_type != p1_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operands P0 and P1 to be of the same type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Length:
+    case OpenCLLIB::Fast_length: {
+      if (!_.IsFloatScalarType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar type";
+      }
+
+      const uint32_t p_type = _.GetOperandTypeId(inst, 4);
+      if (!_.IsFloatScalarOrVectorType(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a float scalar or vector";
+      }
+
+      const uint32_t num_components = _.GetDimension(p_type);
+      if (num_components > 4) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to have no more than 4 components";
+      }
+
+      if (result_type != _.GetComponentType(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P component type to be equal to Result "
+                  "Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Normalize:
+    case OpenCLLIB::Fast_normalize: {
+      if (!_.IsFloatScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar or vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have no more than 4 components";
+      }
+
+      const uint32_t p_type = _.GetOperandTypeId(inst, 4);
+      if (p_type != result_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P type to be equal to Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Bitselect: {
+      if (!_.IsFloatScalarOrVectorType(result_type) &&
+          !_.IsIntScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int or float scalar or "
+                  "vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      for (uint32_t operand_index = 4; operand_index < num_operands;
+           ++operand_index) {
+        const uint32_t operand_type = _.GetOperandTypeId(inst, operand_index);
+        if (result_type != operand_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected types of all operands to be equal to Result "
+                    "Type";
+        }
+      }
+      break;
+    }
+
+    case OpenCLLIB::Select: {
+      if (!_.IsFloatScalarOrVectorType(result_type) &&
+          !_.IsIntScalarOrVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int or float scalar or "
+                  "vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t a_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t b_type = _.GetOperandTypeId(inst, 5);
+      const uint32_t c_type = _.GetOperandTypeId(inst, 6);
+
+      if (result_type != a_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand A type to be equal to Result Type";
+      }
+
+      if (result_type != b_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand B type to be equal to Result Type";
+      }
+
+      if (!_.IsIntScalarOrVectorType(c_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand C to be an int scalar or vector";
+      }
+
+      if (num_components != _.GetDimension(c_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand C to have the same number of components "
+                  "as Result Type";
+      }
+
+      if (_.GetBitWidth(result_type) != _.GetBitWidth(c_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand C to have the same bit width as Result "
+                  "Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Vloadn: {
+      if (!_.IsFloatVectorType(result_type) &&
+          !_.IsIntVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int or float vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have 2, 3, 4, 8 or 16 components";
+      }
+
+      const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t p_type = _.GetOperandTypeId(inst, 5);
+
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
+      }
+
+      if (!_.IsIntScalarType(offset_type) ||
+          _.GetBitWidth(offset_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Offset to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
+      }
+
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::UniformConstant &&
+          p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P storage class to be UniformConstant, "
+                  "Generic, CrossWorkgroup, Workgroup or Function";
+      }
+
+      if (_.GetComponentType(result_type) != p_data_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P data type to be equal to component "
+                  "type of Result Type";
+      }
+
+      const uint32_t n_value = inst->word(7);
+      if (num_components != n_value) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected literal N to be equal to the number of "
+                  "components of Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Vstoren: {
+      if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << ": expected Result Type to be void";
+      }
+
+      const uint32_t data_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
+      const uint32_t p_type = _.GetOperandTypeId(inst, 6);
+
+      if (!_.IsFloatVectorType(data_type) && !_.IsIntVectorType(data_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Data to be an int or float vector";
+      }
+
+      const uint32_t num_components = _.GetDimension(data_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Data to have 2, 3, 4, 8 or 16 components";
+      }
+
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
+      }
+
+      if (!_.IsIntScalarType(offset_type) ||
+          _.GetBitWidth(offset_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Offset to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
+      }
+
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P storage class to be Generic, "
+                  "CrossWorkgroup, Workgroup or Function";
+      }
+
+      if (_.GetComponentType(data_type) != p_data_type) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P data type to be equal to the type of "
+                  "operand Data components";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Vload_half: {
+      if (!_.IsFloatScalarType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float scalar type";
+      }
+
+      const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t p_type = _.GetOperandTypeId(inst, 5);
+
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
+      }
+
+      if (!_.IsIntScalarType(offset_type) ||
+          _.GetBitWidth(offset_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Offset to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
+      }
+
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::UniformConstant &&
+          p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P storage class to be UniformConstant, "
+                  "Generic, CrossWorkgroup, Workgroup or Function";
+      }
+
+      if ((!_.IsFloatScalarType(p_data_type) ||
+           _.GetBitWidth(p_data_type) != 16) &&
+          !_.ContainsUntypedPointer(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P data type to be 16-bit float scalar";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Vload_halfn:
+    case OpenCLLIB::Vloada_halfn: {
+      if (!_.IsFloatVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a float vector type";
+      }
+
+      const uint32_t num_components = _.GetDimension(result_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have 2, 3, 4, 8 or 16 components";
+      }
+
+      const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t p_type = _.GetOperandTypeId(inst, 5);
+
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
+      }
+
+      if (!_.IsIntScalarType(offset_type) ||
+          _.GetBitWidth(offset_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Offset to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
+      }
+
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::UniformConstant &&
+          p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P storage class to be UniformConstant, "
+                  "Generic, CrossWorkgroup, Workgroup or Function";
+      }
+
+      if ((!_.IsFloatScalarType(p_data_type) ||
+           _.GetBitWidth(p_data_type) != 16) &&
+          !_.ContainsUntypedPointer(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P data type to be 16-bit float scalar";
+      }
+
+      const uint32_t n_value = inst->word(7);
+      if (num_components != n_value) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected literal N to be equal to the number of "
+                  "components of Result Type";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Vstore_half:
+    case OpenCLLIB::Vstore_half_r:
+    case OpenCLLIB::Vstore_halfn:
+    case OpenCLLIB::Vstore_halfn_r:
+    case OpenCLLIB::Vstorea_halfn:
+    case OpenCLLIB::Vstorea_halfn_r: {
+      if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << ": expected Result Type to be void";
+      }
+
+      const uint32_t data_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
+      const uint32_t p_type = _.GetOperandTypeId(inst, 6);
+      const uint32_t data_type_bit_width = _.GetBitWidth(data_type);
+
+      if (ext_inst_key == OpenCLLIB::Vstore_half ||
+          ext_inst_key == OpenCLLIB::Vstore_half_r) {
+        if (!_.IsFloatScalarType(data_type) ||
+            (data_type_bit_width != 32 && data_type_bit_width != 64)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected Data to be a 32 or 64-bit float scalar";
+        }
+      } else {
+        if (!_.IsFloatVectorType(data_type) ||
+            (data_type_bit_width != 32 && data_type_bit_width != 64)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected Data to be a 32 or 64-bit float vector";
         }
 
         const uint32_t num_components = _.GetDimension(data_type);
@@ -2656,1194 +2861,1002 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
                  << GetExtInstName(_, inst) << ": "
                  << "expected Data to have 2, 3, 4, 8 or 16 components";
         }
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(offset_type) ||
-            _.GetBitWidth(offset_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Offset to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P storage class to be Generic, "
-                    "CrossWorkgroup, Workgroup or Function";
-        }
-
-        if (_.GetComponentType(data_type) != p_data_type) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P data type to be equal to the type of "
-                    "operand Data components";
-        }
-        break;
       }
 
-      case OpenCLLIB::Vload_half: {
-        if (!_.IsFloatScalarType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float scalar type";
-        }
-
-        const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t p_type = _.GetOperandTypeId(inst, 5);
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(offset_type) ||
-            _.GetBitWidth(offset_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Offset to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::UniformConstant &&
-            p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P storage class to be UniformConstant, "
-                    "Generic, CrossWorkgroup, Workgroup or Function";
-        }
-
-        if ((!_.IsFloatScalarType(p_data_type) ||
-             _.GetBitWidth(p_data_type) != 16) &&
-            !_.ContainsUntypedPointer(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P data type to be 16-bit float scalar";
-        }
-        break;
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
       }
 
-      case OpenCLLIB::Vload_halfn:
-      case OpenCLLIB::Vloada_halfn: {
-        if (!_.IsFloatVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a float vector type";
-        }
-
-        const uint32_t num_components = _.GetDimension(result_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have 2, 3, 4, 8 or 16 components";
-        }
-
-        const uint32_t offset_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t p_type = _.GetOperandTypeId(inst, 5);
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(offset_type) ||
-            _.GetBitWidth(offset_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Offset to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::UniformConstant &&
-            p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P storage class to be UniformConstant, "
-                    "Generic, CrossWorkgroup, Workgroup or Function";
-        }
-
-        if ((!_.IsFloatScalarType(p_data_type) ||
-             _.GetBitWidth(p_data_type) != 16) &&
-            !_.ContainsUntypedPointer(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P data type to be 16-bit float scalar";
-        }
-
-        const uint32_t n_value = inst->word(7);
-        if (num_components != n_value) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected literal N to be equal to the number of "
-                    "components of Result Type";
-        }
-        break;
+      if (!_.IsIntScalarType(offset_type) ||
+          _.GetBitWidth(offset_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Offset to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
       }
 
-      case OpenCLLIB::Vstore_half:
-      case OpenCLLIB::Vstore_half_r:
-      case OpenCLLIB::Vstore_halfn:
-      case OpenCLLIB::Vstore_halfn_r:
-      case OpenCLLIB::Vstorea_halfn:
-      case OpenCLLIB::Vstorea_halfn_r: {
-        if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << ": expected Result Type to be void";
-        }
-
-        const uint32_t data_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
-        const uint32_t p_type = _.GetOperandTypeId(inst, 6);
-        const uint32_t data_type_bit_width = _.GetBitWidth(data_type);
-
-        if (ext_inst_key == OpenCLLIB::Vstore_half ||
-            ext_inst_key == OpenCLLIB::Vstore_half_r) {
-          if (!_.IsFloatScalarType(data_type) ||
-              (data_type_bit_width != 32 && data_type_bit_width != 64)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Data to be a 32 or 64-bit float scalar";
-          }
-        } else {
-          if (!_.IsFloatVectorType(data_type) ||
-              (data_type_bit_width != 32 && data_type_bit_width != 64)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Data to be a 32 or 64-bit float vector";
-          }
-
-          const uint32_t num_components = _.GetDimension(data_type);
-          if (num_components > 4 && num_components != 8 &&
-              num_components != 16) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Data to have 2, 3, 4, 8 or 16 components";
-          }
-        }
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(offset_type) ||
-            _.GetBitWidth(offset_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Offset to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::Generic &&
-            p_storage_class != spv::StorageClass::CrossWorkgroup &&
-            p_storage_class != spv::StorageClass::Workgroup &&
-            p_storage_class != spv::StorageClass::Function) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P storage class to be Generic, "
-                    "CrossWorkgroup, Workgroup or Function";
-        }
-
-        if ((!_.IsFloatScalarType(p_data_type) ||
-             _.GetBitWidth(p_data_type) != 16) &&
-            !_.ContainsUntypedPointer(p_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand P data type to be 16-bit float scalar";
-        }
-
-        // Rounding mode enum is checked by assembler.
-        break;
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P to be a pointer";
       }
 
-      case OpenCLLIB::Shuffle:
-      case OpenCLLIB::Shuffle2: {
-        if (!_.IsFloatVectorType(result_type) &&
-            !_.IsIntVectorType(result_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be an int or float vector type";
-        }
-
-        const uint32_t result_num_components = _.GetDimension(result_type);
-        if (result_num_components != 2 && result_num_components != 4 &&
-            result_num_components != 8 && result_num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to have 2, 4, 8 or 16 components";
-        }
-
-        uint32_t operand_index = 4;
-        const uint32_t x_type = _.GetOperandTypeId(inst, operand_index++);
-
-        if (ext_inst_key == OpenCLLIB::Shuffle2) {
-          const uint32_t y_type = _.GetOperandTypeId(inst, operand_index++);
-          if (x_type != y_type) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected operands X and Y to be of the same type";
-          }
-        }
-
-        const uint32_t shuffle_mask_type =
-            _.GetOperandTypeId(inst, operand_index++);
-
-        if (!_.IsFloatVectorType(x_type) && !_.IsIntVectorType(x_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to be an int or float vector";
-        }
-
-        const uint32_t x_num_components = _.GetDimension(x_type);
-        if (x_num_components != 2 && x_num_components != 4 &&
-            x_num_components != 8 && x_num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X to have 2, 4, 8 or 16 components";
-        }
-
-        const uint32_t result_component_type = _.GetComponentType(result_type);
-
-        if (result_component_type != _.GetComponentType(x_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand X and Result Type to have equal "
-                    "component types";
-        }
-
-        if (!_.IsIntVectorType(shuffle_mask_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Shuffle Mask to be an int vector";
-        }
-
-        if (result_num_components != _.GetDimension(shuffle_mask_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Shuffle Mask to have the same number of "
-                    "components as Result Type";
-        }
-
-        if (_.GetBitWidth(result_component_type) !=
-            _.GetBitWidth(shuffle_mask_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Shuffle Mask components to have the same "
-                    "bit width as Result Type components";
-        }
-        break;
+      if (p_storage_class != spv::StorageClass::Generic &&
+          p_storage_class != spv::StorageClass::CrossWorkgroup &&
+          p_storage_class != spv::StorageClass::Workgroup &&
+          p_storage_class != spv::StorageClass::Function) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P storage class to be Generic, "
+                  "CrossWorkgroup, Workgroup or Function";
       }
 
-      case OpenCLLIB::Printf: {
-        if (!_.IsIntScalarType(result_type) ||
-            _.GetBitWidth(result_type) != 32) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a 32-bit int type";
-        }
-
-        const uint32_t format_type = _.GetOperandTypeId(inst, 4);
-        spv::StorageClass format_storage_class;
-        uint32_t format_data_type = 0;
-        if (!_.GetPointerTypeInfo(format_type, &format_data_type,
-                                  &format_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Format to be a pointer";
-        }
-
-        if (_.HasExtension(
-                Extension::kSPV_EXT_relaxed_printf_string_address_space)) {
-          if (format_storage_class != spv::StorageClass::UniformConstant &&
-              // Extension SPV_EXT_relaxed_printf_string_address_space allows
-              // format strings in Global, Local, Private and Generic address
-              // spaces
-
-              // Global
-              format_storage_class != spv::StorageClass::CrossWorkgroup &&
-              // Local
-              format_storage_class != spv::StorageClass::Workgroup &&
-              // Private
-              format_storage_class != spv::StorageClass::Function &&
-              // Generic
-              format_storage_class != spv::StorageClass::Generic) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Format storage class to be UniformConstant, "
-                      "Crossworkgroup, Workgroup, Function, or Generic";
-          }
-        } else {
-          if (format_storage_class != spv::StorageClass::UniformConstant) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected Format storage class to be UniformConstant";
-          }
-        }
-
-        // If pointer points to an array, get the type of an element
-        if (_.IsIntArrayType(format_data_type))
-          format_data_type = _.GetComponentType(format_data_type);
-
-        if ((!_.IsIntScalarType(format_data_type) ||
-             _.GetBitWidth(format_data_type) != 8) &&
-            !_.ContainsUntypedPointer(format_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Format data type to be 8-bit int";
-        }
-        break;
+      if ((!_.IsFloatScalarType(p_data_type) ||
+           _.GetBitWidth(p_data_type) != 16) &&
+          !_.ContainsUntypedPointer(p_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand P data type to be 16-bit float scalar";
       }
 
-      case OpenCLLIB::Prefetch: {
-        if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << ": expected Result Type to be void";
-        }
-
-        const uint32_t p_type = _.GetOperandTypeId(inst, 4);
-        const uint32_t num_elements_type = _.GetOperandTypeId(inst, 5);
-
-        spv::StorageClass p_storage_class;
-        uint32_t p_data_type = 0;
-        if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Ptr to be a pointer";
-        }
-
-        if (p_storage_class != spv::StorageClass::CrossWorkgroup) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Ptr storage class to be CrossWorkgroup";
-        }
-
-        if (!_.IsFloatScalarOrVectorType(p_data_type) &&
-            !_.IsIntScalarOrVectorType(p_data_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Ptr data type to be int or float scalar or "
-                    "vector";
-        }
-
-        const uint32_t num_components = _.GetDimension(p_data_type);
-        if (num_components > 4 && num_components != 8 && num_components != 16) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected Result Type to be a scalar or a vector with 2, "
-                    "3, 4, 8 or 16 components";
-        }
-
-        const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
-        if (!size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << " can only be used with physical addressing models";
-        }
-
-        if (!_.IsIntScalarType(num_elements_type) ||
-            _.GetBitWidth(num_elements_type) != size_t_bit_width) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst) << ": "
-                 << "expected operand Num Elements to be of type size_t ("
-                 << size_t_bit_width
-                 << "-bit integer for the addressing model used in the module)";
-        }
-        break;
-      }
-    }
-  } else if (ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100 ||
-             ext_inst_type ==
-                 SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-    if (!_.IsVoidType(result_type)) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << GetExtInstName(_, inst) << ": "
-             << "expected result type must be a result id of " << "OpTypeVoid";
+      // Rounding mode enum is checked by assembler.
+      break;
     }
 
-    const bool vulkanDebugInfo =
-        ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100;
+    case OpenCLLIB::Shuffle:
+    case OpenCLLIB::Shuffle2: {
+      if (!_.IsFloatVectorType(result_type) &&
+          !_.IsIntVectorType(result_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be an int or float vector type";
+      }
 
-    auto num_words = inst->words().size();
+      const uint32_t result_num_components = _.GetDimension(result_type);
+      if (result_num_components != 2 && result_num_components != 4 &&
+          result_num_components != 8 && result_num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to have 2, 4, 8 or 16 components";
+      }
 
-    // Handle any non-common NonSemanticShaderDebugInfo instructions.
-    if (vulkanDebugInfo) {
-      const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-          NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
-      switch (ext_inst_key) {
-        // The following block of instructions will be handled by the common
-        // validation.
-        case NonSemanticShaderDebugInfo100DebugInfoNone:
-        case NonSemanticShaderDebugInfo100DebugCompilationUnit:
-        case NonSemanticShaderDebugInfo100DebugTypePointer:
-        case NonSemanticShaderDebugInfo100DebugTypeQualifier:
-        case NonSemanticShaderDebugInfo100DebugTypeArray:
-        case NonSemanticShaderDebugInfo100DebugTypeVector:
-        case NonSemanticShaderDebugInfo100DebugTypedef:
-        case NonSemanticShaderDebugInfo100DebugTypeFunction:
-        case NonSemanticShaderDebugInfo100DebugTypeEnum:
-        case NonSemanticShaderDebugInfo100DebugTypeComposite:
-        case NonSemanticShaderDebugInfo100DebugTypeMember:
-        case NonSemanticShaderDebugInfo100DebugTypeInheritance:
-        case NonSemanticShaderDebugInfo100DebugTypePtrToMember:
-        case NonSemanticShaderDebugInfo100DebugTypeTemplate:
-        case NonSemanticShaderDebugInfo100DebugTypeTemplateParameter:
-        case NonSemanticShaderDebugInfo100DebugTypeTemplateTemplateParameter:
-        case NonSemanticShaderDebugInfo100DebugTypeTemplateParameterPack:
-        case NonSemanticShaderDebugInfo100DebugGlobalVariable:
-        case NonSemanticShaderDebugInfo100DebugFunctionDeclaration:
-        case NonSemanticShaderDebugInfo100DebugFunction:
-        case NonSemanticShaderDebugInfo100DebugLexicalBlock:
-        case NonSemanticShaderDebugInfo100DebugLexicalBlockDiscriminator:
-        case NonSemanticShaderDebugInfo100DebugScope:
-        case NonSemanticShaderDebugInfo100DebugNoScope:
-        case NonSemanticShaderDebugInfo100DebugInlinedAt:
-        case NonSemanticShaderDebugInfo100DebugLocalVariable:
-        case NonSemanticShaderDebugInfo100DebugInlinedVariable:
-        case NonSemanticShaderDebugInfo100DebugValue:
-        case NonSemanticShaderDebugInfo100DebugOperation:
-        case NonSemanticShaderDebugInfo100DebugExpression:
-        case NonSemanticShaderDebugInfo100DebugMacroDef:
-        case NonSemanticShaderDebugInfo100DebugMacroUndef:
-        case NonSemanticShaderDebugInfo100DebugImportedEntity:
-        case NonSemanticShaderDebugInfo100DebugSource:
-          break;
+      uint32_t operand_index = 4;
+      const uint32_t x_type = _.GetOperandTypeId(inst, operand_index++);
 
-        // These checks are for operands that are differnet in
-        // ShaderDebugInfo100
-        case NonSemanticShaderDebugInfo100DebugTypeBasic: {
-          CHECK_CONST_UINT_OPERAND("Flags", 8);
-          break;
+      if (ext_inst_key == OpenCLLIB::Shuffle2) {
+        const uint32_t y_type = _.GetOperandTypeId(inst, operand_index++);
+        if (x_type != y_type) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected operands X and Y to be of the same type";
         }
-        case NonSemanticShaderDebugInfo100DebugDeclare: {
-          for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
-            auto index_inst = _.FindDef(inst->word(word_index));
-            auto type_id = index_inst != nullptr ? index_inst->type_id() : 0;
-            if (type_id == 0 || !IsIntScalar(_, type_id, false, false))
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": "
-                     << "expected index must be scalar integer";
-          }
-          break;
+      }
+
+      const uint32_t shuffle_mask_type =
+          _.GetOperandTypeId(inst, operand_index++);
+
+      if (!_.IsFloatVectorType(x_type) && !_.IsIntVectorType(x_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to be an int or float vector";
+      }
+
+      const uint32_t x_num_components = _.GetDimension(x_type);
+      if (x_num_components != 2 && x_num_components != 4 &&
+          x_num_components != 8 && x_num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X to have 2, 4, 8 or 16 components";
+      }
+
+      const uint32_t result_component_type = _.GetComponentType(result_type);
+
+      if (result_component_type != _.GetComponentType(x_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand X and Result Type to have equal "
+                  "component types";
+      }
+
+      if (!_.IsIntVectorType(shuffle_mask_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Shuffle Mask to be an int vector";
+      }
+
+      if (result_num_components != _.GetDimension(shuffle_mask_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Shuffle Mask to have the same number of "
+                  "components as Result Type";
+      }
+
+      if (_.GetBitWidth(result_component_type) !=
+          _.GetBitWidth(shuffle_mask_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Shuffle Mask components to have the same "
+                  "bit width as Result Type components";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Printf: {
+      if (!_.IsIntScalarType(result_type) || _.GetBitWidth(result_type) != 32) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a 32-bit int type";
+      }
+
+      const uint32_t format_type = _.GetOperandTypeId(inst, 4);
+      spv::StorageClass format_storage_class;
+      uint32_t format_data_type = 0;
+      if (!_.GetPointerTypeInfo(format_type, &format_data_type,
+                                &format_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Format to be a pointer";
+      }
+
+      if (_.HasExtension(
+              Extension::kSPV_EXT_relaxed_printf_string_address_space)) {
+        if (format_storage_class != spv::StorageClass::UniformConstant &&
+            // Extension SPV_EXT_relaxed_printf_string_address_space allows
+            // format strings in Global, Local, Private and Generic address
+            // spaces
+
+            // Global
+            format_storage_class != spv::StorageClass::CrossWorkgroup &&
+            // Local
+            format_storage_class != spv::StorageClass::Workgroup &&
+            // Private
+            format_storage_class != spv::StorageClass::Function &&
+            // Generic
+            format_storage_class != spv::StorageClass::Generic) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected Format storage class to be UniformConstant, "
+                    "Crossworkgroup, Workgroup, Function, or Generic";
         }
-        case NonSemanticShaderDebugInfo100DebugTypeMatrix: {
-          CHECK_DEBUG_OPERAND("Vector Type", CommonDebugInfoDebugTypeVector, 5);
+      } else {
+        if (format_storage_class != spv::StorageClass::UniformConstant) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected Format storage class to be UniformConstant";
+        }
+      }
 
-          CHECK_CONST_UINT_OPERAND("Vector Count", 6);
+      // If pointer points to an array, get the type of an element
+      if (_.IsIntArrayType(format_data_type))
+        format_data_type = _.GetComponentType(format_data_type);
 
-          uint32_t vector_count = inst->word(6);
+      if ((!_.IsIntScalarType(format_data_type) ||
+           _.GetBitWidth(format_data_type) != 8) &&
+          !_.ContainsUntypedPointer(format_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Format data type to be 8-bit int";
+      }
+      break;
+    }
+
+    case OpenCLLIB::Prefetch: {
+      if (_.GetIdOpcode(result_type) != spv::Op::OpTypeVoid) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << ": expected Result Type to be void";
+      }
+
+      const uint32_t p_type = _.GetOperandTypeId(inst, 4);
+      const uint32_t num_elements_type = _.GetOperandTypeId(inst, 5);
+
+      spv::StorageClass p_storage_class;
+      uint32_t p_data_type = 0;
+      if (!_.GetPointerTypeInfo(p_type, &p_data_type, &p_storage_class)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Ptr to be a pointer";
+      }
+
+      if (p_storage_class != spv::StorageClass::CrossWorkgroup) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Ptr storage class to be CrossWorkgroup";
+      }
+
+      if (!_.IsFloatScalarOrVectorType(p_data_type) &&
+          !_.IsIntScalarOrVectorType(p_data_type)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Ptr data type to be int or float scalar or "
+                  "vector";
+      }
+
+      const uint32_t num_components = _.GetDimension(p_data_type);
+      if (num_components > 4 && num_components != 8 && num_components != 16) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected Result Type to be a scalar or a vector with 2, "
+                  "3, 4, 8 or 16 components";
+      }
+
+      const uint32_t size_t_bit_width = GetSizeTBitWidth(_);
+      if (!size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst)
+               << " can only be used with physical addressing models";
+      }
+
+      if (!_.IsIntScalarType(num_elements_type) ||
+          _.GetBitWidth(num_elements_type) != size_t_bit_width) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << GetExtInstName(_, inst) << ": "
+               << "expected operand Num Elements to be of type size_t ("
+               << size_t_bit_width
+               << "-bit integer for the addressing model used in the module)";
+      }
+      break;
+    }
+  }
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateExtInstDebugInfo100(ValidationState_t& _,
+                                         const Instruction* inst) {
+  const uint32_t result_type = inst->type_id();
+  const uint32_t ext_inst_index = inst->word(4);
+  if (!_.IsVoidType(result_type)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << GetExtInstName(_, inst) << ": "
+           << "expected result type must be a result id of " << "OpTypeVoid";
+  }
+
+  const spv_ext_inst_type_t ext_inst_type =
+      spv_ext_inst_type_t(inst->ext_inst_type());
+  const bool vulkanDebugInfo =
+      ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100;
+
+  auto num_words = inst->words().size();
+
+  // Handle any non-common NonSemanticShaderDebugInfo instructions.
+  if (vulkanDebugInfo) {
+    const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
+        NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
+    switch (ext_inst_key) {
+      // The following block of instructions will be handled by the common
+      // validation.
+      case NonSemanticShaderDebugInfo100DebugInfoNone:
+      case NonSemanticShaderDebugInfo100DebugCompilationUnit:
+      case NonSemanticShaderDebugInfo100DebugTypePointer:
+      case NonSemanticShaderDebugInfo100DebugTypeQualifier:
+      case NonSemanticShaderDebugInfo100DebugTypeArray:
+      case NonSemanticShaderDebugInfo100DebugTypeVector:
+      case NonSemanticShaderDebugInfo100DebugTypedef:
+      case NonSemanticShaderDebugInfo100DebugTypeFunction:
+      case NonSemanticShaderDebugInfo100DebugTypeEnum:
+      case NonSemanticShaderDebugInfo100DebugTypeComposite:
+      case NonSemanticShaderDebugInfo100DebugTypeMember:
+      case NonSemanticShaderDebugInfo100DebugTypeInheritance:
+      case NonSemanticShaderDebugInfo100DebugTypePtrToMember:
+      case NonSemanticShaderDebugInfo100DebugTypeTemplate:
+      case NonSemanticShaderDebugInfo100DebugTypeTemplateParameter:
+      case NonSemanticShaderDebugInfo100DebugTypeTemplateTemplateParameter:
+      case NonSemanticShaderDebugInfo100DebugTypeTemplateParameterPack:
+      case NonSemanticShaderDebugInfo100DebugGlobalVariable:
+      case NonSemanticShaderDebugInfo100DebugFunctionDeclaration:
+      case NonSemanticShaderDebugInfo100DebugFunction:
+      case NonSemanticShaderDebugInfo100DebugLexicalBlock:
+      case NonSemanticShaderDebugInfo100DebugLexicalBlockDiscriminator:
+      case NonSemanticShaderDebugInfo100DebugScope:
+      case NonSemanticShaderDebugInfo100DebugNoScope:
+      case NonSemanticShaderDebugInfo100DebugInlinedAt:
+      case NonSemanticShaderDebugInfo100DebugLocalVariable:
+      case NonSemanticShaderDebugInfo100DebugInlinedVariable:
+      case NonSemanticShaderDebugInfo100DebugValue:
+      case NonSemanticShaderDebugInfo100DebugOperation:
+      case NonSemanticShaderDebugInfo100DebugExpression:
+      case NonSemanticShaderDebugInfo100DebugMacroDef:
+      case NonSemanticShaderDebugInfo100DebugMacroUndef:
+      case NonSemanticShaderDebugInfo100DebugImportedEntity:
+      case NonSemanticShaderDebugInfo100DebugSource:
+        break;
+
+      // These checks are for operands that are differnet in
+      // ShaderDebugInfo100
+      case NonSemanticShaderDebugInfo100DebugTypeBasic: {
+        CHECK_CONST_UINT_OPERAND("Flags", 8);
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugDeclare: {
+        for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
+          auto index_inst = _.FindDef(inst->word(word_index));
+          auto type_id = index_inst != nullptr ? index_inst->type_id() : 0;
+          if (type_id == 0 || !IsIntScalar(_, type_id, false, false))
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << GetExtInstName(_, inst) << ": "
+                   << "expected index must be scalar integer";
+        }
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugTypeMatrix: {
+        CHECK_DEBUG_OPERAND("Vector Type", CommonDebugInfoDebugTypeVector, 5);
+
+        CHECK_CONST_UINT_OPERAND("Vector Count", 6);
+
+        uint32_t vector_count = inst->word(6);
+        uint64_t const_val;
+        if (!_.EvalConstantValUint64(vector_count, &const_val)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": Vector Count must be 32-bit integer OpConstant";
+        }
+
+        vector_count = const_val & 0xffffffff;
+        if (!vector_count || vector_count > 4) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": Vector Count must be positive "
+                 << "integer less than or equal to 4";
+        }
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugFunctionDefinition: {
+        CHECK_DEBUG_OPERAND("Function", CommonDebugInfoDebugFunction, 5);
+        CHECK_OPERAND("Definition", spv::Op::OpFunction, 6);
+        const auto* current_function = inst->function();
+        if (current_function->first_block()->id() != inst->block()->id()) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": must be in the entry basic block of the function";
+        }
+
+        const uint32_t definition_id = inst->word(6);
+        if (definition_id != current_function->id()) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": operand Definition must point to the OpFunction it is "
+                    "inside";
+        }
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugLine: {
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
+        CHECK_CONST_UINT_OPERAND("Line Start", 6);
+        CHECK_CONST_UINT_OPERAND("Line End", 7);
+        CHECK_CONST_UINT_OPERAND("Column Start", 8);
+        CHECK_CONST_UINT_OPERAND("Column End", 9);
+
+        // above already validates if 32-bit and non-spec constant
+        // but want to use EvalInt32IfConst to be consistent with other Eval
+        // locations
+        bool is_int32 = false, is_const_int32 = false;
+        uint32_t line_start = 0;
+        uint32_t line_end = 0;
+        uint32_t column_start = 0;
+        uint32_t column_end = 0;
+        std::tie(is_int32, is_const_int32, line_start) =
+            _.EvalInt32IfConst(inst->word(6));
+        std::tie(is_int32, is_const_int32, line_end) =
+            _.EvalInt32IfConst(inst->word(7));
+        std::tie(is_int32, is_const_int32, column_start) =
+            _.EvalInt32IfConst(inst->word(8));
+        std::tie(is_int32, is_const_int32, column_end) =
+            _.EvalInt32IfConst(inst->word(9));
+        if (line_end < line_start) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": operand Line End ("
+                 << line_end << ") is less than Line Start (" << line_start
+                 << ")";
+        } else if (line_start == line_end && column_end < column_start) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": operand Column End ("
+                 << column_end << ") is less than Column Start ("
+                 << column_start << ") when Line Start equals Line End";
+        }
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugSourceContinued: {
+        CHECK_OPERAND("Text", spv::Op::OpString, 5);
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugBuildIdentifier: {
+        CHECK_OPERAND("Identifier", spv::Op::OpString, 5);
+        CHECK_CONST_UINT_OPERAND("Flags", 6);
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugStoragePath: {
+        CHECK_OPERAND("Path", spv::Op::OpString, 5);
+        break;
+      }
+      case NonSemanticShaderDebugInfo100DebugEntryPoint: {
+        CHECK_DEBUG_OPERAND("Entry Point", CommonDebugInfoDebugFunction, 5);
+        CHECK_DEBUG_OPERAND("Compilation Unit",
+                            CommonDebugInfoDebugCompilationUnit, 6);
+        CHECK_OPERAND("Compiler Signature", spv::Op::OpString, 7);
+        CHECK_OPERAND("Command-line Arguments", spv::Op::OpString, 8);
+        break;
+      }
+
+        // Has no additional checks
+      case NonSemanticShaderDebugInfo100DebugNoLine:
+        break;
+      case NonSemanticShaderDebugInfo100InstructionsMax:
+        assert(0);
+        break;
+    }
+  }
+
+  // Handle any non-common OpenCL insts, then common
+  if (ext_inst_type != SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100 ||
+      OpenCLDebugInfo100Instructions(ext_inst_index) !=
+          OpenCLDebugInfo100DebugModuleINTEL) {
+    const CommonDebugInfoInstructions ext_inst_key =
+        CommonDebugInfoInstructions(ext_inst_index);
+    switch (ext_inst_key) {
+      case CommonDebugInfoDebugInfoNone:
+      case CommonDebugInfoDebugNoScope:
+        break;
+        // The binary parser validates the opcode for DebugInfoNone,
+        // DebugNoScope, DebugOperation. We just check the parameters to
+        // DebugOperation are properly constants for vulkan debug info.
+      case CommonDebugInfoDebugOperation: {
+        CHECK_CONST_UINT_OPERAND("Operation", 5);
+        for (uint32_t i = 6; i < num_words; ++i) {
+          CHECK_CONST_UINT_OPERAND("Operand", i);
+        }
+        break;
+      }
+      case CommonDebugInfoDebugCompilationUnit: {
+        CHECK_CONST_UINT_OPERAND("Version", 5);
+        CHECK_CONST_UINT_OPERAND("DWARF Version", 6);
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Language", 8);
+        break;
+      }
+      case CommonDebugInfoDebugSource: {
+        CHECK_OPERAND("File", spv::Op::OpString, 5);
+        if (num_words == 7) CHECK_OPERAND("Text", spv::Op::OpString, 6);
+        break;
+      }
+      case CommonDebugInfoDebugTypeBasic: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        CHECK_OPERAND("Size", spv::Op::OpConstant, 6);
+        CHECK_CONST_UINT_OPERAND("Encoding", 7);
+        break;
+      }
+      case CommonDebugInfoDebugTypePointer: {
+        auto validate_base_type =
+            ValidateOperandDebugType(_, "Base Type", inst, 5, false);
+        if (validate_base_type != SPV_SUCCESS) return validate_base_type;
+        CHECK_CONST_UINT_OPERAND("Storage Class", 6);
+        CHECK_CONST_UINT_OPERAND("Flags", 7);
+        break;
+      }
+      case CommonDebugInfoDebugTypeQualifier: {
+        auto validate_base_type =
+            ValidateOperandDebugType(_, "Base Type", inst, 5, false);
+        if (validate_base_type != SPV_SUCCESS) return validate_base_type;
+        CHECK_CONST_UINT_OPERAND("Type Qualifier", 6);
+        break;
+      }
+      case CommonDebugInfoDebugTypeVector: {
+        auto validate_base_type = ValidateOperandBaseType(_, inst, 5);
+        if (validate_base_type != SPV_SUCCESS) return validate_base_type;
+
+        CHECK_CONST_UINT_OPERAND("Component Count", 6);
+        uint32_t component_count = inst->word(6);
+        if (vulkanDebugInfo) {
           uint64_t const_val;
-          if (!_.EvalConstantValUint64(vector_count, &const_val)) {
+          if (!_.EvalConstantValUint64(component_count, &const_val)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << GetExtInstName(_, inst)
-                   << ": Vector Count must be 32-bit integer OpConstant";
+                   << ": Component Count must be 32-bit integer OpConstant";
           }
-
-          vector_count = const_val & 0xffffffff;
-          if (!vector_count || vector_count > 4) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst)
-                   << ": Vector Count must be positive "
-                   << "integer less than or equal to 4";
-          }
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugFunctionDefinition: {
-          CHECK_DEBUG_OPERAND("Function", CommonDebugInfoDebugFunction, 5);
-          CHECK_OPERAND("Definition", spv::Op::OpFunction, 6);
-          const auto* current_function = inst->function();
-          if (current_function->first_block()->id() != inst->block()->id()) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst)
-                   << ": must be in the entry basic block of the function";
-          }
-
-          const uint32_t definition_id = inst->word(6);
-          if (definition_id != current_function->id()) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst)
-                   << ": operand Definition must point to the OpFunction it is "
-                      "inside";
-          }
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugLine: {
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
-          CHECK_CONST_UINT_OPERAND("Line Start", 6);
-          CHECK_CONST_UINT_OPERAND("Line End", 7);
-          CHECK_CONST_UINT_OPERAND("Column Start", 8);
-          CHECK_CONST_UINT_OPERAND("Column End", 9);
-
-          // above already validates if 32-bit and non-spec constant
-          // but want to use EvalInt32IfConst to be consistent with other Eval
-          // locations
-          bool is_int32 = false, is_const_int32 = false;
-          uint32_t line_start = 0;
-          uint32_t line_end = 0;
-          uint32_t column_start = 0;
-          uint32_t column_end = 0;
-          std::tie(is_int32, is_const_int32, line_start) =
-              _.EvalInt32IfConst(inst->word(6));
-          std::tie(is_int32, is_const_int32, line_end) =
-              _.EvalInt32IfConst(inst->word(7));
-          std::tie(is_int32, is_const_int32, column_start) =
-              _.EvalInt32IfConst(inst->word(8));
-          std::tie(is_int32, is_const_int32, column_end) =
-              _.EvalInt32IfConst(inst->word(9));
-          if (line_end < line_start) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": operand Line End ("
-                   << line_end << ") is less than Line Start (" << line_start
-                   << ")";
-          } else if (line_start == line_end && column_end < column_start) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": operand Column End ("
-                   << column_end << ") is less than Column Start ("
-                   << column_start << ") when Line Start equals Line End";
-          }
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugSourceContinued: {
-          CHECK_OPERAND("Text", spv::Op::OpString, 5);
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugBuildIdentifier: {
-          CHECK_OPERAND("Identifier", spv::Op::OpString, 5);
-          CHECK_CONST_UINT_OPERAND("Flags", 6);
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugStoragePath: {
-          CHECK_OPERAND("Path", spv::Op::OpString, 5);
-          break;
-        }
-        case NonSemanticShaderDebugInfo100DebugEntryPoint: {
-          CHECK_DEBUG_OPERAND("Entry Point", CommonDebugInfoDebugFunction, 5);
-          CHECK_DEBUG_OPERAND("Compilation Unit",
-                              CommonDebugInfoDebugCompilationUnit, 6);
-          CHECK_OPERAND("Compiler Signature", spv::Op::OpString, 7);
-          CHECK_OPERAND("Command-line Arguments", spv::Op::OpString, 8);
-          break;
+          component_count = const_val & 0xffffffff;
         }
 
-          // Has no additional checks
-        case NonSemanticShaderDebugInfo100DebugNoLine:
-          break;
-        case NonSemanticShaderDebugInfo100InstructionsMax:
-          assert(0);
-          break;
+        if (!component_count || component_count > 4) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": Component Count must be positive "
+                 << "integer less than or equal to 4";
+        }
+        break;
       }
-    }
-
-    // Handle any non-common OpenCL insts, then common
-    if (ext_inst_type != SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100 ||
-        OpenCLDebugInfo100Instructions(ext_inst_index) !=
-            OpenCLDebugInfo100DebugModuleINTEL) {
-      const CommonDebugInfoInstructions ext_inst_key =
-          CommonDebugInfoInstructions(ext_inst_index);
-      switch (ext_inst_key) {
-        case CommonDebugInfoDebugInfoNone:
-        case CommonDebugInfoDebugNoScope:
-          break;
-          // The binary parser validates the opcode for DebugInfoNone,
-          // DebugNoScope, DebugOperation. We just check the parameters to
-          // DebugOperation are properly constants for vulkan debug info.
-        case CommonDebugInfoDebugOperation: {
-          CHECK_CONST_UINT_OPERAND("Operation", 5);
-          for (uint32_t i = 6; i < num_words; ++i) {
-            CHECK_CONST_UINT_OPERAND("Operand", i);
-          }
-          break;
-        }
-        case CommonDebugInfoDebugCompilationUnit: {
-          CHECK_CONST_UINT_OPERAND("Version", 5);
-          CHECK_CONST_UINT_OPERAND("DWARF Version", 6);
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Language", 8);
-          break;
-        }
-        case CommonDebugInfoDebugSource: {
-          CHECK_OPERAND("File", spv::Op::OpString, 5);
-          if (num_words == 7) CHECK_OPERAND("Text", spv::Op::OpString, 6);
-          break;
-        }
-        case CommonDebugInfoDebugTypeBasic: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          CHECK_OPERAND("Size", spv::Op::OpConstant, 6);
-          CHECK_CONST_UINT_OPERAND("Encoding", 7);
-          break;
-        }
-        case CommonDebugInfoDebugTypePointer: {
-          auto validate_base_type =
-              ValidateOperandDebugType(_, "Base Type", inst, 5, false);
-          if (validate_base_type != SPV_SUCCESS) return validate_base_type;
-          CHECK_CONST_UINT_OPERAND("Storage Class", 6);
-          CHECK_CONST_UINT_OPERAND("Flags", 7);
-          break;
-        }
-        case CommonDebugInfoDebugTypeQualifier: {
-          auto validate_base_type =
-              ValidateOperandDebugType(_, "Base Type", inst, 5, false);
-          if (validate_base_type != SPV_SUCCESS) return validate_base_type;
-          CHECK_CONST_UINT_OPERAND("Type Qualifier", 6);
-          break;
-        }
-        case CommonDebugInfoDebugTypeVector: {
-          auto validate_base_type = ValidateOperandBaseType(_, inst, 5);
-          if (validate_base_type != SPV_SUCCESS) return validate_base_type;
-
-          CHECK_CONST_UINT_OPERAND("Component Count", 6);
-          uint32_t component_count = inst->word(6);
-          if (vulkanDebugInfo) {
-            uint64_t const_val;
-            if (!_.EvalConstantValUint64(component_count, &const_val)) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst)
-                     << ": Component Count must be 32-bit integer OpConstant";
+      case CommonDebugInfoDebugTypeArray: {
+        auto validate_base_type =
+            ValidateOperandDebugType(_, "Base Type", inst, 5, false);
+        if (validate_base_type != SPV_SUCCESS) return validate_base_type;
+        for (uint32_t i = 6; i < num_words; ++i) {
+          bool invalid = false;
+          auto* component_count = _.FindDef(inst->word(i));
+          if (IsConstIntScalarTypeWith32Or64Bits(_, component_count)) {
+            // TODO: We need a spec discussion for the runtime array for
+            // OpenCL.
+            if (!vulkanDebugInfo && !component_count->word(3)) {
+              invalid = true;
             }
-            component_count = const_val & 0xffffffff;
-          }
-
-          if (!component_count || component_count > 4) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst)
-                   << ": Component Count must be positive "
-                   << "integer less than or equal to 4";
-          }
-          break;
-        }
-        case CommonDebugInfoDebugTypeArray: {
-          auto validate_base_type =
-              ValidateOperandDebugType(_, "Base Type", inst, 5, false);
-          if (validate_base_type != SPV_SUCCESS) return validate_base_type;
-          for (uint32_t i = 6; i < num_words; ++i) {
-            bool invalid = false;
-            auto* component_count = _.FindDef(inst->word(i));
-            if (IsConstIntScalarTypeWith32Or64Bits(_, component_count)) {
-              // TODO: We need a spec discussion for the runtime array for
-              // OpenCL.
-              if (!vulkanDebugInfo && !component_count->word(3)) {
+          } else if (component_count->words().size() > 6 &&
+                     (CommonDebugInfoInstructions(component_count->word(4)) ==
+                          CommonDebugInfoDebugLocalVariable ||
+                      CommonDebugInfoInstructions(component_count->word(4)) ==
+                          CommonDebugInfoDebugGlobalVariable)) {
+            auto* component_count_type = _.FindDef(component_count->word(6));
+            if (component_count_type->words().size() > 7) {
+              uint32_t encoding = component_count_type->word(7);
+              if (CommonDebugInfoInstructions(component_count_type->word(4)) !=
+                      CommonDebugInfoDebugTypeBasic ||
+                  (vulkanDebugInfo && !IsUint32Constant(_, encoding)) ||
+                  OpenCLDebugInfo100DebugBaseTypeAttributeEncoding(
+                      vulkanDebugInfo
+                          ? GetUint32Constant(_, encoding)
+                          : encoding) != OpenCLDebugInfo100Unsigned) {
                 invalid = true;
-              }
-            } else if (component_count->words().size() > 6 &&
-                       (CommonDebugInfoInstructions(component_count->word(4)) ==
-                            CommonDebugInfoDebugLocalVariable ||
-                        CommonDebugInfoInstructions(component_count->word(4)) ==
-                            CommonDebugInfoDebugGlobalVariable)) {
-              auto* component_count_type = _.FindDef(component_count->word(6));
-              if (component_count_type->words().size() > 7) {
-                uint32_t encoding = component_count_type->word(7);
-                if (CommonDebugInfoInstructions(component_count_type->word(
-                        4)) != CommonDebugInfoDebugTypeBasic ||
-                    (vulkanDebugInfo && !IsUint32Constant(_, encoding)) ||
-                    OpenCLDebugInfo100DebugBaseTypeAttributeEncoding(
-                        vulkanDebugInfo
-                            ? GetUint32Constant(_, encoding)
-                            : encoding) != OpenCLDebugInfo100Unsigned) {
-                  invalid = true;
-                } else {
-                  // DebugTypeBasic for DebugLocalVariable/DebugGlobalVariable
-                  // must have Unsigned encoding and 32 or 64 as its size in
-                  // bits.
-                  Instruction* size_in_bits =
-                      _.FindDef(component_count_type->word(6));
-                  if (!_.IsIntScalarType(size_in_bits->type_id()) ||
-                      (size_in_bits->word(3) != 32 &&
-                       size_in_bits->word(3) != 64)) {
-                    invalid = true;
-                  }
-                }
               } else {
-                invalid = true;
+                // DebugTypeBasic for DebugLocalVariable/DebugGlobalVariable
+                // must have Unsigned encoding and 32 or 64 as its size in
+                // bits.
+                Instruction* size_in_bits =
+                    _.FindDef(component_count_type->word(6));
+                if (!_.IsIntScalarType(size_in_bits->type_id()) ||
+                    (size_in_bits->word(3) != 32 &&
+                     size_in_bits->word(3) != 64)) {
+                  invalid = true;
+                }
               }
             } else {
               invalid = true;
             }
-            if (invalid) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": Component Count must be "
-                     << "OpConstant with a 32- or 64-bits integer scalar type "
-                        "or "
-                     << "DebugGlobalVariable or DebugLocalVariable with a 32- "
-                        "or "
-                     << "64-bits unsigned integer scalar type";
-            }
+          } else {
+            invalid = true;
           }
-          break;
-        }
-        case CommonDebugInfoDebugTypedef: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          auto validate_base_type = ValidateOperandBaseType(_, inst, 6);
-          if (validate_base_type != SPV_SUCCESS) return validate_base_type;
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          break;
-        }
-        case CommonDebugInfoDebugTypeFunction: {
-          CHECK_CONST_UINT_OPERAND("Flags", 5);
-          auto* return_type = _.FindDef(inst->word(6));
-          // TODO: We need a spec discussion that we have to allow return and
-          // parameter types of a DebugTypeFunction to have template parameter.
-          if (return_type->opcode() != spv::Op::OpTypeVoid) {
-            auto validate_return =
-                ValidateOperandDebugType(_, "Return Type", inst, 6, true);
-            if (validate_return != SPV_SUCCESS) return validate_return;
+          if (invalid) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << GetExtInstName(_, inst) << ": Component Count must be "
+                   << "OpConstant with a 32- or 64-bits integer scalar type "
+                      "or "
+                   << "DebugGlobalVariable or DebugLocalVariable with a 32- "
+                      "or "
+                   << "64-bits unsigned integer scalar type";
           }
-          for (uint32_t word_index = 7; word_index < num_words; ++word_index) {
-            auto validate_param = ValidateOperandDebugType(
-                _, "Parameter Types", inst, word_index, true);
-            if (validate_param != SPV_SUCCESS) return validate_param;
-          }
-          break;
         }
-        case CommonDebugInfoDebugTypeEnum: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        break;
+      }
+      case CommonDebugInfoDebugTypedef: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        auto validate_base_type = ValidateOperandBaseType(_, inst, 6);
+        if (validate_base_type != SPV_SUCCESS) return validate_base_type;
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        break;
+      }
+      case CommonDebugInfoDebugTypeFunction: {
+        CHECK_CONST_UINT_OPERAND("Flags", 5);
+        auto* return_type = _.FindDef(inst->word(6));
+        // TODO: We need a spec discussion that we have to allow return and
+        // parameter types of a DebugTypeFunction to have template parameter.
+        if (return_type->opcode() != spv::Op::OpTypeVoid) {
+          auto validate_return =
+              ValidateOperandDebugType(_, "Return Type", inst, 6, true);
+          if (validate_return != SPV_SUCCESS) return validate_return;
+        }
+        for (uint32_t word_index = 7; word_index < num_words; ++word_index) {
+          auto validate_param = ValidateOperandDebugType(
+              _, "Parameter Types", inst, word_index, true);
+          if (validate_param != SPV_SUCCESS) return validate_param;
+        }
+        break;
+      }
+      case CommonDebugInfoDebugTypeEnum: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](CommonDebugInfoInstructions dbg_inst) {
+                  return dbg_inst == CommonDebugInfoDebugInfoNone;
+                },
+                inst, 6)) {
+          auto validate_underlying_type =
+              ValidateOperandDebugType(_, "Underlying Types", inst, 6, false);
+          if (validate_underlying_type != SPV_SUCCESS)
+            return validate_underlying_type;
+        }
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        CHECK_OPERAND("Size", spv::Op::OpConstant, 11);
+        auto* size = _.FindDef(inst->word(11));
+        if (!_.IsIntScalarType(size->type_id()) || !size->word(3)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": expected operand Size is a "
+                 << "positive integer";
+        }
+        CHECK_CONST_UINT_OPERAND("Flags", 12);
+        for (uint32_t word_index = 13; word_index + 1 < num_words;
+             word_index += 2) {
+          CHECK_OPERAND("Value", spv::Op::OpConstant, word_index);
+          CHECK_OPERAND("Name", spv::Op::OpString, word_index + 1);
+        }
+        break;
+      }
+      case CommonDebugInfoDebugTypeComposite: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](CommonDebugInfoInstructions dbg_inst) {
+                  return dbg_inst == CommonDebugInfoDebugInfoNone;
+                },
+                inst, 12)) {
+          CHECK_OPERAND("Size", spv::Op::OpConstant, 12);
+        }
+        CHECK_CONST_UINT_OPERAND("Flags", 13);
+        for (uint32_t word_index = 14; word_index < num_words; ++word_index) {
           if (!DoesDebugInfoOperandMatchExpectation(
                   _,
                   [](CommonDebugInfoInstructions dbg_inst) {
-                    return dbg_inst == CommonDebugInfoDebugInfoNone;
+                    return dbg_inst == CommonDebugInfoDebugTypeMember ||
+                           dbg_inst == CommonDebugInfoDebugFunction ||
+                           dbg_inst == CommonDebugInfoDebugTypeInheritance;
                   },
-                  inst, 6)) {
-            auto validate_underlying_type =
-                ValidateOperandDebugType(_, "Underlying Types", inst, 6, false);
-            if (validate_underlying_type != SPV_SUCCESS)
-              return validate_underlying_type;
+                  inst, word_index)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << GetExtInstName(_, inst) << ": "
+                   << "expected operand Members "
+                   << "must be DebugTypeMember, DebugFunction, or "
+                      "DebugTypeInheritance";
           }
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
+        }
+        break;
+      }
+      case CommonDebugInfoDebugTypeMember: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        // TODO: We need a spec discussion that we have to allow member types
+        // to have template parameter.
+        auto validate_type = ValidateOperandDebugType(_, "Type", inst, 6, true);
+        if (validate_type != SPV_SUCCESS) return validate_type;
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        // NonSemantic.Shader.DebugInfo doesn't have the Parent operand
+        if (vulkanDebugInfo) {
+          CHECK_OPERAND("Offset", spv::Op::OpConstant, 10);
           CHECK_OPERAND("Size", spv::Op::OpConstant, 11);
-          auto* size = _.FindDef(inst->word(11));
-          if (!_.IsIntScalarType(size->type_id()) || !size->word(3)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": expected operand Size is a "
-                   << "positive integer";
-          }
           CHECK_CONST_UINT_OPERAND("Flags", 12);
-          for (uint32_t word_index = 13; word_index + 1 < num_words;
-               word_index += 2) {
-            CHECK_OPERAND("Value", spv::Op::OpConstant, word_index);
-            CHECK_OPERAND("Name", spv::Op::OpString, word_index + 1);
-          }
-          break;
+          if (num_words == 14) CHECK_OPERAND("Value", spv::Op::OpConstant, 13);
+        } else {
+          CHECK_DEBUG_OPERAND("Parent", CommonDebugInfoDebugTypeComposite, 10);
+          CHECK_OPERAND("Offset", spv::Op::OpConstant, 11);
+          CHECK_OPERAND("Size", spv::Op::OpConstant, 12);
+          CHECK_CONST_UINT_OPERAND("Flags", 13);
+          if (num_words == 15) CHECK_OPERAND("Value", spv::Op::OpConstant, 14);
         }
-        case CommonDebugInfoDebugTypeComposite: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
+        break;
+      }
+      case CommonDebugInfoDebugTypeInheritance: {
+        CHECK_DEBUG_OPERAND("Child", CommonDebugInfoDebugTypeComposite, 5);
+        auto* debug_inst = _.FindDef(inst->word(5));
+        auto composite_type =
+            OpenCLDebugInfo100DebugCompositeType(debug_inst->word(6));
+        if (composite_type != OpenCLDebugInfo100Class &&
+            composite_type != OpenCLDebugInfo100Structure) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected operand Child must be class or struct debug "
+                    "type";
+        }
+        CHECK_DEBUG_OPERAND("Parent", CommonDebugInfoDebugTypeComposite, 6);
+        debug_inst = _.FindDef(inst->word(6));
+        composite_type =
+            OpenCLDebugInfo100DebugCompositeType(debug_inst->word(6));
+        if (composite_type != OpenCLDebugInfo100Class &&
+            composite_type != OpenCLDebugInfo100Structure) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected operand Parent must be class or struct debug "
+                    "type";
+        }
+        CHECK_OPERAND("Offset", spv::Op::OpConstant, 7);
+        CHECK_OPERAND("Size", spv::Op::OpConstant, 8);
+        CHECK_CONST_UINT_OPERAND("Flags", 9);
+        break;
+      }
+      case CommonDebugInfoDebugFunction: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
+        CHECK_CONST_UINT_OPERAND("Flags", 12);
+        CHECK_CONST_UINT_OPERAND("Scope Line", 13);
+        // NonSemantic.Shader.DebugInfo.100 doesn't include a reference to the
+        // OpFunction
+        if (vulkanDebugInfo) {
+          if (num_words == 15) {
+            CHECK_DEBUG_OPERAND("Declaration",
+                                CommonDebugInfoDebugFunctionDeclaration, 14);
+          }
+        } else {
           if (!DoesDebugInfoOperandMatchExpectation(
                   _,
                   [](CommonDebugInfoInstructions dbg_inst) {
                     return dbg_inst == CommonDebugInfoDebugInfoNone;
                   },
-                  inst, 12)) {
-            CHECK_OPERAND("Size", spv::Op::OpConstant, 12);
+                  inst, 14)) {
+            CHECK_OPERAND("Function", spv::Op::OpFunction, 14);
           }
-          CHECK_CONST_UINT_OPERAND("Flags", 13);
-          for (uint32_t word_index = 14; word_index < num_words; ++word_index) {
-            if (!DoesDebugInfoOperandMatchExpectation(
-                    _,
-                    [](CommonDebugInfoInstructions dbg_inst) {
-                      return dbg_inst == CommonDebugInfoDebugTypeMember ||
-                             dbg_inst == CommonDebugInfoDebugFunction ||
-                             dbg_inst == CommonDebugInfoDebugTypeInheritance;
-                    },
-                    inst, word_index)) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": "
-                     << "expected operand Members "
-                     << "must be DebugTypeMember, DebugFunction, or "
-                        "DebugTypeInheritance";
-            }
+          if (num_words == 16) {
+            CHECK_DEBUG_OPERAND("Declaration",
+                                CommonDebugInfoDebugFunctionDeclaration, 15);
           }
-          break;
         }
-        case CommonDebugInfoDebugTypeMember: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          // TODO: We need a spec discussion that we have to allow member types
-          // to have template parameter.
-          auto validate_type =
-              ValidateOperandDebugType(_, "Type", inst, 6, true);
-          if (validate_type != SPV_SUCCESS) return validate_type;
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          // NonSemantic.Shader.DebugInfo doesn't have the Parent operand
-          if (vulkanDebugInfo) {
-            CHECK_OPERAND("Offset", spv::Op::OpConstant, 10);
-            CHECK_OPERAND("Size", spv::Op::OpConstant, 11);
-            CHECK_CONST_UINT_OPERAND("Flags", 12);
-            if (num_words == 14)
-              CHECK_OPERAND("Value", spv::Op::OpConstant, 13);
-          } else {
-            CHECK_DEBUG_OPERAND("Parent", CommonDebugInfoDebugTypeComposite,
-                                10);
-            CHECK_OPERAND("Offset", spv::Op::OpConstant, 11);
-            CHECK_OPERAND("Size", spv::Op::OpConstant, 12);
-            CHECK_CONST_UINT_OPERAND("Flags", 13);
-            if (num_words == 15)
-              CHECK_OPERAND("Value", spv::Op::OpConstant, 14);
-          }
-          break;
+        break;
+      }
+      case CommonDebugInfoDebugFunctionDeclaration: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
+        CHECK_CONST_UINT_OPERAND("Flags", 12);
+        break;
+      }
+      case CommonDebugInfoDebugLexicalBlock: {
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
+        CHECK_CONST_UINT_OPERAND("Line", 6);
+        CHECK_CONST_UINT_OPERAND("Column", 7);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 8);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        if (num_words == 10) CHECK_OPERAND("Name", spv::Op::OpString, 9);
+        break;
+      }
+      case CommonDebugInfoDebugScope: {
+        auto validate_scope = ValidateOperandLexicalScope(_, "Scope", inst, 5);
+        if (validate_scope != SPV_SUCCESS) return validate_scope;
+        if (num_words == 7) {
+          CHECK_DEBUG_OPERAND("Inlined At", CommonDebugInfoDebugInlinedAt, 6);
         }
-        case CommonDebugInfoDebugTypeInheritance: {
-          CHECK_DEBUG_OPERAND("Child", CommonDebugInfoDebugTypeComposite, 5);
-          auto* debug_inst = _.FindDef(inst->word(5));
-          auto composite_type =
-              OpenCLDebugInfo100DebugCompositeType(debug_inst->word(6));
-          if (composite_type != OpenCLDebugInfo100Class &&
-              composite_type != OpenCLDebugInfo100Structure) {
+        break;
+      }
+      case CommonDebugInfoDebugLocalVariable: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        // TODO: We need a spec discussion that we have to allow local
+        // variable types to have template parameter.
+        auto validate_type = ValidateOperandDebugType(_, "Type", inst, 6, true);
+        if (validate_type != SPV_SUCCESS) return validate_type;
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_parent =
+            ValidateOperandLexicalScope(_, "Parent", inst, 10);
+        if (validate_parent != SPV_SUCCESS) return validate_parent;
+        CHECK_CONST_UINT_OPERAND("Flags", 11);
+        if (num_words == 13) {
+          CHECK_CONST_UINT_OPERAND("ArgNumber", 12);
+        }
+        break;
+      }
+      case CommonDebugInfoDebugDeclare: {
+        CHECK_DEBUG_OPERAND("Local Variable", CommonDebugInfoDebugLocalVariable,
+                            5);
+        auto* operand = _.FindDef(inst->word(6));
+        if (operand->opcode() != spv::Op::OpVariable &&
+            operand->opcode() != spv::Op::OpFunctionParameter) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected operand Variable must be a result id of "
+                    "OpVariable or OpFunctionParameter";
+        }
+
+        CHECK_DEBUG_OPERAND("Expression", CommonDebugInfoDebugExpression, 7);
+        break;
+      }
+      case CommonDebugInfoDebugExpression: {
+        for (uint32_t word_index = 5; word_index < num_words; ++word_index) {
+          CHECK_DEBUG_OPERAND("Operation", CommonDebugInfoDebugOperation,
+                              word_index);
+        }
+        break;
+      }
+      case CommonDebugInfoDebugTypeTemplate: {
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](CommonDebugInfoInstructions dbg_inst) {
+                  return dbg_inst == CommonDebugInfoDebugTypeComposite ||
+                         dbg_inst == CommonDebugInfoDebugFunction;
+                },
+                inst, 5)) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst) << ": "
+                 << "expected operand Target must be DebugTypeComposite "
+                 << "or DebugFunction";
+        }
+        for (uint32_t word_index = 6; word_index < num_words; ++word_index) {
+          if (!DoesDebugInfoOperandMatchExpectation(
+                  _,
+                  [](CommonDebugInfoInstructions dbg_inst) {
+                    return dbg_inst ==
+                               CommonDebugInfoDebugTypeTemplateParameter ||
+                           dbg_inst ==
+                               CommonDebugInfoDebugTypeTemplateTemplateParameter;
+                  },
+                  inst, word_index)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << GetExtInstName(_, inst) << ": "
-                   << "expected operand Child must be class or struct debug "
-                      "type";
+                   << "expected operand Parameters must be "
+                   << "DebugTypeTemplateParameter or "
+                   << "DebugTypeTemplateTemplateParameter";
           }
-          CHECK_DEBUG_OPERAND("Parent", CommonDebugInfoDebugTypeComposite, 6);
-          debug_inst = _.FindDef(inst->word(6));
-          composite_type =
-              OpenCLDebugInfo100DebugCompositeType(debug_inst->word(6));
-          if (composite_type != OpenCLDebugInfo100Class &&
-              composite_type != OpenCLDebugInfo100Structure) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected operand Parent must be class or struct debug "
-                      "type";
-          }
-          CHECK_OPERAND("Offset", spv::Op::OpConstant, 7);
-          CHECK_OPERAND("Size", spv::Op::OpConstant, 8);
-          CHECK_CONST_UINT_OPERAND("Flags", 9);
-          break;
         }
-        case CommonDebugInfoDebugFunction: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
-          CHECK_CONST_UINT_OPERAND("Flags", 12);
-          CHECK_CONST_UINT_OPERAND("Scope Line", 13);
-          // NonSemantic.Shader.DebugInfo.100 doesn't include a reference to the
-          // OpFunction
-          if (vulkanDebugInfo) {
-            if (num_words == 15) {
-              CHECK_DEBUG_OPERAND("Declaration",
-                                  CommonDebugInfoDebugFunctionDeclaration, 14);
-            }
-          } else {
-            if (!DoesDebugInfoOperandMatchExpectation(
-                    _,
-                    [](CommonDebugInfoInstructions dbg_inst) {
-                      return dbg_inst == CommonDebugInfoDebugInfoNone;
-                    },
-                    inst, 14)) {
-              CHECK_OPERAND("Function", spv::Op::OpFunction, 14);
-            }
-            if (num_words == 16) {
-              CHECK_DEBUG_OPERAND("Declaration",
-                                  CommonDebugInfoDebugFunctionDeclaration, 15);
-            }
-          }
-          break;
+        break;
+      }
+      case CommonDebugInfoDebugTypeTemplateParameter: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        auto validate_actual_type =
+            ValidateOperandDebugType(_, "Actual Type", inst, 6, false);
+        if (validate_actual_type != SPV_SUCCESS) return validate_actual_type;
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](CommonDebugInfoInstructions dbg_inst) {
+                  return dbg_inst == CommonDebugInfoDebugInfoNone;
+                },
+                inst, 7)) {
+          CHECK_OPERAND("Value", spv::Op::OpConstant, 7);
         }
-        case CommonDebugInfoDebugFunctionDeclaration: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          CHECK_DEBUG_OPERAND("Type", CommonDebugInfoDebugTypeFunction, 6);
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
-          CHECK_CONST_UINT_OPERAND("Flags", 12);
-          break;
-        }
-        case CommonDebugInfoDebugLexicalBlock: {
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
-          CHECK_CONST_UINT_OPERAND("Line", 6);
-          CHECK_CONST_UINT_OPERAND("Column", 7);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 8);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          if (num_words == 10) CHECK_OPERAND("Name", spv::Op::OpString, 9);
-          break;
-        }
-        case CommonDebugInfoDebugScope: {
-          auto validate_scope =
-              ValidateOperandLexicalScope(_, "Scope", inst, 5);
-          if (validate_scope != SPV_SUCCESS) return validate_scope;
-          if (num_words == 7) {
-            CHECK_DEBUG_OPERAND("Inlined At", CommonDebugInfoDebugInlinedAt, 6);
-          }
-          break;
-        }
-        case CommonDebugInfoDebugLocalVariable: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          // TODO: We need a spec discussion that we have to allow local
-          // variable types to have template parameter.
-          auto validate_type =
-              ValidateOperandDebugType(_, "Type", inst, 6, true);
-          if (validate_type != SPV_SUCCESS) return validate_type;
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_parent =
-              ValidateOperandLexicalScope(_, "Parent", inst, 10);
-          if (validate_parent != SPV_SUCCESS) return validate_parent;
-          CHECK_CONST_UINT_OPERAND("Flags", 11);
-          if (num_words == 13) {
-            CHECK_CONST_UINT_OPERAND("ArgNumber", 12);
-          }
-          break;
-        }
-        case CommonDebugInfoDebugDeclare: {
-          CHECK_DEBUG_OPERAND("Local Variable",
-                              CommonDebugInfoDebugLocalVariable, 5);
-          auto* operand = _.FindDef(inst->word(6));
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 8);
+        CHECK_CONST_UINT_OPERAND("Line", 9);
+        CHECK_CONST_UINT_OPERAND("Column", 10);
+        break;
+      }
+      case CommonDebugInfoDebugGlobalVariable: {
+        CHECK_OPERAND("Name", spv::Op::OpString, 5);
+        auto validate_type =
+            ValidateOperandDebugType(_, "Type", inst, 6, false);
+        if (validate_type != SPV_SUCCESS) return validate_type;
+        CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
+        CHECK_CONST_UINT_OPERAND("Line", 8);
+        CHECK_CONST_UINT_OPERAND("Column", 9);
+        auto validate_scope = ValidateOperandLexicalScope(_, "Scope", inst, 10);
+        if (validate_scope != SPV_SUCCESS) return validate_scope;
+        CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
+        if (!DoesDebugInfoOperandMatchExpectation(
+                _,
+                [](CommonDebugInfoInstructions dbg_inst) {
+                  return dbg_inst == CommonDebugInfoDebugInfoNone;
+                },
+                inst, 12)) {
+          auto* operand = _.FindDef(inst->word(12));
           if (operand->opcode() != spv::Op::OpVariable &&
-              operand->opcode() != spv::Op::OpFunctionParameter) {
+              operand->opcode() != spv::Op::OpConstant) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
                    << GetExtInstName(_, inst) << ": "
                    << "expected operand Variable must be a result id of "
-                      "OpVariable or OpFunctionParameter";
+                      "OpVariable or OpConstant or DebugInfoNone";
           }
-
-          CHECK_DEBUG_OPERAND("Expression", CommonDebugInfoDebugExpression, 7);
-          break;
         }
-        case CommonDebugInfoDebugExpression: {
-          for (uint32_t word_index = 5; word_index < num_words; ++word_index) {
-            CHECK_DEBUG_OPERAND("Operation", CommonDebugInfoDebugOperation,
-                                word_index);
-          }
-          break;
+        if (num_words == 15) {
+          CHECK_DEBUG_OPERAND("Static Member Declaration",
+                              CommonDebugInfoDebugTypeMember, 14);
         }
-        case CommonDebugInfoDebugTypeTemplate: {
-          if (!DoesDebugInfoOperandMatchExpectation(
-                  _,
-                  [](CommonDebugInfoInstructions dbg_inst) {
-                    return dbg_inst == CommonDebugInfoDebugTypeComposite ||
-                           dbg_inst == CommonDebugInfoDebugFunction;
-                  },
-                  inst, 5)) {
-            return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << GetExtInstName(_, inst) << ": "
-                   << "expected operand Target must be DebugTypeComposite "
-                   << "or DebugFunction";
-          }
-          for (uint32_t word_index = 6; word_index < num_words; ++word_index) {
-            if (!DoesDebugInfoOperandMatchExpectation(
-                    _,
-                    [](CommonDebugInfoInstructions dbg_inst) {
-                      return dbg_inst ==
-                                 CommonDebugInfoDebugTypeTemplateParameter ||
-                             dbg_inst ==
-                                 CommonDebugInfoDebugTypeTemplateTemplateParameter;
-                    },
-                    inst, word_index)) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": "
-                     << "expected operand Parameters must be "
-                     << "DebugTypeTemplateParameter or "
-                     << "DebugTypeTemplateTemplateParameter";
-            }
-          }
-          break;
-        }
-        case CommonDebugInfoDebugTypeTemplateParameter: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          auto validate_actual_type =
-              ValidateOperandDebugType(_, "Actual Type", inst, 6, false);
-          if (validate_actual_type != SPV_SUCCESS) return validate_actual_type;
-          if (!DoesDebugInfoOperandMatchExpectation(
-                  _,
-                  [](CommonDebugInfoInstructions dbg_inst) {
-                    return dbg_inst == CommonDebugInfoDebugInfoNone;
-                  },
-                  inst, 7)) {
-            CHECK_OPERAND("Value", spv::Op::OpConstant, 7);
-          }
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 8);
-          CHECK_CONST_UINT_OPERAND("Line", 9);
-          CHECK_CONST_UINT_OPERAND("Column", 10);
-          break;
-        }
-        case CommonDebugInfoDebugGlobalVariable: {
-          CHECK_OPERAND("Name", spv::Op::OpString, 5);
-          auto validate_type =
-              ValidateOperandDebugType(_, "Type", inst, 6, false);
-          if (validate_type != SPV_SUCCESS) return validate_type;
-          CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 7);
-          CHECK_CONST_UINT_OPERAND("Line", 8);
-          CHECK_CONST_UINT_OPERAND("Column", 9);
-          auto validate_scope =
-              ValidateOperandLexicalScope(_, "Scope", inst, 10);
-          if (validate_scope != SPV_SUCCESS) return validate_scope;
-          CHECK_OPERAND("Linkage Name", spv::Op::OpString, 11);
-          if (!DoesDebugInfoOperandMatchExpectation(
-                  _,
-                  [](CommonDebugInfoInstructions dbg_inst) {
-                    return dbg_inst == CommonDebugInfoDebugInfoNone;
-                  },
-                  inst, 12)) {
-            auto* operand = _.FindDef(inst->word(12));
-            if (operand->opcode() != spv::Op::OpVariable &&
-                operand->opcode() != spv::Op::OpConstant) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst) << ": "
-                     << "expected operand Variable must be a result id of "
-                        "OpVariable or OpConstant or DebugInfoNone";
-            }
-          }
-          if (num_words == 15) {
-            CHECK_DEBUG_OPERAND("Static Member Declaration",
-                                CommonDebugInfoDebugTypeMember, 14);
-          }
-          break;
-        }
-        case CommonDebugInfoDebugInlinedAt: {
-          CHECK_CONST_UINT_OPERAND("Line", 5);
-          auto validate_scope =
-              ValidateOperandLexicalScope(_, "Scope", inst, 6);
-          if (validate_scope != SPV_SUCCESS) return validate_scope;
-          if (num_words == 8) {
-            CHECK_DEBUG_OPERAND("Inlined", CommonDebugInfoDebugInlinedAt, 7);
-          }
-          break;
-        }
-        case CommonDebugInfoDebugValue: {
-          CHECK_DEBUG_OPERAND("Local Variable",
-                              CommonDebugInfoDebugLocalVariable, 5);
-          CHECK_DEBUG_OPERAND("Expression", CommonDebugInfoDebugExpression, 7);
-
-          for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
-            // TODO: The following code simply checks if it is a const int
-            // scalar or a DebugLocalVariable or DebugGlobalVariable, but we
-            // have to check it using the same validation for Indexes of
-            // OpAccessChain.
-            if (!IsConstWithIntScalarType(_, inst, word_index) &&
-                !IsDebugVariableWithIntScalarType(_, inst, word_index)) {
-              return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                     << GetExtInstName(_, inst)
-                     << ": expected operand Indexes is "
-                     << "OpConstant, DebugGlobalVariable, or "
-                     << "type is OpConstant with an integer scalar type";
-            }
-          }
-          break;
-        }
-
-        // TODO: Add validation rules for remaining cases as well.
-        case CommonDebugInfoDebugTypePtrToMember:
-        case CommonDebugInfoDebugTypeTemplateTemplateParameter:
-        case CommonDebugInfoDebugTypeTemplateParameterPack:
-        case CommonDebugInfoDebugLexicalBlockDiscriminator:
-        case CommonDebugInfoDebugInlinedVariable:
-        case CommonDebugInfoDebugMacroDef:
-        case CommonDebugInfoDebugMacroUndef:
-        case CommonDebugInfoDebugImportedEntity:
-          break;
-        case CommonDebugInfoInstructionsMax:
-          assert(0);
-          break;
+        break;
       }
-    }
-  } else if (ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_CLSPVREFLECTION) {
-    auto import_inst = _.FindDef(inst->GetOperandAs<uint32_t>(2));
-    const std::string name = import_inst->GetOperandAs<std::string>(1);
-    const std::string reflection = "NonSemantic.ClspvReflection.";
-    char* end_ptr;
-    auto version_string = name.substr(reflection.size());
-    if (version_string.empty()) {
-      return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
-             << "Missing NonSemantic.ClspvReflection import version";
-    }
-    uint32_t version = static_cast<uint32_t>(
-        std::strtoul(version_string.c_str(), &end_ptr, 10));
-    if (end_ptr && *end_ptr != '\0') {
-      return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
-             << "NonSemantic.ClspvReflection import does not encode the "
-                "version correctly";
-    }
-    if (version == 0 || version > NonSemanticClspvReflectionRevision) {
-      return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
-             << "Unknown NonSemantic.ClspvReflection import version";
-    }
+      case CommonDebugInfoDebugInlinedAt: {
+        CHECK_CONST_UINT_OPERAND("Line", 5);
+        auto validate_scope = ValidateOperandLexicalScope(_, "Scope", inst, 6);
+        if (validate_scope != SPV_SUCCESS) return validate_scope;
+        if (num_words == 8) {
+          CHECK_DEBUG_OPERAND("Inlined", CommonDebugInfoDebugInlinedAt, 7);
+        }
+        break;
+      }
+      case CommonDebugInfoDebugValue: {
+        CHECK_DEBUG_OPERAND("Local Variable", CommonDebugInfoDebugLocalVariable,
+                            5);
+        CHECK_DEBUG_OPERAND("Expression", CommonDebugInfoDebugExpression, 7);
 
-    return ValidateClspvReflectionInstruction(_, inst, version);
+        for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
+          // TODO: The following code simply checks if it is a const int
+          // scalar or a DebugLocalVariable or DebugGlobalVariable, but we
+          // have to check it using the same validation for Indexes of
+          // OpAccessChain.
+          if (!IsConstWithIntScalarType(_, inst, word_index) &&
+              !IsDebugVariableWithIntScalarType(_, inst, word_index)) {
+            return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << GetExtInstName(_, inst)
+                   << ": expected operand Indexes is "
+                   << "OpConstant, DebugGlobalVariable, or "
+                   << "type is OpConstant with an integer scalar type";
+          }
+        }
+        break;
+      }
+
+      // TODO: Add validation rules for remaining cases as well.
+      case CommonDebugInfoDebugTypePtrToMember:
+      case CommonDebugInfoDebugTypeTemplateTemplateParameter:
+      case CommonDebugInfoDebugTypeTemplateParameterPack:
+      case CommonDebugInfoDebugLexicalBlockDiscriminator:
+      case CommonDebugInfoDebugInlinedVariable:
+      case CommonDebugInfoDebugMacroDef:
+      case CommonDebugInfoDebugMacroUndef:
+      case CommonDebugInfoDebugImportedEntity:
+        break;
+      case CommonDebugInfoInstructionsMax:
+        assert(0);
+        break;
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t ValidateExtInstNonsemanticClspvReflection(
+    ValidationState_t& _, const Instruction* inst) {
+  auto import_inst = _.FindDef(inst->GetOperandAs<uint32_t>(2));
+  const std::string name = import_inst->GetOperandAs<std::string>(1);
+  const std::string reflection = "NonSemantic.ClspvReflection.";
+  char* end_ptr;
+  auto version_string = name.substr(reflection.size());
+  if (version_string.empty()) {
+    return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
+           << "Missing NonSemantic.ClspvReflection import version";
+  }
+  uint32_t version =
+      static_cast<uint32_t>(std::strtoul(version_string.c_str(), &end_ptr, 10));
+  if (end_ptr && *end_ptr != '\0') {
+    return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
+           << "NonSemantic.ClspvReflection import does not encode the "
+              "version correctly";
+  }
+  if (version == 0 || version > NonSemanticClspvReflectionRevision) {
+    return _.diag(SPV_ERROR_INVALID_DATA, import_inst)
+           << "Unknown NonSemantic.ClspvReflection import version";
+  }
+
+  return ValidateClspvReflectionInstruction(_, inst, version);
+}
+
+spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
+  const spv_ext_inst_type_t ext_inst_type =
+      spv_ext_inst_type_t(inst->ext_inst_type());
+
+  if (ext_inst_type == SPV_EXT_INST_TYPE_GLSL_STD_450) {
+    return ValidateExtInstGlslStd450(_, inst);
+  } else if (ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_STD) {
+    return ValidateExtInstOpenClStd(_, inst);
+  } else if (ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100 ||
+             ext_inst_type ==
+                 SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
+    return ValidateExtInstDebugInfo100(_, inst);
+  } else if (ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_CLSPVREFLECTION) {
+    return ValidateExtInstNonsemanticClspvReflection(_, inst);
   }
 
   return SPV_SUCCESS;


### PR DESCRIPTION
@stefano-bucciarelli-arm asked me where future TOSA Ext Instructions would be validated, I pointed to `ValidateExtInst` and realize how huge it was

This is 2 commits, first just move the `get_ext_inst_name` lambda to be a function so it doesn't have to be passed around everywhere. Then I just created dedicated `ValidateExtInst*` for each set of extended instruction sets currently supported

This is just a copy-and-paste job, but shows a LOT of diff because it removed a level of indentation from everything