### PR TITLE
Add `SPV_KHR_maximal_reconvergence` to the allowlist

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -1123,6 +1123,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_NV_shader_invocation_reorder",
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
+      "SPV_KHR_maximal_reconvergence",
   });
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -467,6 +467,7 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_NV_shader_invocation_reorder",
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
+      "SPV_KHR_maximal_reconvergence",
   });
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -304,6 +304,7 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_NV_shader_invocation_reorder",
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
+      "SPV_KHR_maximal_reconvergence",
   });
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -156,6 +156,7 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
       "SPV_NV_shader_invocation_reorder",
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
+      "SPV_KHR_maximal_reconvergence",
   });
 }
 bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {


### PR DESCRIPTION
Add extension to the allowlist to allow optimization passes to run.

Verified fixes https://github.com/microsoft/DirectXShaderCompiler/issues/7826