### PR TITLE
spirv-val: Check output location uniqueness per-stream for GeometryStreams

### DIFF
--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -551,12 +551,22 @@ spv_result_t ValidateLocations(ValidationState_t& _,
       return SPV_SUCCESS;
   }
 
+  const bool is_geometry =
+      entry_point->GetOperandAs<spv::ExecutionModel>(0) ==
+      spv::ExecutionModel::Geometry;
+  const bool has_geometry_streams =
+      is_geometry && _.HasCapability(spv::Capability::GeometryStreams);
+
   // Locations are stored as a combined location and component values.
   std::unordered_set<uint32_t> input_locations;
   std::unordered_set<uint32_t> output_locations_index0;
   std::unordered_set<uint32_t> output_locations_index1;
   std::unordered_set<uint32_t> patch_locations_index0;
   std::unordered_set<uint32_t> patch_locations_index1;
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>>
+      output_locations_per_stream;
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>>
+      output_index1_locations_per_stream;
   std::unordered_set<uint32_t> seen;
   for (uint32_t i = 3; i < entry_point->operands().size(); ++i) {
     auto interface_id = entry_point->GetOperandAs<uint32_t>(i);
@@ -594,12 +604,31 @@ spv_result_t ValidateLocations(ValidationState_t& _,
       continue;
     }
 
-    auto locations = (storage_class == spv::StorageClass::Input)
-                         ? &input_locations
-                         : &output_locations_index0;
-    if (auto error = GetLocationsForVariable(
-            _, entry_point, interface_var, locations, &output_locations_index1))
-      return error;
+    // For geometry shader outputs with GeometryStreams,
+    // use per-stream location sets since each stream
+    // has an independent location namespace.
+    if (has_geometry_streams && storage_class == spv::StorageClass::Output) {
+      uint32_t stream = 0;
+      for (auto& dec : _.id_decorations(interface_var->id())) {
+        if (dec.dec_type() == spv::Decoration::Stream) {
+          stream = dec.params()[0];
+          break;
+        }
+      }
+      if (auto error = GetLocationsForVariable(
+              _, entry_point, interface_var,
+              &output_locations_per_stream[stream],
+              &output_index1_locations_per_stream[stream]))
+        return error;
+    } else {
+      auto locations = (storage_class == spv::StorageClass::Input)
+                           ? &input_locations
+                           : &output_locations_index0;
+      if (auto error = GetLocationsForVariable(
+              _, entry_point, interface_var, locations,
+              &output_locations_index1))
+        return error;
+    }
   }
 
   return SPV_SUCCESS;

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -551,9 +551,8 @@ spv_result_t ValidateLocations(ValidationState_t& _,
       return SPV_SUCCESS;
   }
 
-  const bool is_geometry =
-      entry_point->GetOperandAs<spv::ExecutionModel>(0) ==
-      spv::ExecutionModel::Geometry;
+  const bool is_geometry = entry_point->GetOperandAs<spv::ExecutionModel>(0) ==
+                           spv::ExecutionModel::Geometry;
   const bool has_geometry_streams =
       is_geometry && _.HasCapability(spv::Capability::GeometryStreams);
 
