### PR TITLE
spirv-opt: Allow exe preserve_interface to be false

### DIFF
--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -748,7 +748,7 @@ OptStatus ParseFlags(int argc, const char** argv,
                      spvtools::ValidatorOptions* validator_options,
                      spvtools::OptimizerOptions* optimizer_options) {
   std::vector<std::string> pass_flags;
-  bool preserve_interface = true;
+  bool preserve_interface = false;
   for (int argi = 1; argi < argc; ++argi) {
     const char* cur_arg = argv[argi];
     if ('-' == cur_arg[0]) {


### PR DESCRIPTION
The spirv-opt.exe front-end initializes preserve_interface to true, and allows the user to reinitialize it to true by passing --preserve-interface.  It should be initialized to false, so the user has both options available from the command line.  

The PR includes a test, but the test framework doesn't seem to exercise the exe front-ends, so it passes without this commit.  We can either omit the test or extend the testing to allow exercising the exe's.