### PR TITLE
Fix Emacs support due to changed spirv-as syntax

### DIFF
--- a/tools/emacs/50spirv-tools.el
+++ b/tools/emacs/50spirv-tools.el
@@ -31,7 +31,7 @@
 
 (add-to-list 'jka-compr-compression-info-list
              '["\\.spv\\'"
-               "Assembling SPIRV" "spirv-as" ("-o" "-")
+               "Assembling SPIRV" "spirv-as" ("-o" "-" "-")
                "Disassembling SPIRV" "spirv-dis" ("--no-color" "--raw-id")
                t nil "\003\002\043\007"])
 


### PR DESCRIPTION
Hi!

It seems like `spirv-as` has updated its syntax. When I run the previous Emacs code and try to save the file, I get the following error:

```
Error while executing "spirv-as -o - < /tmp/jka-com7UpTxB"

error: exactly one input file must be specified.
```

After reading the documentation, it seems that you now need to put a dash for both the input and the output file:

```
spirv-as --help
/run/current-system/sw/bin/spirv-as - Create a SPIR-V binary module from SPIR-V assembly text

Usage: /run/current-system/sw/bin/spirv-as [options] [<filename>]

The SPIR-V assembly text is read from <filename>.  If no file is specified,
or if the filename is "-", then the assembly text is read from standard input.
The SPIR-V binary module is written to file "out.spv", unless the -o option
is used.
```

After adding another dash, saving works fine for me.

Thanks for this package!