### PR TITLE
spirv-opt: Correct DebugValue placement in ADCE

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -309,8 +309,8 @@ Pass::Status AggressiveDCEPass::ProcessDebugInformation(
         // DebugDeclare Variable is not live. Find the value that was being
         // stored to this variable. If it's live then create a new DebugValue
         // with this value. Otherwise let it die in peace.
-        get_def_use_mgr()->ForEachUser(var_id, [this, var_id,
-                                                inst](Instruction* user) {
+        get_def_use_mgr()->ForEachUser(var_id, [this,
+                                                var_id](Instruction* user) {
           if (user->opcode() == spv::Op::OpStore) {
             uint32_t stored_value_id = 0;
             const uint32_t kStoreValueInIdx = 1;
@@ -320,10 +320,10 @@ Pass::Status AggressiveDCEPass::ProcessDebugInformation(
             }
 
             // value being stored is still live
-            Instruction* next_inst = inst->NextNode();
+            Instruction* next_inst = user->NextNode();
             bool added =
                 context()->get_debug_info_mgr()->AddDebugValueForVariable(
-                    user, var_id, stored_value_id, inst);
+                    user, var_id, stored_value_id, user);
             if (added && next_inst) {
               auto new_debug_value = next_inst->PreviousNode();
               live_insts_.Set(new_debug_value->unique_id());


### PR DESCRIPTION
When a DebugDeclare's variable is eliminated, it can generate multiple DebugValue instructions, one for each OpStore to the eliminated variable.  The current logic is not placing the DebugValues in the correct place.  They are currently placed at the DebugDeclare location, and multiple DebugValues are not tested.  This PR fixes the location and extends the DebugValue test such that a DebugDeclare is broken into multiple DebugValues, and shows that the placement of both DebugValues is now correct.