### PR TITLE
spirv-val: Add SPV_KHR_post_depth_coverage

### DIFF
--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -819,6 +819,7 @@ spv_result_t ValidateExecutionMode(ValidationState_t& _,
     case spv::ExecutionMode::SampleInterlockUnorderedEXT:
     case spv::ExecutionMode::ShadingRateInterlockOrderedEXT:
     case spv::ExecutionMode::ShadingRateInterlockUnorderedEXT:
+    case spv::ExecutionMode::PostDepthCoverage:
     case spv::ExecutionMode::EarlyAndLateFragmentTestsAMD:
     case spv::ExecutionMode::StencilRefUnchangedFrontAMD:
     case spv::ExecutionMode::StencilRefGreaterFrontAMD:

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -1831,6 +1831,24 @@ OpFunctionEnd
   EXPECT_THAT(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateMode, FragmentShaderPostDepthCoverageVertexBad) {
+  const std::string spirv = R"(
+OpCapability Shader
+OpCapability SampleMaskPostDepthCoverage
+OpExtension "SPV_KHR_post_depth_coverage"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Vertex %main "main"
+OpExecutionMode %main PostDepthCoverage
+)" + kVoidFunction;
+
+  CompileSuccessfully(spirv);
+  EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "Execution mode can only be used with the Fragment execution model"));
+}
+
 TEST_F(ValidateMode, FragmentShaderStencilRefFrontTooManyModesBad) {
   const std::string spirv = R"(
 OpCapability Shader


### PR DESCRIPTION
Adds the missing `PostDepthCoverage` check from `SPV_KHR_post_depth_coverage`