### PR TITLE
val: more validation of OpTypeFloat

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -672,6 +672,7 @@ cc_library(
         ":val_test_lib",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@spirv_headers//:spirv_cpp11_headers",
     ],
 ) for f in glob(
     ["test/val/val_*_test.cpp"],

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -17,6 +17,8 @@
 
 // Ensures type declarations are unique unless allowed by the specification.
 
+#include <optional>
+
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
@@ -107,27 +109,45 @@ spv_result_t ValidateTypeInt(ValidationState_t& _, const Instruction* inst) {
 }
 
 spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
-  // Validates that the number of bits specified for an Int type is valid.
-  // Scalar integer types can be parameterized only with 32-bits.
-  // Int8, Int16, and Int64 capabilities allow using 8-bit, 16-bit, and 64-bit
-  // integers, respectively.
+  // Validates:
+  // - the number of bits specified for a float type is valid
+  // - the fp encoding is valid, and only used on matching bit widths
+  // - required capabilities are declared
   auto num_bits = inst->GetOperandAs<const uint32_t>(1);
-  const bool has_encoding = inst->operands().size() > 2;
+
+  std::optional<spv::FPEncoding> encoding;
+  if (inst->operands().size() > 2) {
+    encoding = inst->GetOperandAs<spv::FPEncoding>(2);
+  }
+  // The number of operands is already checked by the grammar structure.
+  // The fp encoding operand is an optional enum, and there are no further
+  // operands.
+
   if (num_bits == 32) {
+    if (encoding.has_value()) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "32-bit floating point type must not have encoding parameter.";
+    }
     return SPV_SUCCESS;
   }
-  auto operands = inst->words();
 
   if (num_bits == 16) {
     // An absence of FP encoding implies IEEE 754. The Float16 and Float16Buffer
     // capabilities only enable IEEE 754 binary 16
-    if (has_encoding || _.features().declare_float16_type) {
-      return SPV_SUCCESS;
+    if (!encoding.has_value() && !_.features().declare_float16_type) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Using a 16-bit floating point "
+             << "type requires the Float16 or Float16Buffer capability,"
+                " or an extension that explicitly enables 16-bit floating "
+                "point.";
     }
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Using a 16-bit floating point "
-           << "type requires the Float16 or Float16Buffer capability,"
-              " or an extension that explicitly enables 16-bit floating point.";
+    if (encoding.has_value() &&
+        encoding.value() != spv::FPEncoding::BFloat16KHR) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Unsupported 16-bit floating point encoding ("
+             << static_cast<uint32_t>(encoding.value()) << ").";
+    }
+    return SPV_SUCCESS;
   }
   if (num_bits == 8) {
     if (!_.features().declare_float8_type) {
@@ -135,33 +155,32 @@ spv_result_t ValidateTypeFloat(ValidationState_t& _, const Instruction* inst) {
              << "Using a 8-bit floating point "
              << "type requires the Float8EXT capability.";
     }
-    if (!has_encoding) {
+    if (encoding.has_value()) {
+      const auto enc = encoding.value();
+      if (enc != spv::FPEncoding::Float8E4M3EXT &&
+          enc != spv::FPEncoding::Float8E5M2EXT) {
+        return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << "Unsupported 8-bit floating point encoding ("
+               << static_cast<uint32_t>(enc) << ").";
+      }
+    } else {
       // we don't support fp8 without encoding
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "8-bit floating point type requires an encoding.";
     }
-    const spvtools::OperandDesc* desc = nullptr;
-    const std::set<spv::FPEncoding> known_encodings{
-        spv::FPEncoding::Float8E4M3EXT, spv::FPEncoding::Float8E5M2EXT};
-    spv_result_t status = spvtools::LookupOperand(SPV_OPERAND_TYPE_FPENCODING,
-                                                  inst->words()[3], &desc);
-    if ((status != SPV_SUCCESS) ||
-        (known_encodings.find(static_cast<spv::FPEncoding>(desc->value)) ==
-         known_encodings.end())) {
-      return _.diag(SPV_ERROR_INVALID_DATA, inst)
-             << "Unsupported 8-bit floating point encoding ("
-             << desc->name().data() << ").";
-    }
-
     return SPV_SUCCESS;
   }
   if (num_bits == 64) {
-    if (_.HasCapability(spv::Capability::Float64)) {
-      return SPV_SUCCESS;
+    if (!_.HasCapability(spv::Capability::Float64)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Using a 64-bit floating point "
+             << "type requires the Float64 capability.";
     }
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Using a 64-bit floating point "
-           << "type requires the Float64 capability.";
+    if (encoding.has_value()) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "64-bit floating point type must not have encoding parameter.";
+    }
+    return SPV_SUCCESS;
   }
   return _.diag(SPV_ERROR_INVALID_DATA, inst)
          << "Invalid number of bits (" << num_bits << ") used for OpTypeFloat.";

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -14,10 +14,12 @@
 
 // Validation tests for Data Rules.
 
+#include <sstream>
 #include <string>
 #include <utility>
 
 #include "gmock/gmock.h"
+#include "spirv/unified1/spirv.hpp11"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 
@@ -125,6 +127,15 @@ std::string header_with_float64 = R"(
      OpCapability Shader
      OpCapability Linkage
      OpCapability Float64
+     OpMemoryModel Logical GLSL450
+)";
+
+std::string header_with_float64_bfloat16 = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpCapability Float64
+     OpCapability BFloat16TypeKHR
+     OpExtension "SPV_KHR_bfloat16"
      OpMemoryModel Logical GLSL450
 )";
 
