### PR TITLE
assembler: Handle leading + in hex float literals

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -101,7 +101,7 @@ decimal and hexadecimal form.
 
 The syntax for a floating point literal is the same as floating point
 constants in the C programming language, except:
-* An optional leading minus (`-`) is part of the literal.
+* An optional leading minus (`-`) or leading plus (`+`) is part of the literal.
 * An optional type specifier suffix is not allowed.
 Infinity and NaN values are expressed in hexadecimal float literals
 by using the maximum representable exponent for the bit width.
@@ -124,6 +124,9 @@ of `%aNaN` in the previous example is the same as the word with bits
 The disassembler prints infinite, NaN, and subnormal values in hexadecimal form.
 Zero and normal values are printed in decimal form with enough digits
 to preserve all significand bits.
+
+Hex float values that underflow are rounded to zero.  If there is a leading
+minus sign, underflow goes to negative zero.
 
 ## Arbitrary Integers
 <a name="immediate"></a>

--- a/source/util/hex_float.h
+++ b/source/util/hex_float.h
@@ -1011,13 +1011,17 @@ std::ostream& operator<<(std::ostream& os, const HexFloat<T, Traits>& value) {
   return os;
 }
 
-// Returns true if negate_value is true and the next character on the
-// input stream is a plus or minus sign.  In that case we also set the fail bit
-// on the stream and set the value to the zero value for its type.
+// Encodes whether a leading sign has been seen, and if so which one.
+enum class LeadingSign { None, Plus, Minus };
+
+// Returns true if leading_sign is either Plus or Minus, and the next character
+// on the input stream is a plus or minus sign.  In that case we also set the
+// fail bit on the stream and set the value to the zero value for its type.
 template <typename T, typename Traits>
