### PR TITLE
cmake: Fix redundant dependency for build-version.inc

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -149,11 +149,6 @@ add_custom_command(OUTPUT ${SPIRV_TOOLS_BUILD_VERSION_INC}
    DEPENDS ${SPIRV_TOOLS_BUILD_VERSION_INC_GENERATOR}
            ${SPIRV_TOOLS_CHANGES_FILE}
    COMMENT "Update build-version.inc in the SPIRV-Tools build directory (if necessary).")
-# Convenience target for standalone generation of the build-version.inc file.
-# This is not required for any dependence chain.
-add_custom_target(spirv-tools-build-version
-   DEPENDS ${SPIRV_TOOLS_BUILD_VERSION_INC})
-set_property(TARGET spirv-tools-build-version PROPERTY FOLDER "SPIRV-Tools build")
 
 list(APPEND PCH_DEPENDS
 	${CORE_TABLES_HEADER_INC_FILE}
@@ -340,7 +335,7 @@ function(spirv_tools_default_target_options target)
   )
   set_property(TARGET ${target} PROPERTY FOLDER "SPIRV-Tools libraries")
   spvtools_check_symbol_exports(${target})
-  add_dependencies(${target} spirv-tools-build-version core_tables extinst_tables)
+  add_dependencies(${target} core_tables extinst_tables)
 endfunction()
 
 # Always build ${SPIRV_TOOLS}-shared. This is expected distro packages, and


### PR DESCRIPTION
The custom command to generate build-version.inc was being depended on
in two ways by the SPIRV-Tools-static target.

This caused issues with the Xcode "new build system" which does not allow
this.

This change removes the redundant dependency through the
spirv-tools-build-version target. The dependency through the source file
properties on software_version.cpp is sufficient.

The spirv-tools-build-version target has also been removed since it is
no longer used and was only a convenience target.

Fixes #6548
