### PR TITLE
Allow SPV_NV_push_constant_bank to be optimized

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -1155,6 +1155,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
       "SPV_KHR_maximal_reconvergence",
+      "SPV_NV_push_constant_bank",
   });
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -469,6 +469,7 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
       "SPV_KHR_maximal_reconvergence",
+      "SPV_NV_push_constant_bank",
   });
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -306,6 +306,7 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
       "SPV_KHR_maximal_reconvergence",
+      "SPV_NV_push_constant_bank",
   });
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -158,6 +158,7 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
       "SPV_NV_cluster_acceleration_structure",
       "SPV_NV_linear_swept_spheres",
       "SPV_KHR_maximal_reconvergence",
+      "SPV_NV_push_constant_bank",
   });
 }
 bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {


### PR DESCRIPTION
This is needed to continue to allow certain optimizations on shaders that use SPV_NV_push_constant_bank.