### PR TITLE
spirv-val: Use spvOpcodeString consistently

### DIFF
--- a/source/val/validate_composites.cpp
+++ b/source/val/validate_composites.cpp
@@ -532,8 +532,7 @@ spv_result_t ValidateVectorShuffle(ValidationState_t& _,
   if (!resultType || resultType->opcode() != spv::Op::OpTypeVector) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "The Result Type of OpVectorShuffle must be"
-           << " OpTypeVector. Found Op"
-           << spvOpcodeString(static_cast<spv::Op>(resultType->opcode()))
+           << " OpTypeVector. Found Op" << spvOpcodeString(resultType->opcode())
            << ".";
   }
 

--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1100,7 +1100,7 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
                << "Result <id> from OpSampledImage instruction must not appear "
                   "as "
                   "operands of Op"
-               << spvOpcodeString(static_cast<spv::Op>(consumer_opcode)) << "."
+               << spvOpcodeString(consumer_opcode) << "."
                << " Found result <id> " << _.getIdName(inst->id())
                << " as an operand of <id> " << _.getIdName(consumer_instr->id())
                << ".";
@@ -1110,12 +1110,11 @@ spv_result_t ValidateSampledImage(ValidationState_t& _,
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "Result <id> from OpSampledImage instruction must not appear "
                   "as operand for Op"
-               << spvOpcodeString(static_cast<spv::Op>(consumer_opcode))
+               << spvOpcodeString(consumer_opcode)
                << ", since it is not specified as taking an "
-               << "OpTypeSampledImage."
-               << " Found result <id> " << _.getIdName(inst->id())
-               << " as an operand of <id> " << _.getIdName(consumer_instr->id())
-               << ".";
+               << "OpTypeSampledImage." << " Found result <id> "
+               << _.getIdName(inst->id()) << " as an operand of <id> "
+               << _.getIdName(consumer_instr->id()) << ".";
       }
     }
   }


### PR DESCRIPTION
small cleanup to use `spvOpcodeString` like it is everywhere else