### PR TITLE
spirv-val: Better atomic storage class message

### DIFF
--- a/source/val/validate_atomics.cpp
+++ b/source/val/validate_atomics.cpp
@@ -235,7 +235,9 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
       if (!IsStorageClassAllowedByUniversalRules(storage_class)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode)
-               << ": storage class forbidden by universal validation rules.";
+               << ": Can not be used with storage class "
+               << spvtools::StorageClassToString(storage_class)
+               << " by universal validation rules";
       }
 
       // Then Shader rules
@@ -249,8 +251,10 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
               (storage_class != spv::StorageClass::PhysicalStorageBuffer) &&
               (storage_class != spv::StorageClass::TaskPayloadWorkgroupEXT)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                   << _.VkErrorID(4686) << spvOpcodeString(opcode)
-                   << ": Vulkan spec only allows storage classes for atomic to "
+                   << _.VkErrorID(4686) << spvOpcodeString(opcode) << ": "
+                   << spvtools::StorageClassToString(storage_class)
+                   << " is not allowed, the Vulkan spec only allows storage "
+                      "classes for atomic to "
                       "be: Uniform, Workgroup, Image, StorageBuffer, "
                       "PhysicalStorageBuffer or TaskPayloadWorkgroupEXT.";
           }
@@ -335,8 +339,9 @@ spv_result_t AtomicsPass(ValidationState_t& _, const Instruction* inst) {
             (storage_class != spv::StorageClass::CrossWorkgroup) &&
             (storage_class != spv::StorageClass::Generic)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << spvOpcodeString(opcode)
-                 << ": storage class must be Function, Workgroup, "
+                 << spvOpcodeString(opcode) << ": storage class is "
+                 << spvtools::StorageClassToString(storage_class)
+                 << ", but must be Function, Workgroup, "
                     "CrossWorkGroup or Generic in the OpenCL environment.";
         }
 

--- a/test/val/val_atomics_test.cpp
+++ b/test/val/val_atomics_test.cpp
@@ -783,7 +783,8 @@ OpAtomicStore %f32_var_function %device %relaxed %f32_1
               AnyVUID("VUID-StandaloneSpirv-None-04686"));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("AtomicStore: Vulkan spec only allows storage classes for "
+      HasSubstr("AtomicStore: Function is not allowed, the Vulkan spec only "
+                "allows storage classes for "
                 "atomic to be: Uniform, Workgroup, Image, StorageBuffer, "
                 "PhysicalStorageBuffer or TaskPayloadWorkgroupEXT."));
 }
@@ -1081,7 +1082,8 @@ OpAtomicStore %f32_im_var %device %relaxed %f32_1
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_OPENCL_1_2));
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr("AtomicStore: storage class must be Function, Workgroup, "
+      HasSubstr("AtomicStore: storage class is Image, but must be Function, "
+                "Workgroup, "
                 "CrossWorkGroup or Generic in the OpenCL environment."));
 }
 
@@ -1093,8 +1095,8 @@ OpAtomicStore %f32_uc_var %device %relaxed %f32_1
   CompileSuccessfully(GenerateKernelCode(body));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("AtomicStore: storage class forbidden by universal "
-                        "validation rules."));
+              HasSubstr("AtomicStore: Can not be used with storage class "
+                        "UniformConstant by universal validation rules"));
 }
 
 TEST_F(ValidateAtomics, AtomicStoreWrongScopeType) {


### PR DESCRIPTION
> AtomicIAdd: storage class forbidden by universal validation rules.

Is a terrible error message and requires me to read the source code to know what is wrong/going on

Now it will say

> AtomicIAdd: Can not be used with storage class Output by universal validation rules