### PR TITLE
spirv-val: Add DotProduce Capability

### DIFF
--- a/source/val/validate_dot_product.cpp
+++ b/source/val/validate_dot_product.cpp
@@ -166,7 +166,7 @@ spv_result_t ValidateSameSignedDot(ValidationState_t& _,
                  << "DotProductInputAll capability is additionally required to "
                     "the DotProduct capability to use vectors. (It is possible "
                     "to set DotProductInput4x8BitPacked to only use 32-bit "
-                    "scalars)";
+                    "scalars packed as a 4-wide 8-byte vector)";
         }
       }
     }

--- a/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
+++ b/test/val/val_extension_spv_khr_integer_dot_product_test.cpp
@@ -1572,7 +1572,8 @@ TEST_F(ValidateIntegerDotProductSimple, CapabilityDotProductInputAll) {
       getDiagnosticString(),
       HasSubstr("DotProductInputAll capability is additionally required to the "
                 "DotProduct capability to use vectors. (It is possible to set "
-                "DotProductInput4x8BitPacked to only use 32-bit scalars)"));
+                "DotProductInput4x8BitPacked to only use 32-bit scalars packed "
+                "as a 4-wide 8-byte vector)"));
 }
 
 TEST_F(ValidateIntegerDotProductSimple, CapabilityDotProductInputAll2) {


### PR DESCRIPTION
I realized in https://github.com/KhronosGroup/SPIRV-Tools/pull/6524 I forgot the validation around `DotProductInputAll`,  ` DotProductInput4x8Bit` and `DotProductInput4x8BitPacked`