### PR TITLE
spirv-opt: Correct ADCE bug keeping dead DebugValue Value operands

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -305,7 +305,7 @@ Pass::Status AggressiveDCEPass::ProcessDebugInformation(
               NonSemanticShaderDebugInfo100DebugValue) {
         uint32_t id = inst->GetSingleWordInOperand(kDebugValueValue);
         auto def = get_def_use_mgr()->GetDef(id);
-        if (!live_insts_.Set(def->unique_id())) {
+        if (!IsLive(def)) {
           AddToWorklist(inst);
           uint32_t undef_id = Type2Undef(def->type_id());
           if (undef_id == 0) {

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -8686,8 +8686,6 @@ OpDecorate %b Binding 0
 %int_1 = OpConstant %int 1
 %int_2 = OpConstant %int 2
 ; CHECK: [[undef:%\w+]] = OpUndef %int
-; ADCE will create another undef and use the new one.
-; CHECK: [[undef:%\w+]] = OpUndef %int
 %198 = OpUndef %int
 %38 = OpExtInst %void %1 DebugInfoNone
 %16 = OpExtInst %void %1 DebugExpression
@@ -8717,8 +8715,8 @@ OpDecorate %b Binding 0
 %242 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_1
 %239 = OpExtInst %void %1 DebugValue %31 %198 %16 %int_2
 ; CHECK: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue [[var]] [[undef]] {{%\w+}} %int_0
-; CHECK-NOT: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue
-; CHECK-NOT: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue
+; CHECK: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue [[var]] [[undef]] {{%\w+}} %int_1
+; CHECK: {{%\w+}} = OpExtInst %void {{%\w+}} DebugValue [[var]] [[undef]] {{%\w+}} %int_2
 %160 = OpExtInst %void %1 DebugLine %22 %uint_6 %uint_6 %uint_3 %uint_10
 %147 = OpLoad %type_buffer_image %b
 OpImageWrite %147 %uint_0 %int_0 None


### PR DESCRIPTION
A logic error in ProcessDebugInfo(), a pass recently added to ADCE, causes some shaders to fail optimization.  When examining the Value operand of a DebugValue instruction, we should only be reading the live list, as this change corrects.  Previously, we were using the .Set method, which was incorrectly marking these instructions live.  Since other dependencies may have been killed, the SPIR-V is left in an inconsistent state.

This PR partially corrects https://github.com/microsoft/DirectXShaderCompiler/issues/7744.  The remaining issue is in scalar-replacement=0.  Since this PR has more wide-ranging benefits and I haven't root-caused the remaining problem, I'm submitting it now.