### PR TITLE
opt: Remove double iteration of decorations

### DIFF
--- a/source/opt/decoration_manager.h
+++ b/source/opt/decoration_manager.h
@@ -157,7 +157,14 @@ class DecorationManager {
   void AnalyzeDecorations();
 
   template <typename T>
-  std::vector<T> InternalGetDecorationsFor(uint32_t id, bool include_linkage);
+  std::vector<T*> InternalGetDecorationsFor(uint32_t id, bool include_linkage);
+
+  template <typename T>
+  bool InternalWhileEachDecoration(uint32_t id, std::function<bool(T*)> f);
+
+  template <typename T>
+  bool InternalWhileEachDecoration(uint32_t id,
+                                   std::function<bool(T*)> f) const;
 
   // Tracks decoration information of an ID.
   struct TargetData {

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -486,7 +486,7 @@ bool Instruction::IsReadOnlyPointerShaders() const {
       break;
   }
 
-  context()->get_decoration_mgr()->HasDecoration(
+  return context()->get_decoration_mgr()->HasDecoration(
       result_id(), uint32_t(spv::Decoration::NonWritable));
 }
 


### PR DESCRIPTION
The WhileEachDecoration() function first used GetDecorationsFor() which
walks over the decorations and collects them in a vector.  It then
called a callback for each such instructions.  With this change, the
callback is called while iterating the decorations.

This has the side effect that if the callback returns early, the rest of
the decorations are never visited.  Consequently, HasDecoration() can
early out as soon as it encounters the desired decoration.