### PR TITLE
spirv-val: Fix crash with bad OpUntypedArrayLengthKHR

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -2140,7 +2140,11 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
   auto pointer_ty_id = state.GetOperandTypeId(inst, (untyped ? 3 : 2));
   auto pointer_ty = state.FindDef(pointer_ty_id);
   if (untyped) {
-    if (pointer_ty->opcode() != spv::Op::OpTypeUntypedPointerKHR) {
+    if (!pointer_ty) {
+      return state.diag(SPV_ERROR_INVALID_ID, inst)
+             << "Pointer must be an 'untyped pointer' pointer type, an ID such "
+                "as OpTypeUntypedPointerKHR is invalid";
+    } else if (pointer_ty->opcode() != spv::Op::OpTypeUntypedPointerKHR) {
       return state.diag(SPV_ERROR_INVALID_ID, inst)
              << "Pointer must be an untyped pointer";
     }

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -2140,13 +2140,10 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
   auto pointer_ty_id = state.GetOperandTypeId(inst, (untyped ? 3 : 2));
   auto pointer_ty = state.FindDef(pointer_ty_id);
   if (untyped) {
-    if (!pointer_ty) {
+    if (!pointer_ty ||
+        pointer_ty->opcode() != spv::Op::OpTypeUntypedPointerKHR) {
       return state.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Pointer must be an 'untyped pointer' pointer type, an ID such "
-                "as OpTypeUntypedPointerKHR is invalid";
-    } else if (pointer_ty->opcode() != spv::Op::OpTypeUntypedPointerKHR) {
-      return state.diag(SPV_ERROR_INVALID_ID, inst)
-             << "Pointer must be an untyped pointer";
+             << "Pointer must be an untyped pointer object";
     }
   } else if (pointer_ty->opcode() != spv::Op::OpTypePointer) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -8010,7 +8010,7 @@ OpFunctionEnd
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer must be an untyped pointer"));
+              HasSubstr("Pointer must be an untyped pointer object"));
 }
 
 TEST_F(ValidateMemory, UntypedArrayLengthBadPointer2) {
@@ -8049,8 +8049,7 @@ TEST_F(ValidateMemory, UntypedArrayLengthBadPointer2) {
   CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_3));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Pointer must be an 'untyped pointer' pointer type, an "
-                        "ID such as OpTypeUntypedPointerKHR is invalid"));
+              HasSubstr("Pointer must be an untyped pointer object"));
 }
 
 TEST_F(ValidateMemory, UntypedArrayLengtBadStruct) {


### PR DESCRIPTION
working on the internal extension (and being new to Untyped Pointers still) I accidentally set the `OpUntypedArrayLengthKHR` Pointer ID to be `OpTypeUntypedPointerKHR` and it just crashed in `spirv-val`... so now it doesn't crash and provides hopefully a likely good answer for the next person like me

... the issue is `pointer` and `type` are really easy to mix up... `OpTypeUntyped` will always be my favorite thing to explain to those new to SPIR-V :smile: 