### PR TITLE
spirv-val: Add Mesh Shading Read Output check

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2703,6 +2703,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-ViewportIndex-ViewportIndex-07060);
     case 7102:
       return VUID_WRAP(VUID-StandaloneSpirv-MeshEXT-07102);
+    case 7107:
+      return VUID_WRAP(VUID-StandaloneSpirv-MeshEXT-07107);
     case 7290:
       return VUID_WRAP(VUID-StandaloneSpirv-Input-07290);
     case 7320:

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -6526,16 +6526,20 @@ TEST_F(ValidateBuiltIns,
 %void = OpTypeVoid
  %3 = OpTypeFunction %void
 %uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
 %uint_32 = OpConstant %uint 32
 %uint_1 = OpConstant %uint 1
-%int = OpTypeInt 32 1
+%uint_0 = OpConstant %uint 0
+%int_0 = OpConstant %int 0
 %bool = OpTypeBool
 %_arr_gl_PrimitiveShadingRateEXT_uint_32 = OpTypeArray %int %uint_32
 %_ptr_Output__arr_gl_PrimitiveShadingRateEXT_uint_32 = OpTypePointer Output %_arr_gl_PrimitiveShadingRateEXT_uint_32
 %gl_PrimitiveShadingRateEXT = OpVariable %_ptr_Output__arr_gl_PrimitiveShadingRateEXT_uint_32 Output
+%uint_ptr = OpTypePointer Output %int
 %main = OpFunction %void None %3
  %5 = OpLabel
-%ref_load = OpLoad %_arr_gl_PrimitiveShadingRateEXT_uint_32 %gl_PrimitiveShadingRateEXT
+      %21 = OpAccessChain %uint_ptr %gl_PrimitiveShadingRateEXT %uint_0
+      OpStore %21 %int_0
       OpReturn
       OpFunctionEnd
 )";


### PR DESCRIPTION
adds `VUID-StandaloneSpirv-MeshEXT-07107`

<img width="869" height="63" alt="image" src="https://github.com/user-attachments/assets/2645938a-7da1-4365-85e5-bc1eff53a151" />

- Atomics are not allowed on Output, so `OpLoad` should cover it all
- Added (for practice) and Untyped Pointer test, but they aren't allowed