### PR TITLE
spirv-val: Label LongVector VUID

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -887,6 +887,7 @@ spv_result_t ValidateVariable(ValidationState_t& _, const Instruction* inst) {
             return false;
           })) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << _.VkErrorID(12297)
                << "Long vector types with more than 4 components (or types "
                   "containing them) not supported in storage class "
                << StorageClassToString(storage_class);

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -227,13 +227,13 @@ spv_result_t ValidateTypeVector(ValidationState_t& _, const Instruction* inst) {
       return SPV_SUCCESS;
     }
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Having " << num_components << " components for "
-           << spvOpcodeString(inst->opcode())
-           << " requires the Vector16 capability";
+           << _.VkErrorID(12295) << "Having " << num_components
+           << " components for " << spvOpcodeString(inst->opcode())
+           << " requires the Vector16 or LongVectorEXT capability";
   } else {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Illegal number of components (" << num_components << ") for "
-           << spvOpcodeString(inst->opcode());
+           << _.VkErrorID(12295) << "Illegal number of components ("
+           << num_components << ") for " << spvOpcodeString(inst->opcode());
   }
 
   return SPV_SUCCESS;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2961,6 +2961,10 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Scope-12243);
     case 12294:
       return VUID_WRAP(VUID-StandaloneSpirv-Function-12294);
+    case 12295:
+      return VUID_WRAP(VUID-StandaloneSpirv-None-12295);
+    case 12297:
+      return VUID_WRAP(VUID-StandaloneSpirv-Type-12297);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -140,7 +140,8 @@ std::string header_with_float64_bfloat16 = R"(
 )";
 
 std::string invalid_comp_error = "Illegal number of components";
-std::string missing_cap_error = "requires the Vector16 capability";
+std::string missing_cap_error =
+    "requires the Vector16 or LongVectorEXT capability";
 std::string missing_int8_cap_error = "requires the Int8 capability";
 std::string missing_int16_cap_error =
     "requires the Int16 capability,"

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -761,7 +761,8 @@ TEST_P(ValidateIdWithMessage, OpTypeVectorColumnCountEightWithoutVector16Bad) {
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(make_message(
-                  "Having 8 components for TypeVector requires the Vector16 "
+                  "Having 8 components for TypeVector requires the Vector16 or "
+                  "LongVectorEXT "
                   "capability\n  %v8float = OpTypeVector %float 8\n")));
 }
 
@@ -776,6 +777,7 @@ TEST_P(ValidateIdWithMessage,
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr(make_message(
                   "Having 16 components for TypeVector requires the Vector16 "
+                  "or LongVectorEXT "
                   "capability\n  %v16float = OpTypeVector %float 16\n")));
 }
 

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -10357,6 +10357,8 @@ OpFunctionEnd
       getDiagnosticString(),
       HasSubstr("Long vector types with more than 4 components (or types "
                 "containing them) not supported in storage class Input"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Type-12297"));
 }
 
 TEST_F(ValidateMemory, LongVectorMissingCapabilityBad) {
@@ -10379,6 +10381,8 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Illegal number of components (5) for TypeVector"));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-None-12295"));
 }
 
 }  // namespace


### PR DESCRIPTION
We decided today to move these to Standalone VUID https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8106/diffs