### PR TITLE
spirv-opt: Harden CFGCleanupPass against ID overflow

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -813,7 +813,9 @@ Pass::Status AggressiveDCEPass::ProcessImpl() {
 
   // Cleanup all CFG including all unreachable blocks.
   for (Function& fp : *context()->module()) {
-    modified |= CFGCleanup(&fp);
+    auto status = CFGCleanup(&fp);
+    if (status == Status::Failure) return Status::Failure;
+    if (status == Status::SuccessWithChange) modified = true;
   }
 
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;

--- a/source/opt/cfg_cleanup_pass.cpp
+++ b/source/opt/cfg_cleanup_pass.cpp
@@ -25,8 +25,17 @@ namespace opt {
 
 Pass::Status CFGCleanupPass::Process() {
   // Process all entry point functions.
-  ProcessFunction pfn = [this](Function* fp) { return CFGCleanup(fp); };
+  bool failure = false;
+  ProcessFunction pfn = [this, &failure](Function* fp) {
+    auto status = CFGCleanup(fp);
+    if (status == Status::Failure) {
+      failure = true;
+      return false;
+    }
+    return status == Status::SuccessWithChange;
+  };
   bool modified = context()->ProcessReachableCallTree(pfn);
+  if (failure) return Pass::Status::Failure;
   return modified ? Pass::Status::SuccessWithChange
                   : Pass::Status::SuccessWithoutChange;
 }

--- a/source/opt/mem_pass.h
+++ b/source/opt/mem_pass.h
@@ -114,7 +114,7 @@ class MemPass : public Pass {
   void DCEInst(Instruction* inst, const std::function<void(Instruction*)>&);
 
   // Call all the cleanup helper functions on |func|.
-  bool CFGCleanup(Function* func);
+  Status CFGCleanup(Function* func);
 
   // Return true if |op| is supported decorate.
   inline bool IsNonTypeDecorate(spv::Op op) const {
@@ -142,15 +142,15 @@ class MemPass : public Pass {
   bool HasOnlySupportedRefs(uint32_t varId);
 
   // Remove all the unreachable basic blocks in |func|.
-  bool RemoveUnreachableBlocks(Function* func);
+  Status RemoveUnreachableBlocks(Function* func);
 
   // Remove the block pointed by the iterator |*bi|. This also removes
   // all the instructions in the pointed-to block.
   void RemoveBlock(Function::iterator* bi);
 
   // Remove Phi operands in |phi| that are coming from blocks not in
-  // |reachable_blocks|.
-  void RemovePhiOperands(
+  // |reachable_blocks|. Returns false if it fails.
+  bool RemovePhiOperands(
       Instruction* phi,
       const std::unordered_set<BasicBlock*>& reachable_blocks);
 


### PR DESCRIPTION
Modifies CFGCleanupPass and MemPass helper functions to gracefully
handle ID overflow events (when TakeNextIdBound() returns 0).
Propagates Status::Failure instead of asserting or continuing with
invalid IDs.
