### PR TITLE
spirv-opt: Harden CopyPropagateArraysPass against ID overflow

### DIFF
--- a/source/opt/copy_prop_arrays.h
+++ b/source/opt/copy_prop_arrays.h
@@ -118,7 +118,8 @@ class CopyPropagateArrays : public MemPass {
 
     // Converts all immediate values in the AccessChain their OpConstant
     // equivalent.
-    void BuildConstants();
+    // Returns false if the constants could not be created.
+    bool BuildConstants();
 
     // Returns the type id of the pointer type that can be used to point to this
     // memory object.
@@ -175,7 +176,8 @@ class CopyPropagateArrays : public MemPass {
   // Replaces all loads of |var_inst| with a load from |source| instead.
   // |insertion_pos| is a position where it is possible to construct the
   // address of |source| and also dominates all of the loads of |var_inst|.
-  void PropagateObject(Instruction* var_inst, MemoryObject* source,
+  // Returns false if the propagation failed.
+  bool PropagateObject(Instruction* var_inst, MemoryObject* source,
                        Instruction* insertion_pos);
 
   // Returns true if all of the references to |ptr_inst| can be rewritten and
@@ -241,7 +243,7 @@ class CopyPropagateArrays : public MemPass {
   // types of other instructions as needed.  This function should not be called
   // if |CanUpdateUses(original_ptr_inst, new_pointer_inst->type_id())| returns
   // false.
-  void UpdateUses(Instruction* original_ptr_inst,
+  bool UpdateUses(Instruction* original_ptr_inst,
                   Instruction* new_pointer_inst);
 
   // Return true if |UpdateUses| is able to change all of the uses of

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -331,6 +331,7 @@ Instruction* DebugInfoManager::GetDebugOperationWithDeref() {
   if (deref_operation_ != nullptr) return deref_operation_;
 
   uint32_t result_id = context()->TakeNextId();
+  if (result_id == 0) return nullptr;
   std::unique_ptr<Instruction> deref_operation;
 
   if (context()->get_feature_mgr()->GetExtInstImportId_OpenCL100DebugInfo()) {
@@ -374,10 +375,13 @@ Instruction* DebugInfoManager::GetDebugOperationWithDeref() {
 Instruction* DebugInfoManager::DerefDebugExpression(Instruction* dbg_expr) {
   assert(dbg_expr->GetCommonDebugOpcode() == CommonDebugInfoDebugExpression);
   std::unique_ptr<Instruction> deref_expr(dbg_expr->Clone(context()));
-  deref_expr->SetResultId(context()->TakeNextId());
-  deref_expr->InsertOperand(
-      kDebugExpressOperandOperationIndex,
-      {SPV_OPERAND_TYPE_ID, {GetDebugOperationWithDeref()->result_id()}});
+  uint32_t result_id = context()->TakeNextId();
+  if (result_id == 0) return nullptr;
+  deref_expr->SetResultId(result_id);
+  Instruction* deref_op = GetDebugOperationWithDeref();
+  if (!deref_op) return nullptr;
+  deref_expr->InsertOperand(kDebugExpressOperandOperationIndex,
+                            {SPV_OPERAND_TYPE_ID, {deref_op->result_id()}});
   auto* deref_expr_instr =
       context()->ext_inst_debuginfo_end()->InsertBefore(std::move(deref_expr));
   AnalyzeDebugInst(deref_expr_instr);

--- a/source/opt/pass.cpp
+++ b/source/opt/pass.cpp
@@ -117,6 +117,9 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
         // TODO(1841): Handle id overflow.
         Instruction* extract = ir_builder.AddCompositeExtract(
             original_element_type_id, object_to_copy->result_id(), {i});
+        if (extract == nullptr) {
+          return 0;
+        }
         uint32_t new_id =
             GenerateCopy(extract, new_element_type_id, insertion_position);
         if (new_id == 0) {
@@ -125,8 +128,12 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
         element_ids.push_back(new_id);
       }
 
-      return ir_builder.AddCompositeConstruct(new_type_id, element_ids)
-          ->result_id();
+      Instruction* construct =
+          ir_builder.AddCompositeConstruct(new_type_id, element_ids);
+      if (construct == nullptr) {
+        return 0;
+      }
+      return construct->result_id();
     }
     case spv::Op::OpTypeStruct: {
       std::vector<uint32_t> element_ids;
@@ -136,6 +143,9 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
         // TODO(1841): Handle id overflow.
         Instruction* extract = ir_builder.AddCompositeExtract(
             orig_member_type_id, object_to_copy->result_id(), {i});
+        if (extract == nullptr) {
+          return 0;
+        }
         uint32_t new_id =
             GenerateCopy(extract, new_member_type_id, insertion_position);
         if (new_id == 0) {
@@ -143,8 +153,12 @@ uint32_t Pass::GenerateCopy(Instruction* object_to_copy, uint32_t new_type_id,
         }
         element_ids.push_back(new_id);
       }
-      return ir_builder.AddCompositeConstruct(new_type_id, element_ids)
-          ->result_id();
+      Instruction* construct =
+          ir_builder.AddCompositeConstruct(new_type_id, element_ids);
+      if (construct == nullptr) {
+        return 0;
+      }
+      return construct->result_id();
     }
     default:
       // If we do not have an aggregate type, then we have a problem.  Either we


### PR DESCRIPTION
Updates CopyPropagateArraysPass and Pass::GenerateCopy to return Status/bool/0 and gracefully handle ID overflow events (when instruction creation fails).

This completes the hardening of CopyPropagateArraysPass by fixing nullptr checks in GenerateCopy and ensuring UpdateUses handles failures gracefully. Also hardens DebugInfoManager::DerefDebugExpression and GetDebugOperationWithDeref to handle ID overflow.
