### PR TITLE
spirv-opt: Handle id overflow in CCP and constant folding

### DIFF
--- a/source/opt/ccp_pass.cpp
+++ b/source/opt/ccp_pass.cpp
@@ -165,6 +165,9 @@ SSAPropagator::PropStatus CCPPass::VisitAssignment(Instruction* instr) {
       context()->get_instruction_folder().FoldInstructionToConstant(instr,
                                                                     map_func);
 
+  if (folded_inst && context()->id_overflow()) {
+    return SSAPropagator::kFailed;
+  }
   if (folded_inst != nullptr) {
     // We do not want to change the body of the function by adding new
     // instructions.  When folding we can only generate new constants.
@@ -376,6 +379,7 @@ Pass::Status CCPPass::Process() {
   // Process all entry point functions.
   ProcessFunction pfn = [this](Function* fp) { return PropagateConstants(fp); };
   bool modified = context()->ProcessReachableCallTree(pfn);
+  if (context()->id_overflow()) return Pass::Status::Failure;
   return modified ? Pass::Status::SuccessWithChange
                   : Pass::Status::SuccessWithoutChange;
 }

--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -829,7 +829,9 @@ const analysis::Constant* FoldFPBinaryOp(
     // Build the constant object and return it.
     std::vector<uint32_t> ids;
     for (const analysis::Constant* member : results_components) {
-      ids.push_back(const_mgr->GetDefiningInstruction(member)->result_id());
+      Instruction* def = const_mgr->GetDefiningInstruction(member);
+      if (!def) return nullptr;
+      ids.push_back(def->result_id());
     }
     return const_mgr->GetConstant(vector_type, ids);
   } else {
@@ -1404,7 +1406,9 @@ ConstantFoldingRule FoldFMix() {
     }
 
     if (is_vector) {
-      uint32_t one_id = const_mgr->GetDefiningInstruction(one)->result_id();
+      Instruction* one_inst = const_mgr->GetDefiningInstruction(one);
+      if (one_inst == nullptr) return nullptr;
+      uint32_t one_id = one_inst->result_id();
       one =
           const_mgr->GetConstant(result_type, std::vector<uint32_t>(4, one_id));
     }

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -597,6 +597,9 @@ Instruction* InstructionFolder::FoldInstructionToConstant(
   const analysis::Constant* folded_const = nullptr;
   for (auto rule : GetConstantFoldingRules().GetRulesForInstruction(inst)) {
     folded_const = rule(context_, inst, constants);
+    if (folded_const == nullptr && inst->context()->id_overflow()) {
+      return nullptr;
+    }
     if (folded_const != nullptr) {
       Instruction* const_inst =
           const_mgr->GetDefiningInstruction(folded_const, inst->type_id());


### PR DESCRIPTION
This is a partial fix for https://github.com/KhronosGroup/SPIRV-Tools/issues/6260

This change handles the case where the id overflows when running CCP or constant folding.
When this happens, the pass will now return a failure status.
