### PR TITLE
spirv-opt: Cache IsReadOnlyLoad in ValueNumberTable

### DIFF
--- a/source/opt/value_number_table.cpp
+++ b/source/opt/value_number_table.cpp
@@ -38,6 +38,45 @@ uint32_t ValueNumberTable::GetValueNumber(uint32_t id) const {
   return GetValueNumber(context()->get_def_use_mgr()->GetDef(id));
 }
 
+bool ValueNumberTable::IsReadOnlyLoad(Instruction* inst) {
+  if (!inst->IsLoad()) {
+    return false;
+  }
+
+  Instruction* address_def = inst->GetBaseAddress();
+  if (!address_def) {
+    return false;
+  }
+
+  auto cached_result = read_only_variable_cache_.find(address_def->result_id());
+  if (cached_result != read_only_variable_cache_.end()) {
+    return cached_result->second;
+  }
+
+  bool is_read_only = IsReadOnlyVariable(address_def);
+  read_only_variable_cache_[address_def->result_id()] = is_read_only;
+  return is_read_only;
+}
+
+bool ValueNumberTable::IsReadOnlyVariable(Instruction* address_def) {
+  if (address_def->opcode() == spv::Op::OpVariable) {
+    if (address_def->IsReadOnlyPointer()) {
+      return true;
+    }
+  }
+
+  if (address_def->opcode() == spv::Op::OpLoad) {
+    const analysis::Type* address_type =
+        context()->get_type_mgr()->GetType(address_def->type_id());
+    if (address_type->AsSampledImage() != nullptr) {
+      const auto* image_type =
+          address_type->AsSampledImage()->image_type()->AsImage();
+      return image_type->sampled() == 1;
+    }
+  }
+  return false;
+}
+
 uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
   // If it already has a value return that.
   uint32_t value = GetValueNumber(inst);
@@ -88,7 +127,7 @@ uint32_t ValueNumberTable::AssignValueNumber(Instruction* inst) {
   // Note that this test will also handle volatile loads because they are not
   // read only.  However, if this is ever relaxed because we analyze stores, we
   // will have to add a new case for volatile loads.
-  if (inst->IsLoad() && !inst->IsReadOnlyLoad()) {
+  if (inst->IsLoad() && !IsReadOnlyLoad(inst)) {
     return assign_new_number(inst);
   }
 

--- a/source/opt/value_number_table.h
+++ b/source/opt/value_number_table.h
@@ -70,6 +70,14 @@ class ValueNumberTable {
   // Assigns a value number to every result id in the module.
   void BuildDominatorTreeValueNumberTable();
 
+  // Returns true if |inst| is a load from read-only memory. This is a cached
+  // version of |Instruction::IsReadOnlyLoad| that is local to this pass.
+  bool IsReadOnlyLoad(Instruction* inst);
+
+  // Returns true if the variable pointed to by |address_def| is read-only.
+  // This is the part of |IsReadOnlyLoad| that is cached.
+  bool IsReadOnlyVariable(Instruction* address_def);
+
   // Returns the new value number.
   uint32_t TakeNextValueNumber() { return next_value_number_++; }
 
@@ -81,6 +89,10 @@ class ValueNumberTable {
   std::unordered_map<Instruction, uint32_t, ValueTableHash, ComputeSameValue>
       instruction_to_value_;
   std::unordered_map<uint32_t, uint32_t> id_to_value_;
+  // A cache for the results of |IsReadOnlyVariable|. The key is the base
+  // variable of a load.
+  std::unordered_map<uint32_t, bool> read_only_variable_cache_;
+
   IRContext* context_;
   uint32_t next_value_number_;
 };


### PR DESCRIPTION
This change introduces a caching mechanism for IsReadOnlyLoad within the
ValueNumberTable class. This is done to improve performance by avoiding
repeated computations.

This is an alternative solution to PR #6384.
