### PR TITLE
Handle OpTypeVectorIdEXT in validate_interfaces.cpp

### DIFF
--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -155,11 +155,12 @@ spv_result_t NumConsumedLocations(ValidationState_t& _, const Instruction* type,
       *num_locations = 1;
       break;
     case spv::Op::OpTypeVector:
+    case spv::Op::OpTypeVectorIdEXT:
       // 3- and 4-component 64-bit vectors consume two locations.
       if ((_.ContainsSizedIntOrFloatType(type->id(), spv::Op::OpTypeInt, 64) ||
            _.ContainsSizedIntOrFloatType(type->id(), spv::Op::OpTypeFloat,
                                          64)) &&
-          (type->GetOperandAs<uint32_t>(2) > 2)) {
+          (_.GetDimension(type->id()) > 2)) {
         *num_locations = 2;
       } else {
         *num_locations = 1;
@@ -239,12 +240,13 @@ uint32_t NumConsumedComponents(ValidationState_t& _, const Instruction* type) {
       }
       break;
     case spv::Op::OpTypeVector:
+    case spv::Op::OpTypeVectorIdEXT:
       // Vectors consume components equal to the underlying type's consumption
       // times the number of elements in the vector. Note that 3- and 4-element
       // vectors cannot have a component decoration (i.e. assumed to be zero).
       num_components =
           NumConsumedComponents(_, _.FindDef(type->GetOperandAs<uint32_t>(1)));
-      num_components *= type->GetOperandAs<uint32_t>(2);
+      num_components *= _.GetDimension(type->id());
       break;
     case spv::Op::OpTypeArray:
       // Skip the array.

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -2039,6 +2039,65 @@ OpFunctionEnd
                 "with a Storage Class of Input or Output.\n"));
 }
 
+TEST_F(ValidateInterfacesTest, VectorIdFragmentInputOutputPass) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability LongVectorEXT
+OpExtension "SPV_EXT_long_vector"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main" %in %out
+OpExecutionMode %main OriginUpperLeft
+OpDecorate %in Location 0
+OpDecorate %out Location 0
+%void = OpTypeVoid
+%f32 = OpTypeFloat 32
+%u32 = OpTypeInt 32 0
+%u4 = OpConstant %u32 4
+%f32vec = OpTypeVectorIdEXT %f32 %u4
+%in_ptr = OpTypePointer Input %f32vec
+%out_ptr = OpTypePointer Output %f32vec
+%in = OpVariable %in_ptr Input
+%out = OpVariable %out_ptr Output
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+}
+
+TEST_F(ValidateInterfacesTest, VectorIdVertexInputOutputPass) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability LongVectorEXT
+OpExtension "SPV_EXT_long_vector"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main" %in %out
+OpDecorate %in Location 0
+OpDecorate %out Location 0
+%void = OpTypeVoid
+%f32 = OpTypeFloat 32
+%u32 = OpTypeInt 32 0
+%u4 = OpConstant %u32 4
+%f32vec = OpTypeVectorIdEXT %f32 %u4
+%in_ptr = OpTypePointer Input %f32vec
+%out_ptr = OpTypePointer Output %f32vec
+%in = OpVariable %in_ptr Input
+%out = OpVariable %out_ptr Output
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
VectorId can be used in input/output storage classes as long as it has a non-specconstant component count. Handle the type and add a couple tests.