### PR TITLE
spirv-val: Fix VUID churn for 10685

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -315,9 +315,7 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
           }
           if (!ok) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << (_.HasCapability(spv::Capability::TileShadingQCOM)
-                           ? _.VkErrorID(10685)
-                           : _.VkErrorID(6426))
+                   << _.VkErrorID(10685)
                    << "In the Vulkan environment, GLCompute execution model "
                       "entry points require either the "
                    << (_.HasCapability(spv::Capability::TileShadingQCOM)

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2538,8 +2538,6 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeRuntimeArray-04680);
     case 4682:
       return VUID_WRAP(VUID-StandaloneSpirv-OpControlBarrier-04682);
-    case 6426:
-      return VUID_WRAP(VUID-StandaloneSpirv-LocalSize-06426); // formally 04683
     case 4685:
       return VUID_WRAP(VUID-StandaloneSpirv-OpGroupNonUniformBallotBitCount-04685);
     case 4686:
@@ -2752,7 +2750,7 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
     case 10684:
       return VUID_WRAP(VUID-StandaloneSpirv-None-10684);
     case 10685:
-      return VUID_WRAP(VUID-StandaloneSpirv-None-10685);
+      return VUID_WRAP(VUID-StandaloneSpirv-None-10685); // formally 04683/06426
     case 10824:
       // This use to be a standalone, but maintenance9 will set allow_vulkan_32_bit_bitwise now
       return VUID_WRAP(VUID-RuntimeSpirv-None-10824);

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -64,7 +64,7 @@ OpEntryPoint GLCompute %main "main"
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
-              AnyVUID("VUID-StandaloneSpirv-LocalSize-06426"));
+              AnyVUID("VUID-StandaloneSpirv-None-10685"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(


### PR DESCRIPTION
`VK_QCOM_tile_shading` messed up the VUID in the spec, there is no `VUID-StandaloneSpirv-LocalSize-06426` and it is now just `VUID-StandaloneSpirv-None-10685`