### PR TITLE
spirv-opt: Add extensions to the allow list

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -1162,6 +1162,9 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
+      "SPV_EXT_shader_atomic_float16_add",
+      "SPV_KHR_abort",
+      "SPV_KHR_constant_data",
   });
 }
 

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -473,6 +473,9 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
+      "SPV_EXT_shader_atomic_float16_add",
+      "SPV_KHR_abort",
+      "SPV_KHR_constant_data",
   });
 }
 

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -310,6 +310,9 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
+      "SPV_EXT_shader_atomic_float16_add",
+      "SPV_KHR_abort",
+      "SPV_KHR_constant_data",
   });
 }
 

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -162,6 +162,9 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
+      "SPV_EXT_shader_atomic_float16_add",
+      "SPV_KHR_abort",
+      "SPV_KHR_constant_data",
   });
 }
 bool LocalSingleStoreElimPass::ProcessVariable(Instruction* var_inst) {


### PR DESCRIPTION
Adds SPV_EXT_shader_atomic_float16_add, SPV_KHR_abort, and
SPV_KHR_constant_data to the allow lists.

Fixes #6486
