### PR TITLE
spirv-val: Label VU 11165 OpCopyMemorySized

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1684,12 +1684,21 @@ spv_result_t ValidateCopyMemory(ValidationState_t& _, const Instruction* inst) {
           }
           if (!int8 && !int16 && !(source_int16_match && target_int16_match)) {
             return _.diag(SPV_ERROR_INVALID_ID, inst)
-                   << "Size must be a multiple of 4";
+                   << _.VkErrorID(11165)
+                   << "Size must be a multiple of 4. This is valid if Source ("
+                   << StorageClassToString(source_sc) << ") and Target ("
+                   << StorageClassToString(source_sc)
+                   << ") storage classes both support either 8-bit or 16-bit";
           }
           if (value % 2 != 0) {
             if (!int8 && !(source_int8_match && target_int8_match)) {
               return _.diag(SPV_ERROR_INVALID_ID, inst)
-                     << "Size must be a multiple of 2";
+                     << _.VkErrorID(11165)
+                     << "Size must be a multiple of 2. This is valid if Source "
+                        "("
+                     << StorageClassToString(source_sc) << ") and Target ("
+                     << StorageClassToString(source_sc)
+                     << ") storage classes both support 8-bit";
             }
           }
         }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2930,6 +2930,9 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-UnequalMemorySemantics-10879);
     case 10880:
       return VUID_WRAP(VUID-StandaloneSpirv-TessLevelInner-10880);
+    case 11165:
+      // Validation (via GPU-AV) will catch this if a non-constant
+      return VUID_WRAP(VUID-RuntimeSpirv-Size-11165);
     case 11167:
       return VUID_WRAP(VUID-StandaloneSpirv-OpUntypedVariableKHR-11167);
     case 11239:

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -7755,6 +7755,41 @@ OpFunctionEnd
   EXPECT_THAT(getDiagnosticString(), HasSubstr("Size must be a multiple of 2"));
 }
 
+TEST_F(ValidateMemory, CopyMemorySizedVulkanConstant) {
+  const std::string spirv = R"(
+        OpCapability Shader
+        OpCapability UntypedPointersKHR
+        OpExtension "SPV_KHR_untyped_pointers"
+        OpMemoryModel Logical GLSL450
+        OpEntryPoint GLCompute %main "main" %v1 %v2
+        OpExecutionMode %main LocalSize 1 1 1
+        OpDecorate %struct Block
+        OpDecorate %v1 DescriptorSet 0
+        OpDecorate %v1 Binding 0
+        OpDecorate %v2 DescriptorSet 0
+        OpDecorate %v2 Binding 0
+        OpMemberDecorate %struct 0 Offset 0
+        %void = OpTypeVoid
+        %int = OpTypeInt 32 0
+        %int_2 = OpConstant %int 2
+        %struct = OpTypeStruct %int
+        %ptr = OpTypeUntypedPointerKHR StorageBuffer
+        %v1 = OpUntypedVariableKHR %ptr StorageBuffer %struct
+        %v2 = OpUntypedVariableKHR %ptr StorageBuffer %struct
+        %void_fn = OpTypeFunction %void
+        %main = OpFunction %void None %void_fn
+        %entry = OpLabel
+        OpCopyMemorySized %v2 %v1 %int_2
+        OpReturn
+        OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr("Size must be a multiple of 4"));
+  EXPECT_THAT(getDiagnosticString(), AnyVUID("VUID-RuntimeSpirv-Size-11165"));
+}
+
 TEST_F(ValidateMemory, PtrEqualUntypedPointersGood) {
   const std::string spirv = R"(
 OpCapability Shader


### PR DESCRIPTION
New error

> [VUID-RuntimeSpirv-Size-11165] Size must be a multiple of 4. This is valid if Source (StorageBuffer) and Target (StorageBuffer) storage classes both support either 8-bit or 16-bit

1. This adds the VUID to be tracked in VVL
2. The current error message didn't make it obvious **why** it must be a multiple of 2 or 4