### PR TITLE
spirv-tools: Fix infinite recursion in SmallVector::operator== on MSVC

### DIFF
--- a/source/util/small_vector.h
+++ b/source/util/small_vector.h
@@ -184,7 +184,8 @@ class SmallVector {
   }
 
 // Avoid infinite recursion from rewritten operators in C++20
-#if __cplusplus <= 201703L
+#if (defined(_MSVC_LANG) && _MSVC_LANG <= 201703L) || \
+    (!defined(_MSVC_LANG) && __cplusplus <= 201703L)
   friend bool operator==(const std::vector<T>& lhs, const SmallVector& rhs) {
     return rhs == lhs;
   }


### PR DESCRIPTION
On MSVC, __cplusplus is not updated by default to reflect the C++ standard version being used; it stays at 199711L unless the /Zc:__cplusplus compiler option is used. Instead, _MSVC_LANG is defined to the correct version.

In C++20, the compiler generates rewritten candidates for operator== (e.g., reversing arguments). If the explicit operator==(std::vector, SmallVector) is present, it can lead to infinite recursion when the compiler attempts to use it to satisfy a comparison, effectively calling itself.

This change updates the preprocessor check to use _MSVC_LANG when defined, ensuring that the legacy operator== is properly disabled for C++20 and later on MSVC, preventing the recursion.

See: https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170

Fixes #6468
