### PR TITLE
spirv-val: Validate divide by zero when possible

### DIFF
--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -5970,6 +5970,7 @@ OpName %entry "entry"
   %voidfn = OpTypeFunction %void
      %int = OpTypeInt 32 1
     %zero = OpConstantNull %int
+    %one = OpConstant %int 1
    %float = OpTypeFloat 32
   %float0 = OpConstantNull %float
     %main = OpFunction %void None %voidfn
@@ -6080,7 +6081,7 @@ TEST_F(ValidateDecorations, NoSignedWrapSNegateGood) {
 
 TEST_F(ValidateDecorations, NoSignedWrapSRemBad) {
   std::string spirv = MakeIntegerShader("OpDecorate %val NoSignedWrap",
-                                        "%val = OpSRem %int %zero %zero");
+                                        "%val = OpSRem %int %zero %one");
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
@@ -6222,7 +6223,7 @@ TEST_F(ValidateDecorations, NoUnsignedWrapSNegateGood) {
 
 TEST_F(ValidateDecorations, NoUnsignedWrapSRemBad) {
   std::string spirv = MakeIntegerShader("OpDecorate %val NoUnsignedWrap",
-                                        "%val = OpSRem %int %zero %zero");
+                                        "%val = OpSRem %int %zero %one");
 
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());


### PR DESCRIPTION
This was prompted by the fact nothing caught [this](https://godbolt.org/z/zTeToGePs) and 

Discussing among various WG memebers, all agreed that if there is a constant (or frozen spec constant in VVL) that `spirv-val` should be catching this early

Spec to make it a proper VU (incase want to gate on Vulkan Env)  https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7853