### PR TITLE
spirv-val: Add vector support for OpConvertPtrToU/OpConvertUToPtr with SPV_INTEL_masked_gather_scatter extension

### DIFF
--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -332,24 +332,67 @@ spv_result_t ValidateConvertPtrToU(ValidationState_t& _,
                                    uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
-  if (!_.IsUnsignedIntScalarType(result_type))
+  const bool has_masked_gather_scatter =
+      _.HasCapability(spv::Capability::MaskedGatherScatterINTEL);
+
+  bool valid_result_type = _.IsUnsignedIntScalarType(result_type);
+  if (!valid_result_type && has_masked_gather_scatter) {
+    valid_result_type = _.IsUnsignedIntVectorType(result_type);
+  }
+
+  if (!valid_result_type) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Expected unsigned int scalar type as Result Type: "
-           << spvOpcodeString(opcode);
+           << "Expected unsigned int scalar type as Result Type"
+           << (has_masked_gather_scatter ? " (or vector of unsigned int with "
+                                           "MaskedGatherScatterINTEL)"
+                                         : "")
+           << ": " << spvOpcodeString(opcode);
+  }
 
   const uint32_t input_type = _.GetOperandTypeId(inst, operand_index);
-  if (!_.IsPointerType(input_type))
+
+  bool valid_input_type = _.IsPointerType(input_type);
+  if (!valid_input_type && has_masked_gather_scatter && input_type) {
+    if (_.IsVectorType(input_type)) {
+      const uint32_t component_type = _.GetComponentType(input_type);
+      valid_input_type = _.IsPointerType(component_type);
+    }
+  }
+
+  if (!valid_input_type) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Expected input to be a pointer: " << spvOpcodeString(opcode);
+           << "Expected input to be a pointer"
+           << (has_masked_gather_scatter
+                   ? " (or vector of pointers with MaskedGatherScatterINTEL)"
+                   : "")
+           << ": " << spvOpcodeString(opcode);
+  }
+
+  if (has_masked_gather_scatter && _.IsVectorType(result_type)) {
+    if (!_.IsVectorType(input_type)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Expected input to be a vector when Result Type is a vector: "
+             << spvOpcodeString(opcode);
+    }
+    if (_.GetDimension(result_type) != _.GetDimension(input_type)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Expected input to have the same dimension as Result Type: "
+             << spvOpcodeString(opcode);
+    }
+  }
 
   if (_.addressing_model() == spv::AddressingModel::Logical)
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Logical addressing not supported: " << spvOpcodeString(opcode);
 
   if (_.addressing_model() == spv::AddressingModel::PhysicalStorageBuffer64) {
+    uint32_t ptr_type = input_type;
+    if (_.IsVectorType(input_type)) {
+      ptr_type = _.GetComponentType(input_type);
+    }
     spv::StorageClass input_storage_class;
     uint32_t input_data_type = 0;
-    _.GetPointerTypeInfo(input_type, &input_data_type, &input_storage_class);
+    _.GetPointerTypeInfo(ptr_type, &input_data_type, &input_storage_class);
     if (input_storage_class != spv::StorageClass::PhysicalStorageBuffer)
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "Pointer storage class must be PhysicalStorageBuffer: "
@@ -396,24 +439,67 @@ spv_result_t ValidateConvertUToPtr(ValidationState_t& _,
                                    uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
-  if (!_.IsPointerType(result_type))
+  const bool has_masked_gather_scatter =
+      _.HasCapability(spv::Capability::MaskedGatherScatterINTEL);
+
+  bool valid_result_type = _.IsPointerType(result_type);
+  if (!valid_result_type && has_masked_gather_scatter) {
+    if (_.IsVectorType(result_type)) {
+      const uint32_t component_type = _.GetComponentType(result_type);
+      valid_result_type = _.IsPointerType(component_type);
+    }
+  }
+
+  if (!valid_result_type) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Expected Result Type to be a pointer: "
-           << spvOpcodeString(opcode);
+           << "Expected Result Type to be a pointer"
+           << (has_masked_gather_scatter
+                   ? " (or vector of pointers with MaskedGatherScatterINTEL)"
+                   : "")
+           << ": " << spvOpcodeString(opcode);
+  }
 
   const uint32_t input_type = _.GetOperandTypeId(inst, operand_index);
-  if (!input_type || !_.IsIntScalarType(input_type))
+
+  bool valid_input_type = input_type && _.IsIntScalarType(input_type);
+  if (!valid_input_type && has_masked_gather_scatter && input_type) {
+    valid_input_type = _.IsIntVectorType(input_type);
+  }
+
+  if (!valid_input_type) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Expected int scalar as input: " << spvOpcodeString(opcode);
+           << "Expected int scalar as input"
+           << (has_masked_gather_scatter
+                   ? " (or vector of int with MaskedGatherScatterINTEL)"
+                   : "")
+           << ": " << spvOpcodeString(opcode);
+  }
+
+  if (has_masked_gather_scatter && _.IsVectorType(result_type)) {
+    if (!_.IsVectorType(input_type)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Expected input to be a vector when Result Type is a vector: "
+             << spvOpcodeString(opcode);
+    }
+    if (_.GetDimension(result_type) != _.GetDimension(input_type)) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Expected input to have the same dimension as Result Type: "
+             << spvOpcodeString(opcode);
+    }
+  }
 
   if (_.addressing_model() == spv::AddressingModel::Logical)
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Logical addressing not supported: " << spvOpcodeString(opcode);
 
   if (_.addressing_model() == spv::AddressingModel::PhysicalStorageBuffer64) {
+    uint32_t ptr_type = result_type;
+    if (_.IsVectorType(result_type)) {
+      ptr_type = _.GetComponentType(result_type);
+    }
     spv::StorageClass result_storage_class;
     uint32_t result_data_type = 0;
-    _.GetPointerTypeInfo(result_type, &result_data_type, &result_storage_class);
+    _.GetPointerTypeInfo(ptr_type, &result_data_type, &result_storage_class);
     if (result_storage_class != spv::StorageClass::PhysicalStorageBuffer)
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << "Pointer storage class must be PhysicalStorageBuffer: "

--- a/test/val/val_conversion_test.cpp
+++ b/test/val/val_conversion_test.cpp
@@ -2544,6 +2544,338 @@ OpFunctionEnd)";
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Expected number of components to be identical"));
 }
