### PR TITLE
Fix std::u8string vs std::string mismatch in tool/val/val.cpp vulkan-sdk-1.4.328(.2)

### DIFF
--- a/tools/val/val.cpp
+++ b/tools/val/val.cpp
@@ -273,7 +273,7 @@ int main(int argc, char** argv) {
       const auto filepath_u8str = filepath.u8string();
       const std::string filepath_str(filepath_u8str.begin(),
                                      filepath_u8str.end());
-      if (!process_single_file(filepath.u8string().c_str(), target_env, options,
+      if (!process_single_file(filepath_str.c_str(), target_env, options,
                                false)) {
         succeed = false;
       }


### PR DESCRIPTION
There is the following piece of code in val.cpp:
```
      // Copy the string, because in C++20 the result type of
      // std::filesystem::path::u8string changes type from std::string to
      // std::u8string, and the pointer type ends up incompatible. Normalize
      // to std::string first via copying.
      const auto filepath_u8str = filepath.u8string();
      const std::string filepath_str(filepath_u8str.begin(),
                                     filepath_u8str.end());
      if (!process_single_file(filepath.u8string().c_str(), target_env, options,
                               false)) {
        succeed = false;
      }
```

That is, filepath_str is created but not used. It fails with C++ 20 for reasons mentioned in the source code comment. 

It's been fixed in other branches but I need to use homogeneous versions for vulkan components and https://github.com/KhronosGroup/SPIRV-Headers stops at 1.4.328.1 so a fixed  vulkan-sdk-1.4.328 for Tools would be nice (I download everything at config time through FetchContent for my project).
I guess it could be tagged vulkan-sdk-1.4.328.1 ?

Thx