@@ -624,9 +623,9 @@ spv_result_t ValidateLocations(ValidationState_t& _,
       auto locations = (storage_class == spv::StorageClass::Input)
                            ? &input_locations
                            : &output_locations_index0;
-      if (auto error = GetLocationsForVariable(
-              _, entry_point, interface_var, locations,
-              &output_locations_index1))
+      if (auto error =
+              GetLocationsForVariable(_, entry_point, interface_var, locations,
+                                      &output_locations_index1))
         return error;
     }
   }

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -798,10 +798,9 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-08721"));
-  EXPECT_THAT(
-      getDiagnosticString(),
-      HasSubstr("Entry-point has conflicting input location assignment "
-                "at location 1"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Entry-point has conflicting input location assignment "
+                        "at location 1"));
 }
 
 TEST_F(ValidateInterfacesTest, VulkanPatchAndNonPatchOverlap) {

--- a/test/val/val_interfaces_test.cpp
+++ b/test/val/val_interfaces_test.cpp
@@ -624,6 +624,186 @@ OpFunctionEnd
                 "at location 1"));
 }
 
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsGeometryStreamsDifferentStreamsSameLocation) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Geometry
+OpCapability GeometryStreams
+OpMemoryModel Logical GLSL450
+OpEntryPoint Geometry %main "main" %var1 %var2
+OpExecutionMode %main Triangles
+OpExecutionMode %main OutputPoints
+OpExecutionMode %main OutputVertices 1
+OpDecorate %var1 Location 1
+OpDecorate %var1 Stream 0
+OpDecorate %var2 Location 1
+OpDecorate %var2 Stream 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%ptr_output_float = OpTypePointer Output %float
+%var1 = OpVariable %ptr_output_float Output
+%var2 = OpVariable %ptr_output_float Output
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+}
+
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsGeometryStreamsSameStreamSameLocationConflict) {
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Geometry
+OpCapability GeometryStreams
+OpMemoryModel Logical GLSL450
+OpEntryPoint Geometry %main "main" %var1 %var2
+OpExecutionMode %main Triangles
+OpExecutionMode %main OutputPoints
+OpExecutionMode %main OutputVertices 1
+OpDecorate %var1 Location 1
+OpDecorate %var1 Stream 1
+OpDecorate %var2 Location 1
+OpDecorate %var2 Stream 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%ptr_output_float = OpTypePointer Output %float
+%var1 = OpVariable %ptr_output_float Output
+%var2 = OpVariable %ptr_output_float Output
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-08722"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Entry-point has conflicting output location assignment "
+                "at location 1"));
+}
+
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsGeometryStreamsComponentSharingAcrossStreams) {
+  // Same location and component on different streams must not conflict.
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Geometry
+OpCapability GeometryStreams
+OpMemoryModel Logical GLSL450
+OpEntryPoint Geometry %main "main" %var1 %var2
+OpExecutionMode %main Triangles
+OpExecutionMode %main OutputPoints
+OpExecutionMode %main OutputVertices 1
+OpDecorate %var1 Location 1
+OpDecorate %var1 Component 0
+OpDecorate %var1 Stream 0
+OpDecorate %var2 Location 1
+OpDecorate %var2 Component 0
+OpDecorate %var2 Stream 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%ptr_output_float = OpTypePointer Output %float
+%var1 = OpVariable %ptr_output_float Output
+%var2 = OpVariable %ptr_output_float Output
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+}
+
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsGeometryNoStreamsCapStillConflicts) {
+  // Without the GeometryStreams capability the per-stream relaxation must not
+  // apply: a Geometry shader with two outputs at the same location still
+  // conflicts, same as any other stage.
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Geometry
+OpMemoryModel Logical GLSL450
+OpEntryPoint Geometry %main "main" %var1 %var2
+OpExecutionMode %main Triangles
+OpExecutionMode %main OutputPoints
+OpExecutionMode %main OutputVertices 1
+OpDecorate %var1 Location 1
+OpDecorate %var2 Location 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%ptr_output_float = OpTypePointer Output %float
+%var1 = OpVariable %ptr_output_float Output
+%var2 = OpVariable %ptr_output_float Output
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-08722"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Entry-point has conflicting output location assignment "
+                "at location 1"));
+}
+
+TEST_F(ValidateInterfacesTest,
+       VulkanLocationsGeometryStreamsInputStillConflicts) {
+  // The per-stream relaxation only applies to the Output storage class.
+  // Input variables in a Geometry+GeometryStreams entry point must still
+  // have unique locations.
+  const std::string text = R"(
+OpCapability Shader
+OpCapability Geometry
+OpCapability GeometryStreams
+OpMemoryModel Logical GLSL450
+OpEntryPoint Geometry %main "main" %var1 %var2
+OpExecutionMode %main InputPoints
+OpExecutionMode %main OutputPoints
+OpExecutionMode %main OutputVertices 1
+OpDecorate %var1 Location 1
+OpDecorate %var2 Location 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%uint = OpTypeInt 32 0
+%uint_1 = OpConstant %uint 1
+%arr_float = OpTypeArray %float %uint_1
+%ptr_input_arr = OpTypePointer Input %arr_float
+%var1 = OpVariable %ptr_input_arr Input
+%var2 = OpVariable %ptr_input_arr Input
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpEntryPoint-08721"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Entry-point has conflicting input location assignment "
+                "at location 1"));
+}
+
 TEST_F(ValidateInterfacesTest, VulkanPatchAndNonPatchOverlap) {
   const std::string text = R"(
                OpCapability Tessellation


### PR DESCRIPTION
The VK_EXT_transform_feedback extension exists specifically to support translation layers from other 3D APIs. In D3D's stream output model, all four geometry streams share the same 32 output registers. When a vertex is emitted on any stream, the current register values go to that stream's buffer and all registers become undefined.

SPIR-V's current location uniqueness rule prevents this by requiring globally-unique locations across all output variables, forcing translation layers to use unique locations per stream. This exhausts maxGeometryOutputComponents (typically 128) at just eight vec4's per stream instead of the 32 that D3D supports.

Relax the location uniqueness check for geometry shader outputs when GeometryStreams capability is present, allowing variables on different streams to share the same location. This matches the D3D hardware model where streams alias the same register file.

Add tests for per-stream output location uniqueness:
- Different streams at the same location pass.
- Same stream at the same location still conflicts (VUID 08722).
- Component-sharing across streams is allowed.
- Without the GeometryStreams capability, duplicate output locations
  in a Geometry shader still conflict.
- Input variables in a Geometry+GeometryStreams entry point still
  require unique locations (VUID 08721).