-inline bool RejectParseDueToLeadingSign(std::istream& is, bool negate_value,
+inline bool RejectParseDueToLeadingSign(std::istream& is,
+                                        LeadingSign leading_sign,
                                         HexFloat<T, Traits>& value) {
-  if (negate_value) {
+  if (leading_sign != LeadingSign::None) {
     auto next_char = is.peek();
     if (next_char == '-' || next_char == '+') {
       // Fail the parse.  Emulate standard behaviour by setting the value to
@@ -1032,22 +1036,24 @@ inline bool RejectParseDueToLeadingSign(std::istream& is, bool negate_value,
 
 // Parses a floating point number from the given stream and stores it into the
 // value parameter.
-// If negate_value is true then the number may not have a leading minus or
-// plus, and if it successfully parses, then the number is negated before
-// being stored into the value parameter.
+// If leading_sign is Plus or Minus, then the number may not have a leading
+// minus or plus. If it successfully parses, and the leading sign was Minus,
+// then the number is negated before being stored into the value parameter.
 // If the value cannot be correctly parsed or overflows the target floating
 // point type, then set the fail bit on the stream.
 // TODO(dneto): Promise C++11 standard behavior in how the value is set in
 // the error case, but only after all target platforms implement it correctly.
 // In particular, the Microsoft C++ runtime appears to be out of spec.
 template <typename T, typename Traits>
-inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
+inline std::istream& ParseNormalFloat(std::istream& is,
+                                      LeadingSign leading_sign,
                                       HexFloat<T, Traits>& value) {
-  if (RejectParseDueToLeadingSign(is, negate_value, value)) {
+  if (RejectParseDueToLeadingSign(is, leading_sign, value)) {
     return is;
   }
   T val;
   is >> val;
+  const bool negate_value = leading_sign == LeadingSign::Minus;
   if (negate_value) {
     val = -val;
   }
@@ -1070,8 +1076,9 @@ inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
 // This will parse the float as it were a 32-bit floating point number,
 // and then round it down to fit into a Float16 value.
 // The number is rounded towards zero.
-// If negate_value is true then the number may not have a leading minus or
-// plus, and if it successfully parses, then the number is negated before
+// If leading_sign is Plus or Minus, then the number may not have a leading
+// minus or plus. If it successfully parses, and the leading sign was Minus,
+// then the number is negated before being stored into the value parameter.
 // being stored into the value parameter.
 // If the value cannot be correctly parsed or overflows the target floating
 // point type, then set the fail bit on the stream.
@@ -1081,11 +1088,11 @@ inline std::istream& ParseNormalFloat(std::istream& is, bool negate_value,
 template <>
 inline std::istream&
 ParseNormalFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>(
-    std::istream& is, bool negate_value,
+    std::istream& is, LeadingSign leading_sign,
     HexFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>& value) {
   // First parse as a 32-bit float.
   HexFloat<FloatProxy<float>> float_val(0.0f);
-  ParseNormalFloat(is, negate_value, float_val);
+  ParseNormalFloat(is, leading_sign, float_val);
 
   // Then convert to 16-bit float, saturating at infinities, and
   // rounding toward zero.
@@ -1106,11 +1113,11 @@ ParseNormalFloat<FloatProxy<Float16>, HexFloatTraits<FloatProxy<Float16>>>(
 template <>
 inline std::istream&
 ParseNormalFloat<FloatProxy<BFloat16>, HexFloatTraits<FloatProxy<BFloat16>>>(
-    std::istream& is, bool negate_value,
+    std::istream& is, LeadingSign leading_sign,
     HexFloat<FloatProxy<BFloat16>, HexFloatTraits<FloatProxy<BFloat16>>>&
         value) {
   HexFloat<FloatProxy<float>> float_val(0.0f);
-  ParseNormalFloat(is, negate_value, float_val);
+  ParseNormalFloat(is, leading_sign, float_val);
 
   float_val.castTo(value, round_direction::kToZero);
 
@@ -1125,8 +1132,8 @@ ParseNormalFloat<FloatProxy<BFloat16>, HexFloatTraits<FloatProxy<BFloat16>>>(
 // This will parse the float as it were a 32-bit floating point number,
 // and then round it down to fit into a Float8_E4M3 value.
 // The number is rounded towards zero.
-// If negate_value is true then the number may not have a leading minus or
-// plus, and if it successfully parses, then the number is negated before
+// If leading_sign is Plus or Minus, then the number may not have a leading
+// minus or plus. If it successfully parses, and the leading sign was Minus,
 // being stored into the value parameter.
 // If the value cannot be correctly parsed or overflows the target floating
 // point type, then set the fail bit on the stream.
@@ -1136,12 +1143,12 @@ ParseNormalFloat<FloatProxy<BFloat16>, HexFloatTraits<FloatProxy<BFloat16>>>(
 template <>
 inline std::istream& ParseNormalFloat<FloatProxy<Float8_E4M3>,
                                       HexFloatTraits<FloatProxy<Float8_E4M3>>>(
-    std::istream& is, bool negate_value,
+    std::istream& is, LeadingSign leading_sign,
     HexFloat<FloatProxy<Float8_E4M3>, HexFloatTraits<FloatProxy<Float8_E4M3>>>&
         value) {
   // First parse as a 32-bit float.
   HexFloat<FloatProxy<float>> float_val(0.0f);
-  ParseNormalFloat(is, negate_value, float_val);
+  ParseNormalFloat(is, leading_sign, float_val);
 
   if (float_val.value().getAsFloat() > 448.0f) {
     is.setstate(std::ios_base::failbit);
@@ -1162,8 +1169,8 @@ inline std::istream& ParseNormalFloat<FloatProxy<Float8_E4M3>,
 // This will parse the float as it were a Float8_E5M2 floating point number,
 // and then round it down to fit into a Float16 value.
 // The number is rounded towards zero.
-// If negate_value is true then the number may not have a leading minus or
-// plus, and if it successfully parses, then the number is negated before
+// If leading_sign is Plus or Minus, then the number may not have a leading
+// minus or plus. If it successfully parses, and the leading sign was Minus,
 // being stored into the value parameter.
 // If the value cannot be correctly parsed or overflows the target floating
 // point type, then set the fail bit on the stream.
@@ -1173,12 +1180,12 @@ inline std::istream& ParseNormalFloat<FloatProxy<Float8_E4M3>,
 template <>
 inline std::istream& ParseNormalFloat<FloatProxy<Float8_E5M2>,
                                       HexFloatTraits<FloatProxy<Float8_E5M2>>>(
-    std::istream& is, bool negate_value,
+    std::istream& is, LeadingSign leading_sign,
     HexFloat<FloatProxy<Float8_E5M2>, HexFloatTraits<FloatProxy<Float8_E5M2>>>&
         value) {
   // First parse as a 32-bit float.
   HexFloat<FloatProxy<float>> float_val(0.0f);
-  ParseNormalFloat(is, negate_value, float_val);
+  ParseNormalFloat(is, leading_sign, float_val);
 
   // Then convert to Float8_E5M2 float, saturating at infinities, and
   // rounding toward zero.
@@ -1270,14 +1277,19 @@ std::istream& operator>>(std::istream& is, HexFloat<T, Traits>& value) {
   }
 
   auto next_char = is.peek();
-  bool negate_value = false;
 
-  if (next_char != '-' && next_char != '0') {
-    return ParseNormalFloat(is, negate_value, value);
+  auto leading_sign = LeadingSign::None;
+
+  if (next_char != '-' && next_char != '0' && next_char != '+') {
+    return ParseNormalFloat(is, LeadingSign::None, value);
   }
 
   if (next_char == '-') {
-    negate_value = true;
+    leading_sign = LeadingSign::Minus;
+    is.get();
+    next_char = is.peek();
+  } else if (next_char == '+') {
+    leading_sign = LeadingSign::Plus;
     is.get();
     next_char = is.peek();
   }
@@ -1287,12 +1299,12 @@ std::istream& operator>>(std::istream& is, HexFloat<T, Traits>& value) {
     auto maybe_hex_start = is.peek();
     if (maybe_hex_start != 'x' && maybe_hex_start != 'X') {
       is.unget();
-      return ParseNormalFloat(is, negate_value, value);
+      return ParseNormalFloat(is, leading_sign, value);
     } else {
       is.get();  // Throw away the 'x';
     }
   } else {
-    return ParseNormalFloat(is, negate_value, value);
+    return ParseNormalFloat(is, leading_sign, value);
   }
 
   // This "looks" like a hex-float so treat it as one.
@@ -1508,7 +1520,8 @@ std::istream& operator>>(std::istream& is, HexFloat<T, Traits>& value) {
   }
 
   uint_type output_bits = static_cast<uint_type>(
-      static_cast<uint_type>(negate_value ? 1 : 0) << HF::top_bit_left_shift);
+      static_cast<uint_type>(leading_sign == LeadingSign::Minus ? 1 : 0)
+      << HF::top_bit_left_shift);
   output_bits |= fraction;
 
   uint_type shifted_exponent = static_cast<uint_type>(

--- a/test/hex_float_test.cpp
+++ b/test/hex_float_test.cpp
@@ -30,6 +30,7 @@ namespace spvtools {
 namespace utils {
 namespace {
 
+using spvtools::utils::LeadingSign;
 using ::testing::Eq;
 
 // In this file "encode" means converting a number into a string,
@@ -1569,73 +1570,96 @@ TEST(HexFloatOperationTests, NanTests) {
 template <typename T>
 struct FloatParseCase {
   std::string literal;
-  bool negate_value;
+  LeadingSign leading_sign;
   bool expect_success;
   HexFloat<FloatProxy<T>> expected_value;
 };
+
+const char* str(const LeadingSign& ls) {
+  switch (ls) {
+    case LeadingSign::None:
+      return "(none)";
+    case LeadingSign::Minus:
+      return "-";
+    case LeadingSign::Plus:
+      return "+";
+  }
+  return "";  // should not happen
+}
 
 using ParseNormalFloatTest = ::testing::TestWithParam<FloatParseCase<float>>;
 
 TEST_P(ParseNormalFloatTest, Samples) {
   std::stringstream input(GetParam().literal);
   HexFloat<FloatProxy<float>> parsed_value(0.0f);
-  ParseNormalFloat(input, GetParam().negate_value, parsed_value);
+  ParseNormalFloat(input, GetParam().leading_sign, parsed_value);
   EXPECT_NE(GetParam().expect_success, input.fail())
       << " literal: " << GetParam().literal
-      << " negate: " << GetParam().negate_value;
+      << " leading_sign: " << str(GetParam().leading_sign);
   if (GetParam().expect_success) {
     EXPECT_THAT(parsed_value.value(), Eq(GetParam().expected_value.value()))
         << " literal: " << GetParam().literal
-        << " negate: " << GetParam().negate_value;
+        << " leading_sign: " << str(GetParam().leading_sign);
   }
 }
 
 // Returns a FloatParseCase with expected failure.
 template <typename T>
-FloatParseCase<T> BadFloatParseCase(std::string literal, bool negate_value,
+FloatParseCase<T> BadFloatParseCase(std::string literal,
+                                    LeadingSign leading_sign,
                                     T expected_value) {
   HexFloat<FloatProxy<T>> proxy_expected_value(expected_value);
-  return FloatParseCase<T>{literal, negate_value, false, proxy_expected_value};
+  return FloatParseCase<T>{literal, leading_sign, false, proxy_expected_value};
 }
 
 // Returns a FloatParseCase that should successfully parse to a given value.
 template <typename T>
-FloatParseCase<T> GoodFloatParseCase(std::string literal, bool negate_value,
+FloatParseCase<T> GoodFloatParseCase(std::string literal,
+                                     LeadingSign leading_sign,
                                      T expected_value) {
   HexFloat<FloatProxy<T>> proxy_expected_value(expected_value);
-  return FloatParseCase<T>{literal, negate_value, true, proxy_expected_value};
+  return FloatParseCase<T>{literal, leading_sign, true, proxy_expected_value};
 }
 
 INSTANTIATE_TEST_SUITE_P(
     FloatParse, ParseNormalFloatTest,
     ::testing::ValuesIn(std::vector<FloatParseCase<float>>{
         // Failing cases due to trivially incorrect syntax.
-        BadFloatParseCase("abc", false, 0.0f),
-        BadFloatParseCase("abc", true, 0.0f),
+        BadFloatParseCase("abc", LeadingSign::None, 0.0f),
+        BadFloatParseCase("abc", LeadingSign::Minus, 0.0f),
+        BadFloatParseCase("abc", LeadingSign::Plus, 0.0f),
 
         // Valid cases.
-        GoodFloatParseCase("0", false, 0.0f),
-        GoodFloatParseCase("0.0", false, 0.0f),
-        GoodFloatParseCase("-0.0", false, -0.0f),
-        GoodFloatParseCase("2.0", false, 2.0f),
-        GoodFloatParseCase("-2.0", false, -2.0f),
-        GoodFloatParseCase("+2.0", false, 2.0f),
-        // Cases with negate_value being true.
-        GoodFloatParseCase("0.0", true, -0.0f),
-        GoodFloatParseCase("2.0", true, -2.0f),
+        GoodFloatParseCase("0", LeadingSign::None, 0.0f),
+        GoodFloatParseCase("0.0", LeadingSign::None, 0.0f),
+        GoodFloatParseCase("-0.0", LeadingSign::None, -0.0f),
+        GoodFloatParseCase("2.0", LeadingSign::None, 2.0f),
+        GoodFloatParseCase("-2.0", LeadingSign::None, -2.0f),
+        GoodFloatParseCase("+2.0", LeadingSign::None, 2.0f),
+        // Cases with leading sign
+        GoodFloatParseCase("0.0", LeadingSign::Minus, -0.0f),
+        GoodFloatParseCase("2.0", LeadingSign::Minus, -2.0f),
+        GoodFloatParseCase("0", LeadingSign::Plus, 0.0f),
+        GoodFloatParseCase("0.0", LeadingSign::Plus, 0.0f),
+        GoodFloatParseCase("2.0", LeadingSign::Plus, 2.0f),
 
-        // When negate_value is true, we should not accept a
+        // When a leading sign is present, we should not accept a
         // leading minus or plus.
-        BadFloatParseCase("-0.0", true, 0.0f),
-        BadFloatParseCase("-2.0", true, 0.0f),
-        BadFloatParseCase("+0.0", true, 0.0f),
-        BadFloatParseCase("+2.0", true, 0.0f),
+        BadFloatParseCase("-0.0", LeadingSign::Minus, 0.0f),
+        BadFloatParseCase("-2.0", LeadingSign::Minus, 0.0f),
+        BadFloatParseCase("+0.0", LeadingSign::Minus, 0.0f),
+        BadFloatParseCase("+2.0", LeadingSign::Minus, 0.0f),
+        BadFloatParseCase("-0.0", LeadingSign::Plus, 0.0f),
+        BadFloatParseCase("-2.0", LeadingSign::Plus, 0.0f),
+        BadFloatParseCase("+0.0", LeadingSign::Plus, 0.0f),
+        BadFloatParseCase("+2.0", LeadingSign::Plus, 0.0f),
 
         // Overflow is an error for 32-bit float parsing.
-        BadFloatParseCase("1e40", false, FLT_MAX),
-        BadFloatParseCase("1e40", true, -FLT_MAX),
-        BadFloatParseCase("-1e40", false, -FLT_MAX),
-        // We can't have -1e40 and negate_value == true since
+        BadFloatParseCase("1e40", LeadingSign::None, FLT_MAX),
+        BadFloatParseCase("1e40", LeadingSign::Plus, FLT_MAX),
+        BadFloatParseCase("1e40", LeadingSign::Minus, -FLT_MAX),
+        BadFloatParseCase("-1e40", LeadingSign::None, -FLT_MAX),
+        // We can't have -1e40 and leading sign == Minus since
         // that represents an original case of "--1e40" which
         // is invalid.
     }));
@@ -1646,14 +1670,14 @@ using ParseNormalFloat16Test =
 TEST_P(ParseNormalFloat16Test, Samples) {
   std::stringstream input(GetParam().literal);
   HexFloat<FloatProxy<Float16>> parsed_value(0);
-  ParseNormalFloat(input, GetParam().negate_value, parsed_value);
+  ParseNormalFloat(input, GetParam().leading_sign, parsed_value);
   EXPECT_NE(GetParam().expect_success, input.fail())
       << " literal: " << GetParam().literal
-      << " negate: " << GetParam().negate_value;
+      << " leading_sign: " << str(GetParam().leading_sign);
   if (GetParam().expect_success) {
     EXPECT_THAT(parsed_value.value(), Eq(GetParam().expected_value.value()))
         << " literal: " << GetParam().literal
-        << " negate: " << GetParam().negate_value;
+        << " leading_sign: " << str(GetParam().leading_sign);
   }
 }
 
@@ -1661,26 +1685,40 @@ INSTANTIATE_TEST_SUITE_P(
     Float16Parse, ParseNormalFloat16Test,
     ::testing::ValuesIn(std::vector<FloatParseCase<Float16>>{
         // Failing cases due to trivially incorrect syntax.
-        BadFloatParseCase<Float16>("abc", false, uint16_t{0}),
-        BadFloatParseCase<Float16>("abc", true, uint16_t{0}),
+        BadFloatParseCase<Float16>("abc", LeadingSign::None, uint16_t{0}),
+        BadFloatParseCase<Float16>("abc", LeadingSign::Minus, uint16_t{0}),
+        BadFloatParseCase<Float16>("abc", LeadingSign::Plus, uint16_t{0}),
 
         // Valid cases.
-        GoodFloatParseCase<Float16>("0", false, uint16_t{0}),
-        GoodFloatParseCase<Float16>("0.0", false, uint16_t{0}),
-        GoodFloatParseCase<Float16>("-0.0", false, uint16_t{0x8000}),
-        GoodFloatParseCase<Float16>("2.0", false, uint16_t{0x4000}),
-        GoodFloatParseCase<Float16>("-2.0", false, uint16_t{0xc000}),
-        GoodFloatParseCase<Float16>("+2.0", false, uint16_t{0x4000}),
-        // Cases with negate_value being true.
-        GoodFloatParseCase<Float16>("0.0", true, uint16_t{0x8000}),
-        GoodFloatParseCase<Float16>("2.0", true, uint16_t{0xc000}),
+        GoodFloatParseCase<Float16>("0", LeadingSign::None, uint16_t{0}),
+        GoodFloatParseCase<Float16>("0.0", LeadingSign::None, uint16_t{0}),
+        GoodFloatParseCase<Float16>("-0.0", LeadingSign::None,
+                                    uint16_t{0x8000}),
+        GoodFloatParseCase<Float16>("2.0", LeadingSign::None, uint16_t{0x4000}),
+        GoodFloatParseCase<Float16>("-2.0", LeadingSign::None,
+                                    uint16_t{0xc000}),
+        GoodFloatParseCase<Float16>("+2.0", LeadingSign::None,
+                                    uint16_t{0x4000}),
+        // Cases with leading sign
+        GoodFloatParseCase<Float16>("0", LeadingSign::Plus, uint16_t{0}),
+        GoodFloatParseCase<Float16>("0.0", LeadingSign::Plus, uint16_t{0}),
+        GoodFloatParseCase<Float16>("2.0", LeadingSign::Plus, uint16_t{0x4000}),
+        GoodFloatParseCase<Float16>("0.0", LeadingSign::Minus,
+                                    uint16_t{0x8000}),
+        GoodFloatParseCase<Float16>("2.0", LeadingSign::Minus,
+                                    uint16_t{0xc000}),
 
-        // When negate_value is true, we should not accept a leading minus or
+        // When a leading sign is present, we should not accept a leading minus
+        // or
         // plus.
-        BadFloatParseCase<Float16>("-0.0", true, uint16_t{0}),
-        BadFloatParseCase<Float16>("-2.0", true, uint16_t{0}),
-        BadFloatParseCase<Float16>("+0.0", true, uint16_t{0}),
-        BadFloatParseCase<Float16>("+2.0", true, uint16_t{0}),
+        BadFloatParseCase<Float16>("-0.0", LeadingSign::Minus, uint16_t{0}),
+        BadFloatParseCase<Float16>("-2.0", LeadingSign::Minus, uint16_t{0}),
+        BadFloatParseCase<Float16>("+0.0", LeadingSign::Minus, uint16_t{0}),
+        BadFloatParseCase<Float16>("+2.0", LeadingSign::Minus, uint16_t{0}),
+        BadFloatParseCase<Float16>("-0.0", LeadingSign::Plus, uint16_t{0}),
+        BadFloatParseCase<Float16>("-2.0", LeadingSign::Plus, uint16_t{0}),
+        BadFloatParseCase<Float16>("+0.0", LeadingSign::Plus, uint16_t{0}),
+        BadFloatParseCase<Float16>("+2.0", LeadingSign::Plus, uint16_t{0}),
     }));
 
 using ParseNormalFloatE4M3Test =
@@ -1689,14 +1727,14 @@ using ParseNormalFloatE4M3Test =
 TEST_P(ParseNormalFloatE4M3Test, Samples) {
   std::stringstream input(GetParam().literal);
   HexFloat<FloatProxy<Float8_E4M3>> parsed_value(0);
-  ParseNormalFloat(input, GetParam().negate_value, parsed_value);
+  ParseNormalFloat(input, GetParam().leading_sign, parsed_value);
   EXPECT_NE(GetParam().expect_success, input.fail())
       << " literal: " << GetParam().literal
-      << " negate: " << GetParam().negate_value;
+      << " leading_sign: " << str(GetParam().leading_sign);
   if (GetParam().expect_success) {
     EXPECT_THAT(parsed_value.value(), Eq(GetParam().expected_value.value()))
         << " literal: " << GetParam().literal
-        << " negate: " << GetParam().negate_value;
+        << " leading_sign: " << str(GetParam().leading_sign);
   }
 }
 
@@ -1704,26 +1742,42 @@ INSTANTIATE_TEST_SUITE_P(
     FloatE4M3Parse, ParseNormalFloatE4M3Test,
     ::testing::ValuesIn(std::vector<FloatParseCase<Float8_E4M3>>{
         // Failing cases due to trivially incorrect syntax.
-        BadFloatParseCase<Float8_E4M3>("abc", false, uint8_t{0}),
-        BadFloatParseCase<Float8_E4M3>("abc", true, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("abc", LeadingSign::None, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("abc", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("abc", LeadingSign::Plus, uint8_t{0}),
 
         // Valid cases.
-        GoodFloatParseCase<Float8_E4M3>("0", false, uint8_t{0}),
-        GoodFloatParseCase<Float8_E4M3>("0.0", false, uint8_t{0}),
-        GoodFloatParseCase<Float8_E4M3>("-0.0", false, uint8_t{0x80}),
-        GoodFloatParseCase<Float8_E4M3>("2.0", false, uint8_t{0x40}),
-        GoodFloatParseCase<Float8_E4M3>("-2.0", false, uint8_t{0xc0}),
-        GoodFloatParseCase<Float8_E4M3>("+2.0", false, uint8_t{0x40}),
-        // Cases with negate_value being true.
-        GoodFloatParseCase<Float8_E4M3>("0.0", true, uint8_t{0x80}),
-        GoodFloatParseCase<Float8_E4M3>("2.0", true, uint8_t{0xc0}),
+        GoodFloatParseCase<Float8_E4M3>("0", LeadingSign::None, uint8_t{0}),
+        GoodFloatParseCase<Float8_E4M3>("0.0", LeadingSign::None, uint8_t{0}),
+        GoodFloatParseCase<Float8_E4M3>("-0.0", LeadingSign::None,
+                                        uint8_t{0x80}),
+        GoodFloatParseCase<Float8_E4M3>("2.0", LeadingSign::None,
+                                        uint8_t{0x40}),
+        GoodFloatParseCase<Float8_E4M3>("-2.0", LeadingSign::None,
+                                        uint8_t{0xc0}),
+        GoodFloatParseCase<Float8_E4M3>("+2.0", LeadingSign::None,
+                                        uint8_t{0x40}),
+        // Cases with leading sign.
+        GoodFloatParseCase<Float8_E4M3>("0", LeadingSign::Plus, uint8_t{0}),
+        GoodFloatParseCase<Float8_E4M3>("0.0", LeadingSign::Plus, uint8_t{0}),
+        GoodFloatParseCase<Float8_E4M3>("2.0", LeadingSign::Plus,
+                                        uint8_t{0x40}),
+        GoodFloatParseCase<Float8_E4M3>("0.0", LeadingSign::Minus,
+                                        uint8_t{0x80}),
+        GoodFloatParseCase<Float8_E4M3>("2.0", LeadingSign::Minus,
+                                        uint8_t{0xc0}),
 
-        // When negate_value is true, we should not accept a leading minus or
+        // When a leading sign is present, we should not accept a leading minus
+        // or
         // plus.
-        BadFloatParseCase<Float8_E4M3>("-0.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E4M3>("-2.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E4M3>("+0.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E4M3>("+2.0", true, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("-0.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("-2.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("+0.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("+2.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("-0.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("-2.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("+0.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E4M3>("+2.0", LeadingSign::Plus, uint8_t{0}),
     }));
 
 using ParseNormalFloatE5M2Test =
@@ -1732,14 +1786,14 @@ using ParseNormalFloatE5M2Test =
 TEST_P(ParseNormalFloatE5M2Test, Samples) {
   std::stringstream input(GetParam().literal);
   HexFloat<FloatProxy<Float8_E5M2>> parsed_value(0);
-  ParseNormalFloat(input, GetParam().negate_value, parsed_value);
+  ParseNormalFloat(input, GetParam().leading_sign, parsed_value);
   EXPECT_NE(GetParam().expect_success, input.fail())
       << " literal: " << GetParam().literal
-      << " negate: " << GetParam().negate_value;
+      << " leading_sign: " << str(GetParam().leading_sign);
   if (GetParam().expect_success) {
     EXPECT_THAT(parsed_value.value(), Eq(GetParam().expected_value.value()))
         << " literal: " << GetParam().literal
-        << " negate: " << GetParam().negate_value;
+        << " leading_sign: " << str(GetParam().leading_sign);
   }
 }
 
@@ -1747,26 +1801,42 @@ INSTANTIATE_TEST_SUITE_P(
     FloatE5M2Parse, ParseNormalFloatE5M2Test,
     ::testing::ValuesIn(std::vector<FloatParseCase<Float8_E5M2>>{
         // Failing cases due to trivially incorrect syntax.
-        BadFloatParseCase<Float8_E5M2>("abc", false, uint8_t{0}),
-        BadFloatParseCase<Float8_E5M2>("abc", true, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("abc", LeadingSign::None, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("abc", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("abc", LeadingSign::Plus, uint8_t{0}),
 
         // Valid cases.
-        GoodFloatParseCase<Float8_E5M2>("0", false, uint8_t{0}),
-        GoodFloatParseCase<Float8_E5M2>("0.0", false, uint8_t{0}),
-        GoodFloatParseCase<Float8_E5M2>("-0.0", false, uint8_t{0x80}),
-        GoodFloatParseCase<Float8_E5M2>("2.0", false, uint8_t{0x40}),
-        GoodFloatParseCase<Float8_E5M2>("-2.0", false, uint8_t{0xc0}),
-        GoodFloatParseCase<Float8_E5M2>("+2.0", false, uint8_t{0x40}),
-        // Cases with negate_value being true.
-        GoodFloatParseCase<Float8_E5M2>("0.0", true, uint8_t{0x80}),
-        GoodFloatParseCase<Float8_E5M2>("2.0", true, uint8_t{0xc0}),
+        GoodFloatParseCase<Float8_E5M2>("0", LeadingSign::None, uint8_t{0}),
+        GoodFloatParseCase<Float8_E5M2>("0.0", LeadingSign::None, uint8_t{0}),
+        GoodFloatParseCase<Float8_E5M2>("-0.0", LeadingSign::None,
+                                        uint8_t{0x80}),
+        GoodFloatParseCase<Float8_E5M2>("2.0", LeadingSign::None,
+                                        uint8_t{0x40}),
+        GoodFloatParseCase<Float8_E5M2>("-2.0", LeadingSign::None,
+                                        uint8_t{0xc0}),
+        GoodFloatParseCase<Float8_E5M2>("+2.0", LeadingSign::None,
+                                        uint8_t{0x40}),
+        // Cases with a leading sign
+        GoodFloatParseCase<Float8_E5M2>("0", LeadingSign::Plus, uint8_t{0}),
+        GoodFloatParseCase<Float8_E5M2>("0.0", LeadingSign::Plus, uint8_t{0}),
+        GoodFloatParseCase<Float8_E5M2>("2.0", LeadingSign::Plus,
+                                        uint8_t{0x40}),
+        GoodFloatParseCase<Float8_E5M2>("0.0", LeadingSign::Minus,
+                                        uint8_t{0x80}),
+        GoodFloatParseCase<Float8_E5M2>("2.0", LeadingSign::Minus,
+                                        uint8_t{0xc0}),
 
-        // When negate_value is true, we should not accept a leading minus or
+        // When a leading sign is present, we should not accept a leading minus
+        // or
         // plus.
-        BadFloatParseCase<Float8_E5M2>("-0.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E5M2>("-2.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E5M2>("+0.0", true, uint8_t{0}),
-        BadFloatParseCase<Float8_E5M2>("+2.0", true, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("-0.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("-2.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("+0.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("+2.0", LeadingSign::Minus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("-0.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("-2.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("+0.0", LeadingSign::Plus, uint8_t{0}),
+        BadFloatParseCase<Float8_E5M2>("+2.0", LeadingSign::Plus, uint8_t{0}),
     }));
 
 // A test case for detecting infinities.
@@ -2139,6 +2209,18 @@ INSTANTIATE_TEST_SUITE_P(
     }));
 
 INSTANTIATE_TEST_SUITE_P(
+    Underflow, Float32StreamParseTest,
+    ::testing::ValuesIn(std::vector<StreamParseCase<float>>{
+        // Underflow
+        {"0x1.p-149", true, "", ldexpf(1, -149)},
+        {"0x1.p-150", true, "", 0.0f},
+        {"+0x1.p-149", true, "", ldexpf(1, -149)},
+        {"+0x1.p-150", true, "", 0.0f},
+        {"-0x1.p-149", true, "", -ldexpf(1, -149)},
+        {"-0x1.p-150", true, "", -0.0f},
+    }));
+
+INSTANTIATE_TEST_SUITE_P(
     HexFloat16ExcessSignificantDigits, Float16StreamParseTest,
     ::testing::ValuesIn(std::vector<StreamParseCase<Float16>>{
         // Zero
@@ -2241,6 +2323,18 @@ INSTANTIATE_TEST_SUITE_P(
         {"0x8.5a40000p0", true, "", makeF16(0, 3, 0x02d)},
         {"0x8.5a7ffffp0", true, "", makeF16(0, 3, 0x02d)}}));
 
+INSTANTIATE_TEST_SUITE_P(
+    Underflow, Float16StreamParseTest,
+    ::testing::ValuesIn(std::vector<StreamParseCase<Float16>>{
+        // Underflow
+        {"0x1.p-24", true, "", Float16(uint16_t(1))},
+        {"0x1.p-25", true, "", Float16(uint16_t(0))},
+        {"+0x1.p-24", true, "", Float16(uint16_t(1))},
+        {"+0x1.p-25", true, "", Float16(uint16_t(0))},
+        {"-0x1.p-24", true, "", Float16(uint16_t(0x8001))},
+        {"-0x1.p-25", true, "", Float16(uint16_t(0x8000))},
+    }));
+
 // Returns a E4M3 constructed from its sign bit, unbiased exponent, and
 // mantissa.
 Float8_E4M3 makeE4M3(int sign_bit, int unbiased_exp, int mantissa) {
@@ -2318,6 +2412,18 @@ INSTANTIATE_TEST_SUITE_P(
         {"0x8.5a40000p0", true, "", makeE4M3(0, 3, 0x0)},
         {"0x8.5a7ffffp0", true, "", makeE4M3(0, 3, 0x0)}}));
 
+INSTANTIATE_TEST_SUITE_P(
+    Underflow, FloatE4M3StreamParseTest,
+    ::testing::ValuesIn(std::vector<StreamParseCase<Float8_E4M3>>{
+        // Underflow
+        {"0x1.p-9", true, "", Float8_E4M3(uint8_t(1))},
+        {"0x1.p-10", true, "", Float8_E4M3(uint8_t(0))},
+        {"+0x1.p-9", true, "", Float8_E4M3(uint8_t(1))},
+        {"+0x1.p-10", true, "", Float8_E4M3(uint8_t(0))},
+        {"-0x1.p-9", true, "", Float8_E4M3(uint8_t(0x81))},
+        {"-0x1.p-10", true, "", Float8_E4M3(uint8_t(0x80))},
+    }));
+
 // Returns a E5M2 constructed from its sign bit, unbiased exponent, and
 // mantissa.
 Float8_E5M2 makeE5M2(int sign_bit, int unbiased_exp, int mantissa) {
@@ -2393,7 +2499,20 @@ INSTANTIATE_TEST_SUITE_P(
         {"0x4.aa40000p0", true, "", makeE5M2(0, 2, 0x0)},
         {"0x4.aa7ffffp0", true, "", makeE5M2(0, 2, 0x0)},
         {"0x8.aa40000p0", true, "", makeE5M2(0, 3, 0x0)},
-        {"0x8.aa7ffffp0", true, "", makeE5M2(0, 3, 0x0)}}));
+        {"0x8.aa7ffffp0", true, "", makeE5M2(0, 3, 0x0)},
+    }));
+
+INSTANTIATE_TEST_SUITE_P(
+    Underflow, FloatE5M2StreamParseTest,
+    ::testing::ValuesIn(std::vector<StreamParseCase<Float8_E5M2>>{
+        // Underflow
+        {"0x1.p-16", true, "", Float8_E5M2(uint8_t(1))},
+        {"0x1.p-17", true, "", Float8_E5M2(uint8_t(0))},
+        {"+0x1.p-16", true, "", Float8_E5M2(uint8_t(1))},
+        {"+0x1.p-17", true, "", Float8_E5M2(uint8_t(0))},
+        {"-0x1.p-16", true, "", Float8_E5M2(uint8_t(0x81))},
+        {"-0x1.p-17", true, "", Float8_E5M2(uint8_t(0x80))},
+    }));
 
 }  // namespace
 }  // namespace utils


### PR DESCRIPTION
Make it symmetric with a leading -

Test underflow to zero.

Bug: crbug.com/488728576