### PR TITLE
spirv-val: Do not require type on untyped def instructions

### DIFF
--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -221,7 +221,8 @@ spv_result_t IdPass(ValidationState_t& _, Instruction* inst) {
                    << " cannot be a type";
           } else if (def->type_id() == 0 &&
                      !spvOpcodeGeneratesType(def->opcode()) &&
-                     InstructionRequiresTypeOperand(inst)) {
+                     InstructionRequiresTypeOperand(inst) &&
+                     InstructionRequiresTypeOperand(def)) {
             return _.diag(SPV_ERROR_INVALID_ID, inst)
                    << "Operand " << _.getIdName(operand_word)
                    << " requires a type";

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -7277,6 +7277,34 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_P(ValidateIdWithMessage,
+       OpLoadStoreWithAliasScopeINTELMaskMemoryOperands) {
+  std::string spirv = R"(
+     OpCapability Shader
+     OpCapability MemoryAccessAliasingINTEL
+     OpExtension "SPV_INTEL_memory_access_aliasing"
+     OpMemoryModel Logical GLSL450
+     OpEntryPoint Fragment %main "main"
+     OpExecutionMode %main OriginUpperLeft
+%alias_domain = OpAliasDomainDeclINTEL
+%alias_scope = OpAliasScopeDeclINTEL %alias_domain
+%alias_list = OpAliasScopeListDeclINTEL %alias_scope
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%ptr_uint = OpTypePointer Function %uint
+%func_type = OpTypeFunction %void
+%main = OpFunction %void None %func_type
+%entry = OpLabel
+%var = OpVariable %ptr_uint Function
+%val = OpLoad %uint %var Aligned|AliasScopeINTELMask 4 %alias_list
+OpStore %var %val Aligned|NoAliasINTELMask 4 %alias_list
+OpReturn
+OpFunctionEnd
+)";
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_P(ValidateIdWithMessage, OpDecorateIdAfterAliasScopeListDeclINTEL) {
   std::string spirv = R"(
      OpCapability Shader


### PR DESCRIPTION
The "requires a type" check in IdPass only considered whether the using instruction expects typed operands, not whether the def instruction is legitimately untyped. Instructions like OpAliasScopeListDeclINTEL, OpAliasScopeDeclINTEL, and OpAliasDomainDeclINTEL intentionally have no result type, so they should not trigger the error when referenced by other instructions

Required for 2 tests in https://github.com/llvm/llvm-project/issues/190736 (IR is legit, but spirv-val rejects it):
 - https://github.com/llvm/llvm-project/blob/6dbf9d1ac5e68ec6811e6b05c67f12fda07f62e3/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store-struct.ll
 - https://github.com/llvm/llvm-project/blob/6dbf9d1ac5e68ec6811e6b05c67f12fda07f62e3/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_memory_access_aliasing/alias-load-store.ll