### PR TITLE
spirv-val: Fix OpImageQueryLod for Kernel

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -1055,8 +1055,7 @@ spv_result_t ValidateImageCoordinate(ValidationState_t& _,
       opcode == spv::Op::OpImageSampleProjDrefExplicitLod ||
       opcode == spv::Op::OpImageGather ||
       opcode == spv::Op::OpImageDrefGather ||
-      (opcode == spv::Op::OpImageQueryLod &&
-       !_.HasCapability(spv::Capability::Kernel)) ||
+      opcode == spv::Op::OpImageQueryLod ||
       opcode == spv::Op::OpImageSparseSampleImplicitLod ||
       opcode == spv::Op::OpImageSparseSampleDrefImplicitLod ||
       opcode == spv::Op::OpImageSparseSampleDrefExplicitLod ||
@@ -1072,8 +1071,6 @@ spv_result_t ValidateImageCoordinate(ValidationState_t& _,
                             opcode == spv::Op::OpImageSparseSampleExplicitLod ||
                             opcode == spv::Op::OpImageRead ||
                             opcode == spv::Op::OpImageWrite ||
-                            (opcode == spv::Op::OpImageQueryLod &&
-                             _.HasCapability(spv::Capability::Kernel)) ||
                             opcode == spv::Op::OpImageSparseRead;
 
   assert(float_only || int_only || int_or_float);

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -4806,11 +4806,25 @@ TEST_F(ValidateImage, QueryLodSuccessKernel) {
 %sampler = OpLoad %type_sampler %uniform_sampler
 %simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
 %res1 = OpImageQueryLod %f32vec2 %simg %f32vec2_hh
-%res2 = OpImageQueryLod %f32vec2 %simg %u32vec2_01
 )";
 
   CompileSuccessfully(GenerateKernelCode(body).c_str());
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateImage, QueryLodNonFloatKernel) {
+  const std::string body = R"(
+%img = OpLoad %type_image_f32_2d_0001 %uniform_image_f32_2d_0001
+%sampler = OpLoad %type_sampler %uniform_sampler
+%simg = OpSampledImage %type_sampled_image_f32_2d_0001 %img %sampler
+%res1 = OpImageQueryLod %f32vec2 %simg %u32vec2_01
+)";
+
+  CompileSuccessfully(GenerateKernelCode(body).c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Expected Coordinate to be a 32-bit float scalar or vector"));
 }
 
 TEST_F(ValidateImage, QueryLodSuccessShader) {


### PR DESCRIPTION
as discussed in https://gitlab.khronos.org/spirv/SPIR-V/-/issues/908#note_586477

this seems to have just been a mistake, confirmed that `OpImageQueryLod` has not special condition to allow int coordinates