### PR TITLE
Add missing EXPECT_THAT stanza to test

### DIFF
--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7443,9 +7443,9 @@ TEST_F(ValidateDecorations, ComponentDecoration64Vec2BadVulkan) {
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateAndRetrieveValidationState(env));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-Component-04922"));
-  HasSubstr(
-      "Sequence of components starting with 2 "
-      "and ending with 6 gets larger than 3");
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Sequence of components starting with 2 "
+                        "and ending with 5 gets larger than 3"));
 }
 
 TEST_F(ValidateDecorations, ComponentDecoration64VecWideBadVulkan) {


### PR DESCRIPTION
GoogleTest ToT has added `[[nodiscard]]` to various places to catch programming errors like this,
https://github.com/google/googletest/commit/065127f1e4b46c5f14fc73cf8d323c221f9dc68e

This is fixes the only error of this type that I encounter when using ToT GoogleTest.