+
+TEST_F(ValidateConversion, ConvertPtrToUVectorWithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %v2ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %v2ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %v2u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateConversion, ConvertPtrToUVectorWithoutCapabilityFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %v2ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %v2ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %v2u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("OpTypeVector Component Type"));
+}
+
+TEST_F(ValidateConversion, ConvertPtrToUVectorResultScalarInputFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %v2u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a vector when Result Type is a "
+                        "vector: ConvertPtrToU"));
+}
+
+TEST_F(ValidateConversion, ConvertPtrToUVectorDimensionMismatchFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%v4u64 = OpTypeVector %u64 4
+%fn = OpTypeFunction %void %v2ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %v2ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %v4u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Expected input to have the same dimension as Result Type: "
+                "ConvertPtrToU"));
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrVectorWithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %v2u64
+%main = OpFunction %void None %fn
+%addrs = OpFunctionParameter %v2u64
+%entry = OpLabel
+%result = OpConvertUToPtr %v2ptr %addrs
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrVectorWithoutCapabilityFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %v2u64
+%main = OpFunction %void None %fn
+%addrs = OpFunctionParameter %v2u64
+%entry = OpLabel
+%result = OpConvertUToPtr %v2ptr %addrs
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("OpTypeVector Component Type"));
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrVectorResultScalarInputFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v2ptr = OpTypeVector %ptr 2
+%fn = OpTypeFunction %void %u64
+%main = OpFunction %void None %fn
+%addr = OpFunctionParameter %u64
+%entry = OpLabel
+%result = OpConvertUToPtr %v2ptr %addr
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Expected input to be a vector when Result Type is a "
+                        "vector: ConvertUToPtr"));
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrVectorDimensionMismatchFails) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v4ptr = OpTypeVector %ptr 4
+%v2u64 = OpTypeVector %u64 2
+%fn = OpTypeFunction %void %v2u64
+%main = OpFunction %void None %fn
+%addrs = OpFunctionParameter %v2u64
+%entry = OpLabel
+%result = OpConvertUToPtr %v4ptr %addrs
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Expected input to have the same dimension as Result Type: "
+                "ConvertUToPtr"));
+}
+
+TEST_F(ValidateConversion, ConvertPtrToUVec4WithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v4ptr = OpTypeVector %ptr 4
+%v4u64 = OpTypeVector %u64 4
+%fn = OpTypeFunction %void %v4ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %v4ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %v4u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrVec4WithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%v4ptr = OpTypeVector %ptr 4
+%v4u64 = OpTypeVector %u64 4
+%fn = OpTypeFunction %void %v4u64
+%main = OpFunction %void None %fn
+%addrs = OpFunctionParameter %v4u64
+%entry = OpLabel
+%result = OpConvertUToPtr %v4ptr %addrs
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// Test that scalar conversion still works with capability present
+TEST_F(ValidateConversion, ConvertPtrToUScalarWithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%fn = OpTypeFunction %void %ptr
+%main = OpFunction %void None %fn
+%p = OpFunctionParameter %ptr
+%entry = OpLabel
+%result = OpConvertPtrToU %u64 %p
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateConversion, ConvertUToPtrScalarWithMaskedGatherScatterSuccess) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability Int64
+OpCapability MaskedGatherScatterINTEL
+OpExtension "SPV_INTEL_masked_gather_scatter"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%u64 = OpTypeInt 64 0
+%u32 = OpTypeInt 32 0
+%ptr = OpTypePointer CrossWorkgroup %u32
+%fn = OpTypeFunction %void %u64
+%main = OpFunction %void None %fn
+%addr = OpFunctionParameter %u64
+%entry = OpLabel
+%result = OpConvertUToPtr %ptr %addr
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv.c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Add missing support for vector operands in `OpConvertPtrToU` and `OpConvertUToPtr` when [SPV_INTEL_masked_gather_scatter](https://github.com/KhronosGroup/SPIRV-Registry/blob/278044a51fee280bfc91322cdb55b51357db5cb8/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc) extension is enabled