@@ -378,7 +389,7 @@ TEST_F(ValidateData, float8_good) {
 %3 = OpTypeFloat 8 Float8E5M2EXT
 )";
   CompileSuccessfully(str.c_str());
-  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
 }
 
 TEST_F(ValidateData, bfloat16_good) {
@@ -438,6 +449,30 @@ TEST_F(ValidateData, float16_buffer_good) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateData, float32_with_encoding_number_bad) {
+  std::string str = header_with_bfloat16 + "%2 = OpTypeFloat 32 !9999";
+  const auto& err = CompileFailure(str.c_str());
+  EXPECT_THAT(err, HasSubstr("Invalid OpTypeFloat encoding"));
+}
+
+TEST_F(ValidateData, float32_with_encoding_enum_bad) {
+  std::string str = header_with_bfloat16 + "%2 = OpTypeFloat 32 BFloat16";
+  const auto& err = CompileFailure(str.c_str());
+  EXPECT_THAT(err, HasSubstr("Invalid FP encoding 'BFloat16'"));
+}
+
+TEST_F(ValidateData, float64_with_encoding_number_bad) {
+  std::string str = header_with_float64 + "%2 = OpTypeFloat 64 !9999";
+  const auto& err = CompileFailure(str.c_str());
+  EXPECT_THAT(err, HasSubstr("Invalid OpTypeFloat encoding"));
+}
+
+TEST_F(ValidateData, float64_with_encoding_enum_bad) {
+  std::string str = header_with_float64 + "%2 = OpTypeFloat 64 BFloat16";
+  const auto& err = CompileFailure(str.c_str());
+  EXPECT_THAT(err, HasSubstr("Invalid FP encoding 'BFloat16'"));
+}
+
 TEST_F(ValidateData, float16_bad) {
   std::string str = header + "%2 = OpTypeFloat 16";
   CompileSuccessfully(str.c_str());
@@ -445,7 +480,7 @@ TEST_F(ValidateData, float16_bad) {
   EXPECT_THAT(getDiagnosticString(), HasSubstr(missing_float16_cap_error));
 }
 
-TEST_F(ValidateData, bfloat16_bad) {
+TEST_F(ValidateData, bfloat16_missing_cap_bad) {
   std::string str = header + "%2 = OpTypeFloat 16 BFloat16KHR";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions());
@@ -453,10 +488,59 @@ TEST_F(ValidateData, bfloat16_bad) {
               HasSubstr("requires one of these capabilities: BFloat16TypeKHR"));
 }
 
-TEST_F(ValidateData, float8_bad) {
+TEST_F(ValidateData, bfloat16_wrong_width_15_bad) {
+  std::stringstream ss;
+  ss << header_with_bfloat16 << "!"
+     << (4u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 15 "
+     << static_cast<uint32_t>(spv::FPEncoding::BFloat16KHR);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Invalid number of bits (15) used for OpTypeFloat"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, bfloat16_wrong_width_8_bad) {
+  std::stringstream ss;
+  ss << header_with_float8_and_bfloat16 << "!"
+     << (4u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 8 "
+     << static_cast<uint32_t>(spv::FPEncoding::BFloat16KHR);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Unsupported 8-bit floating point encoding"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, bfloat16_too_many_operands_bad) {
+  std::stringstream ss;
+  ss << header_with_float8_and_bfloat16 << "!"
+     << (5u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 16 "
+     << static_cast<uint32_t>(spv::FPEncoding::BFloat16KHR) << " 0";
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected no more operands after 4 words, but stated "
+                        "word count is 5"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_E4M3_missing_cap_bad) {
   std::string str = header +
                     R"(%2 = OpTypeFloat 8 Float8E4M3EXT
-%3 = OpTypeFloat 8 Float8E5M2EXT
+)";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: Float8EXT"));
+}
+
+TEST_F(ValidateData, float8_E5M2_missing_cap_bad) {
+  std::string str = header +
+                    R"(%2 = OpTypeFloat 8 Float8E5M2EXT
 )";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions());
@@ -478,6 +562,86 @@ TEST_F(ValidateData, float8_bad_encoding) {
   const auto& err = CompileFailure(str.c_str());
   EXPECT_THAT(err, HasSubstr("Invalid bit width 8 for floating point encoding "
                              "BFloat16KHR; expected 16"));
+}
+
+TEST_F(ValidateData, float8_E4M3_wrong_width_7_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << ((4u << 16) | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 7 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E4M3EXT);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Invalid number of bits (7) used for OpTypeFloat"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_E4M3_wrong_width_16_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << ((4u << 16) | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 16 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E4M3EXT);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Unsupported 16-bit floating point encoding (4214)"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_E5M2_wrong_width_7_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << ((4u << 16) | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 7 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E5M2EXT);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Invalid number of bits (7) used for OpTypeFloat"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_E5M2_wrong_width_16_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << ((4u << 16) | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 16 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E5M2EXT);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Unsupported 16-bit floating point encoding (4215)"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_e4m3_too_many_operands_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << (5u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 8 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E4M3EXT) << " 0";
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected no more operands after 4 words, but stated "
+                        "word count is 5"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float8_e5m2_too_many_operands_bad) {
+  std::stringstream ss;
+  ss << header_with_float8 << "!"
+     << (5u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 8 "
+     << static_cast<uint32_t>(spv::FPEncoding::Float8E5M2EXT) << " 0";
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_BINARY, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected no more operands after 4 words, but stated "
+                        "word count is 5"))
+      << getDiagnosticString();
 }
 
 TEST_F(ValidateData, dot_bfloat16_bad) {
@@ -526,11 +690,39 @@ TEST_F(ValidateData, float64_good) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateData, float64_bad) {
+TEST_F(ValidateData, float64_missing_cap_bad) {
   std::string str = header + "%2 = OpTypeFloat 64";
   CompileSuccessfully(str.c_str());
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr(missing_float64_cap_error));
+}
+
+TEST_F(ValidateData, float32_encoding_param_bad) {
+  std::stringstream ss;
+  ss << header_with_bfloat16 << "!"
+     << (4u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 32 "
+     << static_cast<uint32_t>(spv::FPEncoding::BFloat16KHR);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("32-bit floating point type must not have encoding parameter"))
+      << getDiagnosticString();
+}
+
+TEST_F(ValidateData, float64_encoding_param_bad) {
+  std::stringstream ss;
+  ss << header_with_float64_bfloat16 << "!"
+     << (4u << 16 | static_cast<uint32_t>(spv::Op::OpTypeFloat)) << " 99 64 "
+     << static_cast<uint32_t>(spv::FPEncoding::BFloat16KHR);
+  CompileSuccessfully(ss.str().c_str());
+  OverwriteIdBound(100);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("64-bit floating point type must not have encoding parameter"))
+      << getDiagnosticString();
 }
 
 // Number of bits in a float may be only one of: {16,32,64}

--- a/test/val/val_fixtures.h
+++ b/test/val/val_fixtures.h
@@ -56,6 +56,13 @@ class ValidateBase : public ::testing::Test,
   // This function overwrites the word at the given index with a new word.
   void OverwriteAssembledBinary(uint32_t index, uint32_t word);
 
+  // Overwrites the ID bound.
+  void OverwriteIdBound(uint32_t bound) {
+    // The ID bound is in the header at word index 3.
+    // SPIR-V section 2.3 Physical Layout of a sPIR-V Module and Instruction.
+    OverwriteAssembledBinary(3, bound);
+  }
+
   // Performs validation on the SPIR-V code.
   spv_result_t ValidateInstructions(spv_target_env env = SPV_ENV_UNIVERSAL_1_0);
 


### PR DESCRIPTION
- add tests for too many arguments
- check if 32-bit and 64-bit float types have an encoding arg
- check encoding arg for 16 bit types