### PR TITLE
spirv-val: Add missing SPV_EXT_descriptor_indexing caps

### DIFF
--- a/source/val/validate_capability.cpp
+++ b/source/val/validate_capability.cpp
@@ -212,6 +212,8 @@ bool IsSupportOptionalVulkan_1_2(uint32_t capability) {
     case spv::Capability::InputAttachmentArrayNonUniformIndexing:
     case spv::Capability::UniformTexelBufferArrayNonUniformIndexing:
     case spv::Capability::StorageTexelBufferArrayNonUniformIndexing:
+    case spv::Capability::InputAttachmentArrayDynamicIndexing:
+    case spv::Capability::ShaderNonUniform:
       return true;
     default:
       break;

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -3481,6 +3481,52 @@ OpFunctionEnd
                         "capabilities: TileImageStencilReadAccessEXT"));
 }
 
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11860#issuecomment-4047435834
+TEST_F(ValidateCapability, InputAttachmentArrayDynamicIndexingVulkan12) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability InputAttachment
+               OpCapability InputAttachmentArrayDynamicIndexing
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %color %xs
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %color Location 0
+               OpDecorate %xs Binding 0
+               OpDecorate %xs DescriptorSet 0
+               OpDecorate %xs InputAttachmentIndex 0
+               OpDecorate %index SpecId 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %color = OpVariable %_ptr_Output_v4float Output
+         %11 = OpTypeImage %float SubpassData 0 0 0 2 Unknown
+       %uint = OpTypeInt 32 0
+     %uint_4 = OpConstant %uint 4
+%_arr_11_uint_4 = OpTypeArray %11 %uint_4
+%_ptr_UniformConstant__arr_11_uint_4 = OpTypePointer UniformConstant %_arr_11_uint_4
+         %xs = OpVariable %_ptr_UniformConstant__arr_11_uint_4 UniformConstant
+        %int = OpTypeInt 32 1
+      %index = OpSpecConstant %int 3
+%_ptr_UniformConstant_11 = OpTypePointer UniformConstant %11
+      %int_0 = OpConstant %int 0
+      %v2int = OpTypeVector %int 2
+         %24 = OpConstantComposite %v2int %int_0 %int_0
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+         %20 = OpAccessChain %_ptr_UniformConstant_11 %xs %index
+         %21 = OpLoad %11 %20
+         %25 = OpImageRead %v4float %21 %24
+               OpStore %color %25
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
(from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11860) Adds two missing `SPV_EXT_descriptor_indexing` from being allowed in Vulkan1.2