### PR TITLE
spirv-as: Validate bit width of float types with explicit encodings

### DIFF
--- a/test/text_to_binary.type_declaration_test.cpp
+++ b/test/text_to_binary.type_declaration_test.cpp
@@ -278,6 +278,63 @@ TEST_F(OpSizeOfTest, ArgumentTypes) {
               Eq("Expected id to start with %."));
 }
 
+struct FloatEncodingWidthCase {
+  std::string input;
+  bool expect_pass;
+};
+
+using FloatEncodingWidthTest = spvtest::TextToBinaryTestBase<
+    ::testing::TestWithParam<FloatEncodingWidthCase>>;
+
+TEST_P(FloatEncodingWidthTest, Samples) {
+  const auto& param = GetParam();
+  if (param.expect_pass) {
+    CompileSuccessfully(param.input);
+  } else {
+    auto err = CompileFailure(param.input);
+    EXPECT_THAT(err, testing::HasSubstr("Invalid bit width"));
+    EXPECT_THAT(err, testing::HasSubstr("for floating point encoding"));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    TextToBinaryFloatWidth, FloatEncodingWidthTest,
+    ::testing::ValuesIn(std::vector<FloatEncodingWidthCase>{
+        {"%1 = OpTypeFloat 32", true},
+        {"%1 = OpTypeFloat 64", true},
+        {"%1 = OpTypeFloat 16", true},
+        {"%1 = OpTypeFloat 8", true},
+        // bfloat16
+        {"%1 = OpTypeFloat 0 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 1 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 15 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 16 BFloat16KHR", true},
+        {"%1 = OpTypeFloat 17 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 32 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 64 BFloat16KHR", false},
+        {"%1 = OpTypeFloat 100 BFloat16KHR", false},
+        // fp8 E5M2
+        {"%1 = OpTypeFloat 0 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 1 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 7 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 8 Float8E5M2EXT", true},
+        {"%1 = OpTypeFloat 9 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 16 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 32 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 64 Float8E5M2EXT", false},
+        {"%1 = OpTypeFloat 100 Float8E4M3EXT", false},
+        // fp8 E4M3
+        {"%1 = OpTypeFloat 0 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 1 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 7 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 8 Float8E4M3EXT", true},
+        {"%1 = OpTypeFloat 9 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 16 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 32 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 64 Float8E4M3EXT", false},
+        {"%1 = OpTypeFloat 100 Float8E4M3EXT", false},
+    }));
+
 // TODO(dneto): OpTypeVoid
 // TODO(dneto): OpTypeBool
 // TODO(dneto): OpTypeInt

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -475,10 +475,9 @@ TEST_F(ValidateData, float8_no_encoding_bad) {
 TEST_F(ValidateData, float8_bad_encoding) {
   std::string str =
       header_with_float8_and_bfloat16 + "%2 = OpTypeFloat 8 BFloat16KHR";
-  CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Unsupported 8-bit floating point encoding"));
+  const auto& err = CompileFailure(str.c_str());
+  EXPECT_THAT(err, HasSubstr("Invalid bit width 8 for floating point encoding "
+                             "BFloat16KHR; expected 16"));
 }
 
 TEST_F(ValidateData, dot_bfloat16_bad) {


### PR DESCRIPTION
Do this in the assembler because it's silly to let it get any farther.

Bug: crbug.com/465892071