### PR TITLE
Start v2026.2 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 Revision history for SPIRV-Tools
 
-v2026.1 2026-02-03
+v2026.2-dev 2026-01-23
+  - Start v2026.2-dev
+
+v2026.1 2026-01-22
   - General
     - spirv-tools: Fix infinite recursion in SmallVector::operator== on MSVC (#6470)
     - Add support for SPV_NV_push_constant_bank (#6507)


### PR DESCRIPTION
Update CHANGES to refelec the start of the next relese. Updated the date
for the previous release. It should reflect the date for the last commit
in where the tag was added. Not the release of the Vulan SDK in which
this release will be used.
