### PR TITLE
Fix C++20 compilation: add 'u' suffix to 4294967295 integer literal

### DIFF
--- a/test/opt/convert_to_sampled_image_test.cpp
+++ b/test/opt/convert_to_sampled_image_test.cpp
@@ -83,7 +83,7 @@ INSTANTIATE_TEST_SUITE_P(
         // 6. maximum spec id
         {"4294967295:0", true,
          VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{
-             4294967295, 0}})},
+             4294967295u, 0}})},
         // 7. minimum spec id
         {"0:100", true,
          VectorOfDescriptorSetAndBindingPairs({DescriptorSetAndBinding{0,

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -70,7 +70,7 @@ INSTANTIATE_TEST_SUITE_P(
         {"100:1024   \n \r\t \t \v \f ", true,
          SpecIdToValueStrMap{{100, "1024"}}},
         // 6. maximum spec id
-        {"4294967295:0", true, SpecIdToValueStrMap{{4294967295, "0"}}},
+        {"4294967295:0", true, SpecIdToValueStrMap{{4294967295u, "0"}}},
         // 7. minimum spec id
         {"0:100", true, SpecIdToValueStrMap{{0, "100"}}},
         // 8. random content without spaces are allowed


### PR DESCRIPTION
The literal 4294967295 (UINT32_MAX / 0xFFFFFFFF) exceeds INT_MAX (2,147,483,647) on 32-bit systems. In C++20, integer literal rules are stricter, and the compiler may treat it as int, causing overflow and compilation failure.

Fix by adding the 'u' suffix to make the literal explicitly unsigned (4294967295u), which:
- Correctly represents the value as unsigned int
- Matches the expected uint32_t key type in SpecIdToValueStrMap
- Matches the uint32_t field type in DescriptorSetAndBinding