### PR TITLE
spirv-val: More OpSpecConstantOp

### DIFF
--- a/source/val/validate_conversion.cpp
+++ b/source/val/validate_conversion.cpp
@@ -433,7 +433,8 @@ spv_result_t ValidateConvertUToPtr(ValidationState_t& _,
 }
 
 spv_result_t ValidatePtrCastToGeneric(ValidationState_t& _,
-                                      const Instruction* inst) {
+                                      const Instruction* inst,
+                                      uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   spv::StorageClass result_storage_class;
@@ -449,7 +450,7 @@ spv_result_t ValidatePtrCastToGeneric(ValidationState_t& _,
            << "Expected Result Type to have storage class Generic: "
            << spvOpcodeString(opcode);
 
-  const uint32_t input_type = _.GetOperandTypeId(inst, 2);
+  const uint32_t input_type = _.GetOperandTypeId(inst, operand_index);
   spv::StorageClass input_storage_class;
   uint32_t input_data_type = 0;
   if (!_.GetPointerTypeInfo(input_type, &input_data_type, &input_storage_class))
@@ -471,7 +472,8 @@ spv_result_t ValidatePtrCastToGeneric(ValidationState_t& _,
 }
 
 spv_result_t ValidateGenericCastToPtr(ValidationState_t& _,
-                                      const Instruction* inst) {
+                                      const Instruction* inst,
+                                      uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   spv::StorageClass result_storage_class;
@@ -489,7 +491,7 @@ spv_result_t ValidateGenericCastToPtr(ValidationState_t& _,
            << "Expected Result Type to have storage class Workgroup, "
            << "CrossWorkgroup or Function: " << spvOpcodeString(opcode);
 
-  const uint32_t input_type = _.GetOperandTypeId(inst, 2);
+  const uint32_t input_type = _.GetOperandTypeId(inst, operand_index);
   spv::StorageClass input_storage_class;
   uint32_t input_data_type = 0;
   if (!_.GetPointerTypeInfo(input_type, &input_data_type, &input_storage_class))
@@ -552,10 +554,11 @@ spv_result_t ValidateGenericCastToPtrExplicit(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateBitcast(ValidationState_t& _, const Instruction* inst) {
+spv_result_t ValidateBitcast(ValidationState_t& _, const Instruction* inst,
+                             uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
-  const uint32_t input_type = _.GetOperandTypeId(inst, 2);
+  const uint32_t input_type = _.GetOperandTypeId(inst, operand_index);
   if (!input_type)
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected input to have a type: " << spvOpcodeString(opcode);
@@ -860,6 +863,12 @@ spv_result_t ConversionPass(ValidationState_t& _, const Instruction* inst) {
           return ValidateConvertPtrToU(_, inst, 3);
         case spv::Op::OpConvertUToPtr:
           return ValidateConvertUToPtr(_, inst, 3);
+        case spv::Op::OpGenericCastToPtr:
+          return ValidateGenericCastToPtr(_, inst, 3);
+        case spv::Op::OpPtrCastToGeneric:
+          return ValidatePtrCastToGeneric(_, inst, 3);
+        case spv::Op::OpBitcast:
+          return ValidateBitcast(_, inst, 3);
         default:
           break;
       }

--- a/source/val/validate_logicals.cpp
+++ b/source/val/validate_logicals.cpp
@@ -92,7 +92,8 @@ spv_result_t ValidateFloatCompare(ValidationState_t& _,
 }
 
 spv_result_t ValidateLogicalCompare(ValidationState_t& _,
-                                    const Instruction* inst) {
+                                    const Instruction* inst,
+                                    uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   if (!_.IsBoolScalarType(result_type) && !_.IsBoolVectorType(result_type))
@@ -100,15 +101,17 @@ spv_result_t ValidateLogicalCompare(ValidationState_t& _,
            << "Expected bool scalar or vector type as Result Type: "
            << spvOpcodeString(opcode);
 
-  if (result_type != _.GetOperandTypeId(inst, 2) ||
-      result_type != _.GetOperandTypeId(inst, 3))
+  const uint32_t operand_1 = _.GetOperandTypeId(inst, operand_index);
+  const uint32_t operand_2 = _.GetOperandTypeId(inst, operand_index + 1);
+  if (result_type != operand_1 || result_type != operand_2)
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected both operands to be of Result Type: "
            << spvOpcodeString(opcode);
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateLogicalNot(ValidationState_t& _, const Instruction* inst) {
+spv_result_t ValidateLogicalNot(ValidationState_t& _, const Instruction* inst,
+                                uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   if (!_.IsBoolScalarType(result_type) && !_.IsBoolVectorType(result_type))
@@ -116,14 +119,15 @@ spv_result_t ValidateLogicalNot(ValidationState_t& _, const Instruction* inst) {
            << "Expected bool scalar or vector type as Result Type: "
            << spvOpcodeString(opcode);
 
-  if (result_type != _.GetOperandTypeId(inst, 2))
+  if (result_type != _.GetOperandTypeId(inst, operand_index))
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << "Expected operand to be of Result Type: "
            << spvOpcodeString(opcode);
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateSelect(ValidationState_t& _, const Instruction* inst) {
+spv_result_t ValidateSelect(ValidationState_t& _, const Instruction* inst,
+                            uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   uint32_t dimension = 1;
@@ -186,9 +190,9 @@ spv_result_t ValidateSelect(ValidationState_t& _, const Instruction* inst) {
       return fail();
   }
 
-  const uint32_t condition_type = _.GetOperandTypeId(inst, 2);
-  const uint32_t left_type = _.GetOperandTypeId(inst, 3);
-  const uint32_t right_type = _.GetOperandTypeId(inst, 4);
+  const uint32_t condition_type = _.GetOperandTypeId(inst, operand_index);
+  const uint32_t left_type = _.GetOperandTypeId(inst, operand_index + 1);
+  const uint32_t right_type = _.GetOperandTypeId(inst, operand_index + 2);
 
   if (!condition_type || (!_.IsBoolScalarType(condition_type) &&
                           !_.IsBoolVectorType(condition_type)))
@@ -216,7 +220,8 @@ spv_result_t ValidateSelect(ValidationState_t& _, const Instruction* inst) {
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateIntCompare(ValidationState_t& _, const Instruction* inst) {
+spv_result_t ValidateIntCompare(ValidationState_t& _, const Instruction* inst,
+                                uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   const uint32_t result_type = inst->type_id();
   if (!_.IsBoolScalarType(result_type) && !_.IsBoolVectorType(result_type))
@@ -224,8 +229,8 @@ spv_result_t ValidateIntCompare(ValidationState_t& _, const Instruction* inst) {
            << "Expected bool scalar or vector type as Result Type: "
            << spvOpcodeString(opcode);
 
-  const uint32_t left_type = _.GetOperandTypeId(inst, 2);
-  const uint32_t right_type = _.GetOperandTypeId(inst, 3);
+  const uint32_t left_type = _.GetOperandTypeId(inst, operand_index);
+  const uint32_t right_type = _.GetOperandTypeId(inst, operand_index + 1);
 
   if (!left_type ||
       (!_.IsIntScalarType(left_type) && !_.IsIntVectorType(left_type)))
@@ -305,6 +310,35 @@ spv_result_t LogicalsPass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpSLessThan:
     case spv::Op::OpSLessThanEqual:
       return ValidateIntCompare(_, inst);
+
+    case spv::Op::OpSpecConstantOp: {
+      switch (inst->GetOperandAs<spv::Op>(2u)) {
+        case spv::Op::OpLogicalEqual:
+        case spv::Op::OpLogicalNotEqual:
+        case spv::Op::OpLogicalOr:
+        case spv::Op::OpLogicalAnd:
+          return ValidateLogicalCompare(_, inst, 3);
+        case spv::Op::OpLogicalNot:
+          return ValidateLogicalNot(_, inst, 3);
+        case spv::Op::OpSelect:
+          return ValidateSelect(_, inst, 3);
+        case spv::Op::OpIEqual:
+        case spv::Op::OpINotEqual:
+        case spv::Op::OpUGreaterThan:
+        case spv::Op::OpUGreaterThanEqual:
+        case spv::Op::OpULessThan:
+        case spv::Op::OpULessThanEqual:
+        case spv::Op::OpSGreaterThan:
+        case spv::Op::OpSGreaterThanEqual:
+        case spv::Op::OpSLessThan:
+        case spv::Op::OpSLessThanEqual:
+          return ValidateIntCompare(_, inst, 3);
+        default:
+          break;
+      }
+      break;
+    }
+
     default:
       break;
   }

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -2280,8 +2280,10 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
   return SPV_SUCCESS;
 }
 
-spv_result_t ValidateCooperativeMatrixLengthNV(ValidationState_t& state,
-                                               const Instruction* inst) {
+spv_result_t ValidateCooperativeMatrixLength(ValidationState_t& state,
+                                             const Instruction* inst,
+                                             bool is_khr,
+                                             uint32_t operand_index = 2) {
   const spv::Op opcode = inst->opcode();
   // Result type must be a 32-bit unsigned int.
   const uint32_t result_type_id = inst->type_id();
@@ -2293,15 +2295,14 @@ spv_result_t ValidateCooperativeMatrixLengthNV(ValidationState_t& state,
            << " must be OpTypeInt with width 32 and signedness 0.";
   }
 
-  bool isKhr = inst->opcode() == spv::Op::OpCooperativeMatrixLengthKHR;
-  auto type_id = inst->GetOperandAs<uint32_t>(2);
+  auto type_id = inst->GetOperandAs<uint32_t>(operand_index);
   auto type = state.FindDef(type_id);
-  if (isKhr && type->opcode() != spv::Op::OpTypeCooperativeMatrixKHR) {
+  if (is_khr && type->opcode() != spv::Op::OpTypeCooperativeMatrixKHR) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
            << "The type in Op" << spvOpcodeString(opcode) << " <id> "
            << state.getIdName(type_id)
            << " must be OpTypeCooperativeMatrixKHR.";
-  } else if (!isKhr && type->opcode() != spv::Op::OpTypeCooperativeMatrixNV) {
+  } else if (!is_khr && type->opcode() != spv::Op::OpTypeCooperativeMatrixNV) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
            << "The type in Op" << spvOpcodeString(opcode) << " <id> "
            << state.getIdName(type_id) << " must be OpTypeCooperativeMatrixNV.";
@@ -3391,8 +3392,9 @@ spv_result_t MemoryPass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpCooperativeMatrixStoreNV:
       return ValidateCooperativeMatrixLoadStoreNV(_, inst);
     case spv::Op::OpCooperativeMatrixLengthKHR:
+      return ValidateCooperativeMatrixLength(_, inst, true);
     case spv::Op::OpCooperativeMatrixLengthNV:
-      return ValidateCooperativeMatrixLengthNV(_, inst);
+      return ValidateCooperativeMatrixLength(_, inst, false);
     case spv::Op::OpCooperativeMatrixLoadKHR:
     case spv::Op::OpCooperativeMatrixStoreKHR:
       return ValidateCooperativeMatrixLoadStoreKHR(_, inst);
@@ -3415,6 +3417,18 @@ spv_result_t MemoryPass(ValidationState_t& _, const Instruction* inst) {
       return ValidatePtrComparison(_, inst);
     case spv::Op::OpImageTexelPointer:
     case spv::Op::OpGenericPtrMemSemantics:
+
+    case spv::Op::OpSpecConstantOp: {
+      switch (inst->GetOperandAs<spv::Op>(2u)) {
+        case spv::Op::OpCooperativeMatrixLengthKHR:
+          return ValidateCooperativeMatrixLength(_, inst, true, 3);
+        case spv::Op::OpCooperativeMatrixLengthNV:
+          return ValidateCooperativeMatrixLength(_, inst, false, 3);
+        default:
+          break;
+      }
+    }
+
     default:
       break;
   }

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -272,10 +272,6 @@ INSTANTIATE_TEST_SUITE_P(
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint ConvertFToU %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float ConvertUToF %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint UConvert %uint64_0"),
-        GOOD_KERNEL_10(
-            "%v = OpSpecConstantOp %_ptr_uint GenericCastToPtr %null"),
-        GOOD_KERNEL_10(
-            "%v = OpSpecConstantOp %_ptr_uint PtrCastToGeneric %null"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %uint Bitcast %uint_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FNegate %float_0"),
         GOOD_KERNEL_10("%v = OpSpecConstantOp %float FAdd %float_0 %float_0"),
@@ -524,6 +520,34 @@ OpMemoryModel Logical GLSL450
       HasSubstr("Expected 32-bit float scalar or vector type as Result Type"));
 }
 
+TEST_F(ValidateConstant, BadCooperativeMatrixLength) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability CooperativeMatrixKHR
+OpCapability VulkanMemoryModelKHR
+OpExtension "SPV_KHR_cooperative_matrix"
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical VulkanKHR
+%uint = OpTypeInt 32 0
+%float = OpTypeFloat 32
+%uint_1 = OpConstant %uint 1
+%uint_8 = OpConstant %uint 8
+%float_1 = OpConstant %float 1
+%subgroup = OpConstant %uint 3
+%use_A = OpConstant %uint 0
+%f16mat = OpTypeCooperativeMatrixKHR %float %subgroup %uint_8 %uint_8 %use_A
+
+%good = OpSpecConstantOp %uint CooperativeMatrixLengthKHR %f16mat
+%bad1 = OpSpecConstantOp %uint CooperativeMatrixLengthKHR %float_1
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_4);
+  ASSERT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_UNIVERSAL_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("must be OpTypeCooperativeMatrixKHR"));
+}
+
 #define BAD_KERNEL_OPERANDS(STR, ERR)                                   \
   {                                                                     \
     SPV_ENV_UNIVERSAL_1_0, kKernelPreamble kBasicTypes STR, false, ERR, \
@@ -720,7 +744,118 @@ INSTANTIATE_TEST_SUITE_P(
             "Expected int scalar or vector type as Result Type"),
         BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint Not %float_0",
                             "Expected int scalar or vector as operand"),
-    }));
+
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalOr %true %false",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalOr %true %uint_0",
+            "Expected both operands to be of Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalAnd %true %false",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalAnd %true %uint_0",
+            "Expected both operands to be of Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalEqual %true %false",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalEqual %true %uint_0",
+            "Expected both operands to be of Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalNotEqual %true %false",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool LogicalNotEqual %uint_0 %false",
+            "Expected both operands to be of Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float LogicalNot %true",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %bool LogicalNot %uint_0",
+                            "Expected operand to be of Result Type"),
+
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float Select %true %uint_0 %uint_0",
+            "Expected both objects to be of Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %uint Select %uint_0 %uint_0 %uint_0",
+            "Expected bool scalar or vector type as condition"),
+
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float IEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool IEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float INotEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool INotEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ULessThan %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool ULessThan %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SLessThan %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SLessThan %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float ULessThanEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool ULessThanEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SLessThanEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SLessThanEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float UGreaterThan %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool UGreaterThan %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float UGreaterThanEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool UGreaterThanEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SGreaterThan %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SGreaterThan %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float SGreaterThanEqual %uint_0 %uint_0",
+            "Expected bool scalar or vector type as Result Type"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %bool SGreaterThanEqual %uint_0 %float_0",
+            "Expected operands to be scalar or vector int"),
+
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float GenericCastToPtr %null",
+            "Expected Result Type to be a pointer"),
+        BAD_KERNEL_OPERANDS(
+            "%v = OpSpecConstantOp %float PtrCastToGeneric %null",
+            "Expected Result Type to be a pointer"),
+
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %bool Bitcast %uint_0",
+                            "Expected Result Type to be a pointer or int or "
+                            "float vector or scalar type"),
+        BAD_KERNEL_OPERANDS("%v = OpSpecConstantOp %uint Bitcast %true",
+                            "Expected input to be a pointer or int or float "
+                            "vector or scalar")}));
 
 }  // namespace
 }  // namespace val


### PR DESCRIPTION
All is left after for https://github.com/KhronosGroup/SPIRV-Tools/issues/6564 is the VectorShuffle/CompositeInsert/CompositeExtract and the AccessChains, these will need some more changes to passing in the operand index, so saving them for last
