### PR TITLE
Add validation for NSDI 101

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -678,9 +678,27 @@ cc_library(
     ["test/val/val_*_test.cpp"],
     exclude = [
         "test/val/val_capability_test.cpp",
+        "test/val/val_ext_inst_debug_test.cpp",
         "test/val/val_limits_test.cpp",
     ],
 )]
+
+cc_test(
+    name = "val_ext_inst_debug_test",
+    size = "small",
+    srcs = ["test/val/val_ext_inst_debug_test.cpp"],
+    copts = TEST_COPTS,
+    linkstatic = 1,
+    deps = [
+        ":spirv_tools_internal",
+        ":test_lib",
+        ":val_test_lib",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@spirv_headers//:spirv_common_headers",
+        "@spirv_headers//:spirv_cpp11_headers",
+    ],
+)
 
 cc_test(
     name = "val_capability_test",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,7 +52,7 @@ create_grammar_tables_target(
         ExtInst("glsl.std.450", target="spirv_glsl_grammar_unified1"),
         ExtInst("opencl.std.100", target="spirv_opencl_grammar_unified1"),
         ExtInst("opencl.debuginfo.100", prefix="CLDEBUG100_"),
-        ExtInst("nonsemantic.shader.debuginfo.100", prefix="SHDEBUG100_"),
+        ExtInst("nonsemantic.shader.debuginfo", prefix="SHDEBUG100_"),
         ExtInst("tosa.001000.1", target="spirv_ext_inst_tosa_001000_1", prefix="TOSA_"),
         ExtInst("arm.motion-engine.100", target="spirv_ext_inst_arm_motion_engine_100"),
     ] + [ExtInst(e) for e in [

--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': '972a15cedd008d846f1a39b2e88ce48d7f166cbd',
 
-  'spirv_headers_revision': '6dd7ba990830f7c15ac1345ff3b43ef6ffdad216',
+  'spirv_headers_revision': '869266ad9e6050197d87cf0a22aab59abf7ad008',
 
   'mimalloc_revision': '75d69f4ab736ad9f56cdd76c7eb883f60ac48869',
 }

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -28,7 +28,7 @@ set(EI_amd_evp "${GRAMMAR_DIR}/extinst.spv-amd-shader-explicit-vertex-parameter.
 set(EI_amd_trimm "${GRAMMAR_DIR}/extinst.spv-amd-shader-trinary-minmax.grammar.json")
 set(EI_amd_gcn "${GRAMMAR_DIR}/extinst.spv-amd-gcn-shader.grammar.json")
 set(EI_amd_ballot "${GRAMMAR_DIR}/extinst.spv-amd-shader-ballot.grammar.json")
-set(EI_ns_debuginfo "${GRAMMAR_DIR}/extinst.nonsemantic.shader.debuginfo.100.grammar.json")
+set(EI_ns_debuginfo "${GRAMMAR_DIR}/extinst.nonsemantic.shader.debuginfo.grammar.json")
 set(EI_ns_clspvreflect "${GRAMMAR_DIR}/extinst.nonsemantic.clspvreflection.grammar.json")
 set(EI_ns_vkspreflect "${GRAMMAR_DIR}/extinst.nonsemantic.vkspreflection.grammar.json")
 set(EI_tosa_001000_1 "${GRAMMAR_DIR}/extinst.tosa.001000.1.grammar.json")
@@ -104,7 +104,6 @@ endmacro(spvtools_extinst_lang_headers)
 
 spvtools_extinst_lang_headers("DebugInfo" ${EI_debuginfo})
 spvtools_extinst_lang_headers("OpenCLDebugInfo100" ${EI_cldebuginfo})
-spvtools_extinst_lang_headers("NonSemanticShaderDebugInfo100" ${EI_ns_debuginfo})
 
 spvtools_vimsyntax("unified1" "1.0")
 add_custom_target(spirv-tools-vimsyntax DEPENDS ${VIMSYNTAX_FILE})

--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -295,7 +295,7 @@ Pass::Status AggressiveDCEPass::ProcessDebugInformation(
       if (!inst->IsNonSemanticInstruction()) return true;
 
       if (inst->GetShaderDebugOpcode() ==
-          NonSemanticShaderDebugInfo100DebugDeclare) {
+          NonSemanticShaderDebugInfoDebugDeclare) {
         if (IsLive(inst)) return true;
 
         uint32_t var_id =
@@ -333,7 +333,7 @@ Pass::Status AggressiveDCEPass::ProcessDebugInformation(
           return true;
         });
       } else if (inst->GetShaderDebugOpcode() ==
-                 NonSemanticShaderDebugInfo100DebugValue) {
+                 NonSemanticShaderDebugInfoDebugValue) {
         uint32_t var_operand_idx = kDebugValueValueInIdx;
         uint32_t id = inst->GetSingleWordInOperand(var_operand_idx);
         auto def = get_def_use_mgr()->GetDef(id);
@@ -762,13 +762,13 @@ Pass::Status AggressiveDCEPass::InitializeModuleScopeLiveInstructions() {
   // Add DebugInfo which should never be eliminated to worklist
   for (auto& dbg : get_module()->ext_inst_debuginfo()) {
     auto op = dbg.GetShaderDebugOpcode();
-    if (op == NonSemanticShaderDebugInfo100DebugCompilationUnit ||
-        op == NonSemanticShaderDebugInfo100DebugEntryPoint ||
-        op == NonSemanticShaderDebugInfo100DebugSource ||
-        op == NonSemanticShaderDebugInfo100DebugSourceContinued ||
-        op == NonSemanticShaderDebugInfo100DebugLocalVariable ||
-        op == NonSemanticShaderDebugInfo100DebugExpression ||
-        op == NonSemanticShaderDebugInfo100DebugOperation) {
+    if (op == NonSemanticShaderDebugInfoDebugCompilationUnit ||
+        op == NonSemanticShaderDebugInfoDebugEntryPoint ||
+        op == NonSemanticShaderDebugInfoDebugSource ||
+        op == NonSemanticShaderDebugInfoDebugSourceContinued ||
+        op == NonSemanticShaderDebugInfoDebugLocalVariable ||
+        op == NonSemanticShaderDebugInfoDebugExpression ||
+        op == NonSemanticShaderDebugInfoDebugOperation) {
       AddToWorklist(&dbg);
     }
   }
@@ -1018,7 +1018,7 @@ bool AggressiveDCEPass::ProcessGlobalValues() {
     }
     // Save debug build identifier even if no other instructions refer to it.
     if (dbg.GetShaderDebugOpcode() ==
-        NonSemanticShaderDebugInfo100DebugBuildIdentifier) {
+        NonSemanticShaderDebugInfoDebugBuildIdentifier) {
       // The debug build identifier refers to other instructions that
       // can potentially be removed, they also need to be kept alive.
       dbg.ForEachInId([this](const uint32_t* id) {

--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -118,13 +118,13 @@ void DebugInfoManager::RegisterDbgFunction(Instruction* inst) {
         "Register DebugFunction for a function that already has DebugFunction");
     fn_id_to_dbg_fn_[fn_id] = inst;
   } else if (inst->GetShaderDebugOpcode() ==
-             NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+             NonSemanticShaderDebugInfoDebugFunctionDefinition) {
     auto fn_id = inst->GetSingleWordOperand(
         kDebugFunctionDefinitionOperandOpFunctionIndex);
     auto fn_inst = GetDbgInst(inst->GetSingleWordOperand(
         kDebugFunctionDefinitionOperandDebugFunctionIndex));
     assert(fn_inst && fn_inst->GetShaderDebugOpcode() ==
-                          NonSemanticShaderDebugInfo100DebugFunction);
+                          NonSemanticShaderDebugInfoDebugFunction);
     assert(fn_id_to_dbg_fn_.find(fn_id) == fn_id_to_dbg_fn_.end() &&
            "Register DebugFunctionDefinition for a function that already has "
            "DebugFunctionDefinition");
@@ -214,7 +214,7 @@ uint32_t DebugInfoManager::CreateDebugInlinedAt(const Instruction* line,
     if (line->opcode() == spv::Op::OpLine) {
       line_number = line->GetSingleWordOperand(kOpLineOperandLineIndex);
     } else if (line->GetShaderDebugOpcode() ==
-               NonSemanticShaderDebugInfo100DebugLine) {
+               NonSemanticShaderDebugInfoDebugLine) {
       line_number = line->GetSingleWordOperand(kLineOperandIndexDebugLine);
     } else {
       assert(false &&
@@ -346,18 +346,17 @@ Instruction* DebugInfoManager::GetDebugOperationWithDeref() {
         }));
   } else {
     uint32_t deref_id = context()->get_constant_mgr()->GetUIntConstId(
-        NonSemanticShaderDebugInfo100Deref);
+        NonSemanticShaderDebugInfoDeref);
 
-    deref_operation = std::unique_ptr<Instruction>(
-        new Instruction(context(), spv::Op::OpExtInst,
-                        context()->get_type_mgr()->GetVoidTypeId(), result_id,
-                        {
-                            {SPV_OPERAND_TYPE_ID, {GetDbgSetImportId()}},
-                            {SPV_OPERAND_TYPE_EXTENSION_INSTRUCTION_NUMBER,
-                             {static_cast<uint32_t>(
-                                 NonSemanticShaderDebugInfo100DebugOperation)}},
-                            {SPV_OPERAND_TYPE_ID, {deref_id}},
-                        }));
+    deref_operation = std::unique_ptr<Instruction>(new Instruction(
+        context(), spv::Op::OpExtInst,
+        context()->get_type_mgr()->GetVoidTypeId(), result_id,
+        {
+            {SPV_OPERAND_TYPE_ID, {GetDbgSetImportId()}},
+            {SPV_OPERAND_TYPE_EXTENSION_INSTRUCTION_NUMBER,
+             {static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugOperation)}},
+            {SPV_OPERAND_TYPE_ID, {deref_id}},
+        }));
   }
 
   // Add to the front of |ext_inst_debuginfo_|.
@@ -614,7 +613,7 @@ Instruction* DebugInfoManager::AddDebugValueForDecl(Instruction* dbg_decl,
 
 uint32_t DebugInfoManager::GetVulkanDebugOperation(Instruction* inst) {
   assert(inst->GetShaderDebugOpcode() ==
-             NonSemanticShaderDebugInfo100DebugOperation &&
+             NonSemanticShaderDebugInfoDebugOperation &&
          "inst must be Vulkan DebugOperation");
   return context()
       ->get_constant_mgr()
@@ -645,7 +644,7 @@ uint32_t DebugInfoManager::GetVariableIdOfDebugValueUsedForDeclare(
     }
   } else {
     uint32_t operation_const = GetVulkanDebugOperation(operation);
-    if (operation_const != NonSemanticShaderDebugInfo100Deref) {
+    if (operation_const != NonSemanticShaderDebugInfoDeref) {
       return 0;
     }
   }
@@ -723,7 +722,7 @@ void DebugInfoManager::AnalyzeDebugInst(Instruction* inst) {
 
   if (inst->GetOpenCL100DebugOpcode() == OpenCLDebugInfo100DebugFunction ||
       inst->GetShaderDebugOpcode() ==
-          NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+          NonSemanticShaderDebugInfoDebugFunctionDefinition) {
     RegisterDbgFunction(inst);
   }
 
@@ -736,9 +735,9 @@ void DebugInfoManager::AnalyzeDebugInst(Instruction* inst) {
 
   if (deref_operation_ == nullptr &&
       inst->GetShaderDebugOpcode() ==
-          NonSemanticShaderDebugInfo100DebugOperation) {
+          NonSemanticShaderDebugInfoDebugOperation) {
     uint32_t operation_const = GetVulkanDebugOperation(inst);
-    if (operation_const == NonSemanticShaderDebugInfo100Deref) {
+    if (operation_const == NonSemanticShaderDebugInfoDeref) {
       deref_operation_ = inst;
     }
   }
@@ -876,7 +875,7 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
     fn_id_to_dbg_fn_.erase(fn_id);
   }
   if (instr->GetShaderDebugOpcode() ==
-      NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+      NonSemanticShaderDebugInfoDebugFunctionDefinition) {
     auto fn_id = instr->GetSingleWordOperand(
         kDebugFunctionDefinitionOperandOpFunctionIndex);
     fn_id_to_dbg_fn_.erase(fn_id);
@@ -909,9 +908,9 @@ void DebugInfoManager::ClearDebugInfo(Instruction* instr) {
         break;
       } else if (instr != &*dbg_instr_itr &&
                  dbg_instr_itr->GetShaderDebugOpcode() ==
-                     NonSemanticShaderDebugInfo100DebugOperation) {
+                     NonSemanticShaderDebugInfoDebugOperation) {
         uint32_t operation_const = GetVulkanDebugOperation(&*dbg_instr_itr);
-        if (operation_const == NonSemanticShaderDebugInfo100Deref) {
+        if (operation_const == NonSemanticShaderDebugInfoDeref) {
           deref_operation_ = &*dbg_instr_itr;
           break;
         }

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -425,7 +425,7 @@ bool InlinePass::InlineEntryBlock(
     // Don't inline function definition links, the calling function is not a
     // definition.
     if (callee_inst_itr->GetShaderDebugOpcode() ==
-        NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+        NonSemanticShaderDebugInfoDebugFunctionDefinition) {
       ++callee_inst_itr;
       continue;
     }
@@ -463,7 +463,7 @@ std::unique_ptr<BasicBlock> InlinePass::InlineBasicBlocks(
       // Don't inline function definition links, the calling function is not a
       // definition
       if (inst_itr->GetShaderDebugOpcode() ==
-          NonSemanticShaderDebugInfo100DebugFunctionDefinition)
+          NonSemanticShaderDebugInfoDebugFunctionDefinition)
         continue;
       if (!InlineSingleInstruction(
               callee2caller, new_blk_ptr.get(), &*inst_itr,

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -587,23 +587,23 @@ bool Instruction::AddDebugLine(const Instruction* inst) {
 }
 
 bool Instruction::IsDebugLineInst() const {
-  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShaderDebugOpcode();
-  return ((ext_opt == NonSemanticShaderDebugInfo100DebugLine) ||
-          (ext_opt == NonSemanticShaderDebugInfo100DebugNoLine));
+  NonSemanticShaderDebugInfoInstructions ext_opt = GetShaderDebugOpcode();
+  return ((ext_opt == NonSemanticShaderDebugInfoDebugLine) ||
+          (ext_opt == NonSemanticShaderDebugInfoDebugNoLine));
 }
 
 bool Instruction::IsLineInst() const { return IsLine() || IsNoLine(); }
 
 bool Instruction::IsLine() const {
   if (opcode() == spv::Op::OpLine) return true;
-  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShaderDebugOpcode();
-  return ext_opt == NonSemanticShaderDebugInfo100DebugLine;
+  NonSemanticShaderDebugInfoInstructions ext_opt = GetShaderDebugOpcode();
+  return ext_opt == NonSemanticShaderDebugInfoDebugLine;
 }
 
 bool Instruction::IsNoLine() const {
   if (opcode() == spv::Op::OpNoLine) return true;
-  NonSemanticShaderDebugInfo100Instructions ext_opt = GetShaderDebugOpcode();
-  return ext_opt == NonSemanticShaderDebugInfo100DebugNoLine;
+  NonSemanticShaderDebugInfoInstructions ext_opt = GetShaderDebugOpcode();
+  return ext_opt == NonSemanticShaderDebugInfoDebugNoLine;
 }
 
 Instruction* Instruction::InsertBefore(std::unique_ptr<Instruction>&& inst) {
@@ -691,27 +691,27 @@ OpenCLDebugInfo100Instructions Instruction::GetOpenCL100DebugOpcode() const {
       GetSingleWordInOperand(kExtInstInstructionInIdx));
 }
 
-NonSemanticShaderDebugInfo100Instructions Instruction::GetShaderDebugOpcode()
+NonSemanticShaderDebugInfoInstructions Instruction::GetShaderDebugOpcode()
     const {
   if (opcode() != spv::Op::OpExtInst) {
-    return NonSemanticShaderDebugInfo100InstructionsMax;
+    return NonSemanticShaderDebugInfoInstructionsMax;
   }
 
   if (!context()->get_feature_mgr()->GetExtInstImportId_ShaderDebugInfo()) {
-    return NonSemanticShaderDebugInfo100InstructionsMax;
+    return NonSemanticShaderDebugInfoInstructionsMax;
   }
 
   if (GetSingleWordInOperand(kExtInstSetIdInIdx) !=
       context()->get_feature_mgr()->GetExtInstImportId_ShaderDebugInfo()) {
-    return NonSemanticShaderDebugInfo100InstructionsMax;
+    return NonSemanticShaderDebugInfoInstructionsMax;
   }
 
   uint32_t opcode = GetSingleWordInOperand(kExtInstInstructionInIdx);
-  if (opcode >= NonSemanticShaderDebugInfo100InstructionsMax) {
-    return NonSemanticShaderDebugInfo100InstructionsMax;
+  if (opcode >= NonSemanticShaderDebugInfoInstructionsMax) {
+    return NonSemanticShaderDebugInfoInstructionsMax;
   }
 
-  return NonSemanticShaderDebugInfo100Instructions(opcode);
+  return NonSemanticShaderDebugInfoInstructions(opcode);
 }
 
 CommonDebugInfoInstructions Instruction::GetCommonDebugOpcode() const {
@@ -1053,8 +1053,8 @@ bool Instruction::IsOpcodeSafeToDelete() const {
   }
 
   if (IsNonSemanticInstruction() &&
-      (GetShaderDebugOpcode() == NonSemanticShaderDebugInfo100DebugDeclare ||
-       GetShaderDebugOpcode() == NonSemanticShaderDebugInfo100DebugValue)) {
+      (GetShaderDebugOpcode() == NonSemanticShaderDebugInfoDebugDeclare ||
+       GetShaderDebugOpcode() == NonSemanticShaderDebugInfoDebugValue)) {
     return true;
   }
 

--- a/source/opt/instruction.h
+++ b/source/opt/instruction.h
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
 #include "source/binary.h"
 #include "source/common_debug_info.h"
@@ -35,6 +34,7 @@
 #include "source/util/small_vector.h"
 #include "source/util/string_utils.h"
 #include "spirv-tools/libspirv.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo.h"
 
 constexpr uint32_t kNoDebugScope = 0;
 constexpr uint32_t kNoInlinedAt = 0;
@@ -583,8 +583,8 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
 
   // Returns debug opcode of a NonSemantic.Shader.DebugInfo instruction. If
   // it is not a NonSemantic.Shader.DebugInfo instruction, just return
-  // NonSemanticShaderDebugInfo100InstructionsMax.
-  NonSemanticShaderDebugInfo100Instructions GetShaderDebugOpcode() const;
+  // NonSemanticShaderDebugInfoInstructionsMax.
+  NonSemanticShaderDebugInfoInstructions GetShaderDebugOpcode() const;
 
   // Returns debug opcode of an OpenCL.100.DebugInfo or
   // NonSemantic.Shader.DebugInfo instruction. Since these overlap, we
@@ -598,8 +598,7 @@ class Instruction : public utils::IntrusiveNodeBase<Instruction> {
 
   // Returns true if it is a NonSemantic.Shader.DebugInfo instruction.
   bool IsShaderDebugInstr() const {
-    return GetShaderDebugOpcode() !=
-           NonSemanticShaderDebugInfo100InstructionsMax;
+    return GetShaderDebugOpcode() != NonSemanticShaderDebugInfoInstructionsMax;
   }
   bool IsCommonDebugInstr() const {
     return GetCommonDebugOpcode() != CommonDebugInfoInstructionsMax;

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -46,10 +46,10 @@ bool IsLineInst(const spv_parsed_instruction_t* inst) {
   if (inst->ext_inst_type != SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100)
     return false;
   const uint32_t ext_inst_index = inst->words[kExtInstSetIndex];
-  const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-      NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
-  return ext_inst_key == NonSemanticShaderDebugInfo100DebugLine ||
-         ext_inst_key == NonSemanticShaderDebugInfo100DebugNoLine;
+  const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+      NonSemanticShaderDebugInfoInstructions(ext_inst_index);
+  return ext_inst_key == NonSemanticShaderDebugInfoDebugLine ||
+         ext_inst_key == NonSemanticShaderDebugInfoDebugNoLine;
 }
 
 bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
@@ -306,14 +306,14 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           }
         } else if (inst->ext_inst_type ==
                    SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-          const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-              NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
+          const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+              NonSemanticShaderDebugInfoInstructions(ext_inst_index);
           switch (ext_inst_key) {
-            case NonSemanticShaderDebugInfo100DebugDeclare:
-            case NonSemanticShaderDebugInfo100DebugValue:
-            case NonSemanticShaderDebugInfo100DebugScope:
-            case NonSemanticShaderDebugInfo100DebugNoScope:
-            case NonSemanticShaderDebugInfo100DebugFunctionDefinition: {
+            case NonSemanticShaderDebugInfoDebugDeclare:
+            case NonSemanticShaderDebugInfoDebugValue:
+            case NonSemanticShaderDebugInfoDebugScope:
+            case NonSemanticShaderDebugInfoDebugNoScope:
+            case NonSemanticShaderDebugInfoDebugFunctionDefinition: {
               if (block_ == nullptr) {  // Inside function but outside blocks
                 Errorf(consumer_, src, loc,
                        "Debug info extension instruction found inside function "

--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -951,7 +951,7 @@ bool MergeReturnPass::CreateSingleCaseSwitch(BasicBlock* merge_target) {
   // after OpVariable inst, we have to traverse the whole block to find it.
   for (auto pos = old_block->begin(); pos != old_block->end(); ++pos) {
     if (pos->GetShaderDebugOpcode() ==
-        NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+        NonSemanticShaderDebugInfoDebugFunctionDefinition) {
       start_block->AddInstruction(MakeUnique<Instruction>(*pos));
       pos.Erase();
       break;

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -195,7 +195,7 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
           binary->push_back(context()->get_type_mgr()->GetVoidTypeId());
           binary->push_back(context()->TakeNextId());
           binary->push_back(shader_set_id);
-          binary->push_back(NonSemanticShaderDebugInfo100DebugNoLine);
+          binary->push_back(NonSemanticShaderDebugInfoDebugNoLine);
         } else {
           binary->push_back((1 << 16) |
                             static_cast<uint16_t>(spv::Op::OpNoLine));

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
 #include "source/common_debug_info.h"
 #include "source/extensions.h"
@@ -34,6 +33,7 @@
 #include "source/val/validation_state.h"
 #include "spirv-tools/libspirv.h"
 #include "spirv/unified1/NonSemanticClspvReflection.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo.h"
 
 namespace spvtools {
 namespace val {
@@ -164,6 +164,33 @@ spv_result_t ValidateUint32ConstantOperandForDebugInfo(
   return SPV_SUCCESS;
 }
 
+// For NonSemantic.Shader.DebugInfo.101 cooperative type instructions, check
+// that the operand of |inst| at |word_index| is a result id of a 32-bit
+// unsigned integer constant instruction.  Unlike
+// ValidateUint32ConstantOperandForDebugInfo, this function accepts both
+// OpConstant and OpSpecConstant.  The SPIR-V cooperative types
+// (OpTypeCooperativeVectorEXT, OpTypeCooperativeMatrixKHR) allow
+// specialization constants for their dimension parameters, and the debug type
+// instructions must mirror that.
+spv_result_t ValidateUint32ConstOrSpecConstOperandForDebugInfo(
+    ValidationState_t& _, const std::string& operand_name,
+    const Instruction* inst, uint32_t word_index) {
+  const uint32_t id = inst->word(word_index);
+  const auto* def = _.FindDef(id);
+  if (!def || !spvOpcodeIsConstant(def->opcode())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << GetExtInstName(_, inst) << ": expected operand " << operand_name
+           << " must be a result id of a constant or specialization constant"
+              " instruction";
+  }
+  if (!IsIntScalar(_, def->type_id(), true, true)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << GetExtInstName(_, inst) << ": expected operand " << operand_name
+           << " must be a 32-bit unsigned integer type";
+  }
+  return SPV_SUCCESS;
+}
+
 #define CHECK_OPERAND(NAME, opcode, index)                                   \
   do {                                                                       \
     auto result = ValidateOperandForDebugInfo(_, NAME, opcode, inst, index); \
@@ -175,6 +202,16 @@ spv_result_t ValidateUint32ConstantOperandForDebugInfo(
     auto result =                                                        \
         ValidateUint32ConstantOperandForDebugInfo(_, NAME, inst, index); \
     if (result != SPV_SUCCESS) return result;                            \
+  }
+
+// Like CHECK_CONST_UINT_OPERAND but also allows OpSpecConstant.  Used for
+// NonSemantic.Shader.DebugInfo.101 cooperative type instructions, where
+// dimension operands may be specialization constants.
+#define CHECK_CONST_OR_SPEC_UINT_OPERAND(NAME, index)                        \
+  if (vulkanDebugInfo) {                                                      \
+    auto result = ValidateUint32ConstOrSpecConstOperandForDebugInfo(          \
+        _, NAME, inst, index);                                                \
+    if (result != SPV_SUCCESS) return result;                                 \
   }
 
 // True if the operand of a debug info instruction |inst| at |word_index|
@@ -196,10 +233,10 @@ bool DoesDebugInfoOperandMatchExpectation(
   return true;
 }
 
-// Overload for NonSemanticShaderDebugInfo100Instructions.
+// Overload for NonSemanticShaderDebugInfoInstructions.
 bool DoesDebugInfoOperandMatchExpectation(
     const ValidationState_t& _,
-    const std::function<bool(NonSemanticShaderDebugInfo100Instructions)>&
+    const std::function<bool(NonSemanticShaderDebugInfoInstructions)>&
         expectation,
     const Instruction* inst, uint32_t word_index) {
   if (inst->words().size() <= word_index) return false;
@@ -208,7 +245,7 @@ bool DoesDebugInfoOperandMatchExpectation(
       (debug_inst->ext_inst_type() !=
        SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) ||
       !expectation(
-          NonSemanticShaderDebugInfo100Instructions(debug_inst->word(4)))) {
+          NonSemanticShaderDebugInfoInstructions(debug_inst->word(4)))) {
     return false;
   }
   return true;
@@ -289,12 +326,15 @@ spv_result_t ValidateOperandDebugType(ValidationState_t& _,
                                       const Instruction* inst,
                                       uint32_t word_index,
                                       bool allow_template_param) {
-  // Check for NonSemanticShaderDebugInfo100 specific types.
+  // Check for NonSemanticShaderDebugInfo specific types.
   if (inst->ext_inst_type() ==
       SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-    std::function<bool(NonSemanticShaderDebugInfo100Instructions)> expectation =
-        [](NonSemanticShaderDebugInfo100Instructions dbg_inst) {
-          return dbg_inst == NonSemanticShaderDebugInfo100DebugTypeMatrix;
+    std::function<bool(NonSemanticShaderDebugInfoInstructions)> expectation =
+        [](NonSemanticShaderDebugInfoInstructions dbg_inst) {
+          return dbg_inst == NonSemanticShaderDebugInfoDebugTypeMatrix ||
+                 dbg_inst == NonSemanticShaderDebugInfoDebugTypeVectorIdEXT ||
+                 dbg_inst ==
+                     NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR;
         };
     if (DoesDebugInfoOperandMatchExpectation(_, expectation, inst, word_index))
       return SPV_SUCCESS;
@@ -1086,10 +1126,10 @@ spv_result_t ValidateClspvReflectionInstruction(ValidationState_t& _,
 
 std::string GetDebugSourceText(ValidationState_t& _, const Instruction* inst,
                                uint32_t ext_inst_opcode) {
-  assert(ext_inst_opcode == NonSemanticShaderDebugInfo100DebugSource ||
-         ext_inst_opcode == NonSemanticShaderDebugInfo100DebugSourceContinued);
+  assert(ext_inst_opcode == NonSemanticShaderDebugInfoDebugSource ||
+         ext_inst_opcode == NonSemanticShaderDebugInfoDebugSourceContinued);
   const uint32_t string_operand =
-      (ext_inst_opcode == NonSemanticShaderDebugInfo100DebugSource) ? 6 : 5;
+      (ext_inst_opcode == NonSemanticShaderDebugInfoDebugSource) ? 6 : 5;
   auto* debug_source_text_insn = _.FindDef(inst->word(string_operand));
   // Validated to be an OpString
   assert(debug_source_text_insn->opcode() == spv::Op::OpString);
@@ -1101,7 +1141,7 @@ std::string GetDebugSourceText(ValidationState_t& _, const Instruction* inst,
 // inside
 void BuildDebugSourceLineLength(ValidationState_t& _, const Instruction* inst,
                                 uint32_t ext_inst_index) {
-  if (ext_inst_index == NonSemanticShaderDebugInfo100DebugSource &&
+  if (ext_inst_index == NonSemanticShaderDebugInfoDebugSource &&
       inst->words().size() < 7) {
     return;  // The optional text was not provided
   }
@@ -1121,7 +1161,7 @@ void BuildDebugSourceLineLength(ValidationState_t& _, const Instruction* inst,
   // So we want to find the previous line for checking if we need to append on
   // to the length of the previous line
   bool start_new_line = true;
-  if (ext_inst_index == NonSemanticShaderDebugInfo100DebugSourceContinued) {
+  if (ext_inst_index == NonSemanticShaderDebugInfoDebugSourceContinued) {
     auto prev_index = inst - &_.ordered_instructions()[0] - 1;
     auto prev_inst = &_.ordered_instructions()[prev_index];
 
@@ -1132,7 +1172,7 @@ void BuildDebugSourceLineLength(ValidationState_t& _, const Instruction* inst,
     }
   }
 
-  while (ext_inst_index == NonSemanticShaderDebugInfo100DebugSourceContinued) {
+  while (ext_inst_index == NonSemanticShaderDebugInfoDebugSourceContinued) {
     continue_count++;  // might have multiple Continues in a row
     auto prev_index = inst - &_.ordered_instructions()[0] - continue_count;
     auto prev_inst = &_.ordered_instructions()[prev_index];
@@ -3311,8 +3351,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
   // Parse the declared NSDI version so optional-operand checks are strict
   // (num_words == n) for version kNSDIKnownVersion and lenient (num_words >= n)
   // for future versions that may add trailing operands.
-  static const uint32_t kNSDIKnownVersion =
-      NonSemanticShaderDebugInfo100Version;
+  static const uint32_t kNSDIKnownVersion = NonSemanticShaderDebugInfoVersion;
   const uint32_t nsdi_version = vulkanDebugInfo ? GetNSDIVersion(_, inst) : 0;
   // True if the optional operand at word |n| is present and should be checked.
   auto has_optional_at = [&](uint32_t n) -> bool {
@@ -3322,54 +3361,58 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
 
   // Handle any non-common NonSemanticShaderDebugInfo instructions.
   if (vulkanDebugInfo) {
-    const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-        NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
+    const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+        NonSemanticShaderDebugInfoInstructions(ext_inst_index);
     switch (ext_inst_key) {
       // The following block of instructions will be handled by the common
       // validation.
-      case NonSemanticShaderDebugInfo100DebugInfoNone:
-      case NonSemanticShaderDebugInfo100DebugCompilationUnit:
-      case NonSemanticShaderDebugInfo100DebugTypePointer:
-      case NonSemanticShaderDebugInfo100DebugTypeQualifier:
-      case NonSemanticShaderDebugInfo100DebugTypeArray:
-      case NonSemanticShaderDebugInfo100DebugTypeVector:
-      case NonSemanticShaderDebugInfo100DebugTypedef:
-      case NonSemanticShaderDebugInfo100DebugTypeFunction:
-      case NonSemanticShaderDebugInfo100DebugTypeEnum:
-      case NonSemanticShaderDebugInfo100DebugTypeComposite:
-      case NonSemanticShaderDebugInfo100DebugTypeMember:
-      case NonSemanticShaderDebugInfo100DebugTypeInheritance:
-      case NonSemanticShaderDebugInfo100DebugTypePtrToMember:
-      case NonSemanticShaderDebugInfo100DebugTypeTemplate:
-      case NonSemanticShaderDebugInfo100DebugTypeTemplateParameter:
-      case NonSemanticShaderDebugInfo100DebugTypeTemplateTemplateParameter:
-      case NonSemanticShaderDebugInfo100DebugTypeTemplateParameterPack:
-      case NonSemanticShaderDebugInfo100DebugGlobalVariable:
-      case NonSemanticShaderDebugInfo100DebugFunctionDeclaration:
-      case NonSemanticShaderDebugInfo100DebugFunction:
-      case NonSemanticShaderDebugInfo100DebugLexicalBlock:
-      case NonSemanticShaderDebugInfo100DebugLexicalBlockDiscriminator:
-      case NonSemanticShaderDebugInfo100DebugScope:
-      case NonSemanticShaderDebugInfo100DebugNoScope:
-      case NonSemanticShaderDebugInfo100DebugInlinedAt:
-      case NonSemanticShaderDebugInfo100DebugLocalVariable:
-      case NonSemanticShaderDebugInfo100DebugInlinedVariable:
-      case NonSemanticShaderDebugInfo100DebugValue:
-      case NonSemanticShaderDebugInfo100DebugOperation:
-      case NonSemanticShaderDebugInfo100DebugExpression:
-      case NonSemanticShaderDebugInfo100DebugMacroDef:
-      case NonSemanticShaderDebugInfo100DebugMacroUndef:
-      case NonSemanticShaderDebugInfo100DebugImportedEntity:
-      case NonSemanticShaderDebugInfo100DebugSource:
+      case NonSemanticShaderDebugInfoDebugInfoNone:
+      case NonSemanticShaderDebugInfoDebugCompilationUnit:
+      case NonSemanticShaderDebugInfoDebugTypePointer:
+      case NonSemanticShaderDebugInfoDebugTypeQualifier:
+      case NonSemanticShaderDebugInfoDebugTypeArray:
+      case NonSemanticShaderDebugInfoDebugTypeVector:
+      case NonSemanticShaderDebugInfoDebugTypedef:
+      case NonSemanticShaderDebugInfoDebugTypeFunction:
+      case NonSemanticShaderDebugInfoDebugTypeEnum:
+      case NonSemanticShaderDebugInfoDebugTypeComposite:
+      case NonSemanticShaderDebugInfoDebugTypeMember:
+      case NonSemanticShaderDebugInfoDebugTypeInheritance:
+      case NonSemanticShaderDebugInfoDebugTypePtrToMember:
+      case NonSemanticShaderDebugInfoDebugTypeTemplate:
+      case NonSemanticShaderDebugInfoDebugTypeTemplateParameter:
+      case NonSemanticShaderDebugInfoDebugTypeTemplateTemplateParameter:
+      case NonSemanticShaderDebugInfoDebugTypeTemplateParameterPack:
+      case NonSemanticShaderDebugInfoDebugGlobalVariable:
+      case NonSemanticShaderDebugInfoDebugFunctionDeclaration:
+      case NonSemanticShaderDebugInfoDebugFunction:
+      case NonSemanticShaderDebugInfoDebugLexicalBlock:
+      case NonSemanticShaderDebugInfoDebugLexicalBlockDiscriminator:
+      case NonSemanticShaderDebugInfoDebugScope:
+      case NonSemanticShaderDebugInfoDebugNoScope:
+      case NonSemanticShaderDebugInfoDebugInlinedAt:
+      case NonSemanticShaderDebugInfoDebugLocalVariable:
+      case NonSemanticShaderDebugInfoDebugInlinedVariable:
+      case NonSemanticShaderDebugInfoDebugValue:
+      case NonSemanticShaderDebugInfoDebugOperation:
+      case NonSemanticShaderDebugInfoDebugExpression:
+      case NonSemanticShaderDebugInfoDebugMacroDef:
+      case NonSemanticShaderDebugInfoDebugMacroUndef:
+      case NonSemanticShaderDebugInfoDebugImportedEntity:
+      case NonSemanticShaderDebugInfoDebugSource:
         break;
 
       // These checks are for operands that are different in
       // NonSemantic.Shader.DebugInfo
-      case NonSemanticShaderDebugInfo100DebugTypeBasic: {
+      case NonSemanticShaderDebugInfoDebugTypeBasic: {
         CHECK_CONST_UINT_OPERAND("Flags", 8);
+        // Optional FPEncoding parameter (5th operand, word index 9)
+        if (num_words > 9) {
+          CHECK_CONST_UINT_OPERAND("FPEncoding", 9);
+        }
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugDeclare: {
+      case NonSemanticShaderDebugInfoDebugDeclare: {
         for (uint32_t word_index = 8; word_index < num_words; ++word_index) {
           auto index_inst = _.FindDef(inst->word(word_index));
           auto type_id = index_inst != nullptr ? index_inst->type_id() : 0;
@@ -3380,7 +3423,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         }
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugTypeMatrix: {
+      case NonSemanticShaderDebugInfoDebugTypeMatrix: {
         CHECK_DEBUG_OPERAND("Vector Type", CommonDebugInfoDebugTypeVector, 5);
 
         CHECK_CONST_UINT_OPERAND("Vector Count", 6);
@@ -3402,7 +3445,24 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         }
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugFunctionDefinition: {
+      case NonSemanticShaderDebugInfoDebugTypeVectorIdEXT: {
+        CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
+        // Component Count may be OpSpecConstant when the cooperative vector
+        // type uses a specialization constant for its size.
+        CHECK_CONST_OR_SPEC_UINT_OPERAND("Component Count", 6);
+        break;
+      }
+      case NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR: {
+        CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
+        // Scope, Rows, Columns, and Use may be OpSpecConstant when the
+        // cooperative matrix type uses specialization constants.
+        CHECK_CONST_OR_SPEC_UINT_OPERAND("Scope", 6);
+        CHECK_CONST_OR_SPEC_UINT_OPERAND("Rows", 7);
+        CHECK_CONST_OR_SPEC_UINT_OPERAND("Columns", 8);
+        CHECK_CONST_OR_SPEC_UINT_OPERAND("Use", 9);
+        break;
+      }
+      case NonSemanticShaderDebugInfoDebugFunctionDefinition: {
         CHECK_DEBUG_OPERAND("Function", CommonDebugInfoDebugFunction, 5);
         CHECK_OPERAND("Definition", spv::Op::OpFunction, 6);
         const auto* current_function = inst->function();
@@ -3421,7 +3481,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         }
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugLine: {
+      case NonSemanticShaderDebugInfoDebugLine: {
         CHECK_DEBUG_OPERAND("Source", CommonDebugInfoDebugSource, 5);
         CHECK_CONST_UINT_OPERAND("Line Start", 6);
         CHECK_CONST_UINT_OPERAND("Line End", 7);
@@ -3502,22 +3562,22 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
 
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugSourceContinued: {
+      case NonSemanticShaderDebugInfoDebugSourceContinued: {
         CHECK_OPERAND("Text", spv::Op::OpString, 5);
         // OpenCL didn't have a Continued version
         BuildDebugSourceLineLength(_, inst, ext_inst_index);
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugBuildIdentifier: {
+      case NonSemanticShaderDebugInfoDebugBuildIdentifier: {
         CHECK_OPERAND("Identifier", spv::Op::OpString, 5);
         CHECK_CONST_UINT_OPERAND("Flags", 6);
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugStoragePath: {
+      case NonSemanticShaderDebugInfoDebugStoragePath: {
         CHECK_OPERAND("Path", spv::Op::OpString, 5);
         break;
       }
-      case NonSemanticShaderDebugInfo100DebugEntryPoint: {
+      case NonSemanticShaderDebugInfoDebugEntryPoint: {
         CHECK_DEBUG_OPERAND("Entry Point", CommonDebugInfoDebugFunction, 5);
         CHECK_DEBUG_OPERAND("Compilation Unit",
                             CommonDebugInfoDebugCompilationUnit, 6);
@@ -3527,9 +3587,9 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
       }
 
         // Has no additional checks
-      case NonSemanticShaderDebugInfo100DebugNoLine:
+      case NonSemanticShaderDebugInfoDebugNoLine:
         break;
-      case NonSemanticShaderDebugInfo100InstructionsMax:
+      case NonSemanticShaderDebugInfoInstructionsMax:
         assert(0);
         break;
     }

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -329,12 +329,18 @@ spv_result_t ValidateOperandDebugType(ValidationState_t& _,
   // Check for NonSemanticShaderDebugInfo specific types.
   if (inst->ext_inst_type() ==
       SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
+    const uint32_t nsdi_version = GetNSDIVersion(_, inst);
     std::function<bool(NonSemanticShaderDebugInfoInstructions)> expectation =
-        [](NonSemanticShaderDebugInfoInstructions dbg_inst) {
-          return dbg_inst == NonSemanticShaderDebugInfoDebugTypeMatrix ||
-                 dbg_inst == NonSemanticShaderDebugInfoDebugTypeVectorIdEXT ||
-                 dbg_inst ==
-                     NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR;
+        [nsdi_version](NonSemanticShaderDebugInfoInstructions dbg_inst) {
+          if (dbg_inst == NonSemanticShaderDebugInfoDebugTypeMatrix) return true;
+          // DebugTypeVectorIdEXT and DebugTypeCooperativeMatrixKHR were added
+          // in NonSemantic.Shader.DebugInfo version 101.
+          if (nsdi_version >= NonSemanticShaderDebugInfoVersion &&
+              (dbg_inst == NonSemanticShaderDebugInfoDebugTypeVectorIdEXT ||
+               dbg_inst ==
+                   NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR))
+            return true;
+          return false;
         };
     if (DoesDebugInfoOperandMatchExpectation(_, expectation, inst, word_index))
       return SPV_SUCCESS;
@@ -3407,7 +3413,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
       case NonSemanticShaderDebugInfoDebugTypeBasic: {
         CHECK_CONST_UINT_OPERAND("Flags", 8);
         // Optional FPEncoding parameter (5th operand, word index 9)
-        if (num_words > 9) {
+        if (has_optional_at(10)) {
           CHECK_CONST_UINT_OPERAND("FPEncoding", 9);
         }
         break;
@@ -3446,6 +3452,12 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         break;
       }
       case NonSemanticShaderDebugInfoDebugTypeVectorIdEXT: {
+        if (nsdi_version < NonSemanticShaderDebugInfoVersion) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": requires NonSemantic.Shader.DebugInfo version "
+                 << NonSemanticShaderDebugInfoVersion << " or later";
+        }
         CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
         // Component Count may be OpSpecConstant when the cooperative vector
         // type uses a specialization constant for its size.
@@ -3453,6 +3465,12 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         break;
       }
       case NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR: {
+        if (nsdi_version < NonSemanticShaderDebugInfoVersion) {
+          return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << GetExtInstName(_, inst)
+                 << ": requires NonSemantic.Shader.DebugInfo version "
+                 << NonSemanticShaderDebugInfoVersion << " or later";
+        }
         CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
         // Scope, Rows, Columns, and Use may be OpSpecConstant when the
         // cooperative matrix type uses specialization constants.

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -155,38 +155,23 @@ spv_result_t ValidateOperandForDebugInfo(ValidationState_t& _,
 // word so cannot be validated.
 spv_result_t ValidateUint32ConstantOperandForDebugInfo(
     ValidationState_t& _, const std::string& operand_name,
-    const Instruction* inst, uint32_t word_index) {
-  if (!IsUint32Constant(_, inst->word(word_index))) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << GetExtInstName(_, inst) << ": expected operand " << operand_name
-           << " must be a result id of 32-bit unsigned OpConstant";
-  }
-  return SPV_SUCCESS;
-}
-
-// For NonSemantic.Shader.DebugInfo.101 cooperative type instructions, check
-// that the operand of |inst| at |word_index| is a result id of a 32-bit
-// unsigned integer constant instruction.  Unlike
-// ValidateUint32ConstantOperandForDebugInfo, this function accepts both
-// OpConstant and OpSpecConstant.  The SPIR-V cooperative types
-// (OpTypeCooperativeVectorEXT, OpTypeCooperativeMatrixKHR) allow
-// specialization constants for their dimension parameters, and the debug type
-// instructions must mirror that.
-spv_result_t ValidateUint32ConstOrSpecConstOperandForDebugInfo(
-    ValidationState_t& _, const std::string& operand_name,
-    const Instruction* inst, uint32_t word_index) {
+    const Instruction* inst, uint32_t word_index,
+    bool allow_spec_const = false) {
   const uint32_t id = inst->word(word_index);
-  const auto* def = _.FindDef(id);
-  if (!def || !spvOpcodeIsConstant(def->opcode())) {
+  if (!IsUint32Constant(_, id)) {
+    if (allow_spec_const) {
+      auto* def = _.FindDef(id);
+      if (def && spvOpcodeIsSpecConstant(def->opcode()) &&
+          IsIntScalar(_, def->type_id(), true, true))
+        return SPV_SUCCESS;
+    }
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << GetExtInstName(_, inst) << ": expected operand " << operand_name
-           << " must be a result id of a constant or specialization constant"
-              " instruction";
-  }
-  if (!IsIntScalar(_, def->type_id(), true, true)) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << GetExtInstName(_, inst) << ": expected operand " << operand_name
-           << " must be a 32-bit unsigned integer type";
+           << " must be a result id of "
+           << (allow_spec_const
+                   ? "a 32-bit unsigned integer constant or specialization"
+                     " constant"
+                   : "32-bit unsigned OpConstant");
   }
   return SPV_SUCCESS;
 }
@@ -204,14 +189,24 @@ spv_result_t ValidateUint32ConstOrSpecConstOperandForDebugInfo(
     if (result != SPV_SUCCESS) return result;                            \
   }
 
-// Like CHECK_CONST_UINT_OPERAND but also allows OpSpecConstant.  Used for
+// Like CHECK_CONST_UINT_OPERAND but also allows spec-constants.  Used for
 // NonSemantic.Shader.DebugInfo.101 cooperative type instructions, where
 // dimension operands may be specialization constants.
-#define CHECK_CONST_OR_SPEC_UINT_OPERAND(NAME, index)                \
-  if (vulkanDebugInfo) {                                             \
-    auto result = ValidateUint32ConstOrSpecConstOperandForDebugInfo( \
-        _, NAME, inst, index);                                       \
-    if (result != SPV_SUCCESS) return result;                        \
+#define CHECK_CONST_OR_SPEC_UINT_OPERAND(NAME, index)                          \
+  if (vulkanDebugInfo) {                                                       \
+    auto result =                                                              \
+        ValidateUint32ConstantOperandForDebugInfo(_, NAME, inst, index, true); \
+    if (result != SPV_SUCCESS) return result;                                  \
+  }
+
+// Checks that the NSDI version for the current instruction is at least |v|.
+// Used to guard opcodes added after version 100.
+#define CHECK_NSDI_MIN_VERSION(v)                                       \
+  if (nsdi_version < (v)) {                                             \
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)                         \
+           << GetExtInstName(_, inst)                                   \
+           << ": requires NonSemantic.Shader.DebugInfo version " << (v) \
+           << " or later";                                              \
   }
 
 // True if the operand of a debug info instruction |inst| at |word_index|
@@ -332,7 +327,8 @@ spv_result_t ValidateOperandDebugType(ValidationState_t& _,
     const uint32_t nsdi_version = GetNSDIVersion(_, inst);
     std::function<bool(NonSemanticShaderDebugInfoInstructions)> expectation =
         [nsdi_version](NonSemanticShaderDebugInfoInstructions dbg_inst) {
-          if (dbg_inst == NonSemanticShaderDebugInfoDebugTypeMatrix) return true;
+          if (dbg_inst == NonSemanticShaderDebugInfoDebugTypeMatrix)
+            return true;
           // DebugTypeVectorIdEXT and DebugTypeCooperativeMatrixKHR were added
           // in NonSemantic.Shader.DebugInfo version 101.
           if (nsdi_version >= NonSemanticShaderDebugInfoVersion &&
@@ -3452,12 +3448,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         break;
       }
       case NonSemanticShaderDebugInfoDebugTypeVectorIdEXT: {
-        if (nsdi_version < NonSemanticShaderDebugInfoVersion) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << ": requires NonSemantic.Shader.DebugInfo version "
-                 << NonSemanticShaderDebugInfoVersion << " or later";
-        }
+        CHECK_NSDI_MIN_VERSION(NonSemanticShaderDebugInfoVersion);
         CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
         // Component Count may be OpSpecConstant when the cooperative vector
         // type uses a specialization constant for its size.
@@ -3465,12 +3456,7 @@ spv_result_t ValidateExtInstDebugInfo(ValidationState_t& _,
         break;
       }
       case NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR: {
-        if (nsdi_version < NonSemanticShaderDebugInfoVersion) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << GetExtInstName(_, inst)
-                 << ": requires NonSemantic.Shader.DebugInfo version "
-                 << NonSemanticShaderDebugInfoVersion << " or later";
-        }
+        CHECK_NSDI_MIN_VERSION(NonSemanticShaderDebugInfoVersion);
         CHECK_DEBUG_OPERAND("Component Type", CommonDebugInfoDebugTypeBasic, 5);
         // Scope, Rows, Columns, and Use may be OpSpecConstant when the
         // cooperative matrix type uses specialization constants.

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -207,11 +207,11 @@ spv_result_t ValidateUint32ConstOrSpecConstOperandForDebugInfo(
 // Like CHECK_CONST_UINT_OPERAND but also allows OpSpecConstant.  Used for
 // NonSemantic.Shader.DebugInfo.101 cooperative type instructions, where
 // dimension operands may be specialization constants.
-#define CHECK_CONST_OR_SPEC_UINT_OPERAND(NAME, index)                        \
-  if (vulkanDebugInfo) {                                                      \
-    auto result = ValidateUint32ConstOrSpecConstOperandForDebugInfo(          \
-        _, NAME, inst, index);                                                \
-    if (result != SPV_SUCCESS) return result;                                 \
+#define CHECK_CONST_OR_SPEC_UINT_OPERAND(NAME, index)                \
+  if (vulkanDebugInfo) {                                             \
+    auto result = ValidateUint32ConstOrSpecConstOperandForDebugInfo( \
+        _, NAME, inst, index);                                       \
+    if (result != SPV_SUCCESS) return result;                        \
   }
 
 // True if the operand of a debug info instruction |inst| at |word_index|

--- a/source/val/validate_layout.cpp
+++ b/source/val/validate_layout.cpp
@@ -15,7 +15,6 @@
 // Source code for logical layout validation as described in section 2.4
 
 #include "DebugInfo.h"
-#include "NonSemanticShaderDebugInfo100.h"
 #include "OpenCLDebugInfo100.h"
 #include "source/opcode.h"
 #include "source/operand.h"
@@ -23,6 +22,7 @@
 #include "source/val/instruction.h"
 #include "source/val/validate.h"
 #include "source/val/validation_state.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo.h"
 
 namespace spvtools {
 namespace val {
@@ -50,16 +50,16 @@ spv_result_t ModuleScopedInstructions(ValidationState_t& _,
           }
         } else if (inst->ext_inst_type() ==
                    SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-          const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-              NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
-          if (ext_inst_key == NonSemanticShaderDebugInfo100DebugScope ||
-              ext_inst_key == NonSemanticShaderDebugInfo100DebugNoScope ||
-              ext_inst_key == NonSemanticShaderDebugInfo100DebugDeclare ||
-              ext_inst_key == NonSemanticShaderDebugInfo100DebugValue ||
-              ext_inst_key == NonSemanticShaderDebugInfo100DebugLine ||
-              ext_inst_key == NonSemanticShaderDebugInfo100DebugNoLine ||
+          const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+              NonSemanticShaderDebugInfoInstructions(ext_inst_index);
+          if (ext_inst_key == NonSemanticShaderDebugInfoDebugScope ||
+              ext_inst_key == NonSemanticShaderDebugInfoDebugNoScope ||
+              ext_inst_key == NonSemanticShaderDebugInfoDebugDeclare ||
+              ext_inst_key == NonSemanticShaderDebugInfoDebugValue ||
+              ext_inst_key == NonSemanticShaderDebugInfoDebugLine ||
+              ext_inst_key == NonSemanticShaderDebugInfoDebugNoLine ||
               ext_inst_key ==
-                  NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+                  NonSemanticShaderDebugInfoDebugFunctionDefinition) {
             local_debug_info = true;
           }
         } else {
@@ -259,16 +259,16 @@ spv_result_t FunctionScopedInstructions(ValidationState_t& _,
             }
           } else if (inst->ext_inst_type() ==
                      SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-            const NonSemanticShaderDebugInfo100Instructions ext_inst_key =
-                NonSemanticShaderDebugInfo100Instructions(ext_inst_index);
-            if (ext_inst_key == NonSemanticShaderDebugInfo100DebugScope ||
-                ext_inst_key == NonSemanticShaderDebugInfo100DebugNoScope ||
-                ext_inst_key == NonSemanticShaderDebugInfo100DebugDeclare ||
-                ext_inst_key == NonSemanticShaderDebugInfo100DebugValue ||
-                ext_inst_key == NonSemanticShaderDebugInfo100DebugLine ||
-                ext_inst_key == NonSemanticShaderDebugInfo100DebugNoLine ||
+            const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+                NonSemanticShaderDebugInfoInstructions(ext_inst_index);
+            if (ext_inst_key == NonSemanticShaderDebugInfoDebugScope ||
+                ext_inst_key == NonSemanticShaderDebugInfoDebugNoScope ||
+                ext_inst_key == NonSemanticShaderDebugInfoDebugDeclare ||
+                ext_inst_key == NonSemanticShaderDebugInfoDebugValue ||
+                ext_inst_key == NonSemanticShaderDebugInfoDebugLine ||
+                ext_inst_key == NonSemanticShaderDebugInfoDebugNoLine ||
                 ext_inst_key ==
-                    NonSemanticShaderDebugInfo100DebugFunctionDefinition) {
+                    NonSemanticShaderDebugInfoDebugFunctionDefinition) {
               local_debug_info = true;
             }
           } else {

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -1542,10 +1542,10 @@ TEST_F(DescriptorTypeTest, GetShaderDebugOpcode) {
       BuildModule(SPV_ENV_UNIVERSAL_1_2, nullptr, text);
   Instruction* debug_expression = context->get_def_use_mgr()->GetDef(5);
   EXPECT_EQ(debug_expression->GetShaderDebugOpcode(),
-            NonSemanticShaderDebugInfo100DebugExpression);
+            NonSemanticShaderDebugInfoDebugExpression);
   Instruction* debug_source = context->get_def_use_mgr()->GetDef(6);
   EXPECT_EQ(debug_source->GetShaderDebugOpcode(),
-            NonSemanticShaderDebugInfo100DebugSource);
+            NonSemanticShaderDebugInfoDebugSource);
 
   // Test that an opcode larger than the max will return Max.  This instruction
   // cannot be in the assembly above because the assembler expects the string
@@ -1553,14 +1553,15 @@ TEST_F(DescriptorTypeTest, GetShaderDebugOpcode) {
   // file could have an arbitrary number.
   std::unique_ptr<Instruction> past_max(debug_expression->Clone(context.get()));
   const uint32_t kExtInstOpcodeInIndex = 1;
-  uint32_t large_opcode = NonSemanticShaderDebugInfo100InstructionsMax + 2;
+  uint32_t large_opcode =
+      static_cast<uint32_t>(NonSemanticShaderDebugInfoInstructionsMax) + 2u;
   past_max->SetInOperand(kExtInstOpcodeInIndex, {large_opcode});
   EXPECT_EQ(past_max->GetShaderDebugOpcode(),
-            NonSemanticShaderDebugInfo100InstructionsMax);
+            NonSemanticShaderDebugInfoInstructionsMax);
 
   // Test that an opcode without a value in the enum, but less than Max returns
   // the same value.
-  uint32_t opcode = NonSemanticShaderDebugInfo100InstructionsMax - 2;
+  uint32_t opcode = NonSemanticShaderDebugInfoInstructionsMax - 2;
   past_max->SetInOperand(kExtInstOpcodeInIndex, {opcode});
   EXPECT_EQ(past_max->GetShaderDebugOpcode(), opcode);
 }

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -22,8 +22,150 @@
 
 #include "gmock/gmock.h"
 #include "spirv-tools/libspirv.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo100.h"
 #include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
+
+// Verify that the frozen NonSemanticShaderDebugInfo100.h opcode values match
+// the version-agnostic NonSemanticShaderDebugInfo.h values. The two headers
+// use different enum type names but must have identical opcode numbers.
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugInfoNone) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugInfoNone));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugCompilationUnit) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugCompilationUnit));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeBasic) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeBasic));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypePointer) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypePointer));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeQualifier) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeQualifier));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeArray) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeArray));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeVector) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeVector));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypedef) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypedef));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeFunction) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeFunction));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeEnum) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeEnum));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeComposite) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeComposite));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeMember) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeMember));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeInheritance) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeInheritance));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypePtrToMember) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypePtrToMember));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeTemplate) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeTemplate));
+static_assert(static_cast<uint32_t>(
+                  NonSemanticShaderDebugInfo100DebugTypeTemplateParameter) ==
+              static_cast<uint32_t>(
+                  NonSemanticShaderDebugInfoDebugTypeTemplateParameter));
+static_assert(
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfo100DebugTypeTemplateTemplateParameter) ==
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfoDebugTypeTemplateTemplateParameter));
+static_assert(
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfo100DebugTypeTemplateParameterPack) ==
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfoDebugTypeTemplateParameterPack));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugGlobalVariable) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugGlobalVariable));
+static_assert(
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfo100DebugFunctionDeclaration) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugFunctionDeclaration));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugFunction) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugFunction));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugLexicalBlock) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugLexicalBlock));
+static_assert(
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfo100DebugLexicalBlockDiscriminator) ==
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfoDebugLexicalBlockDiscriminator));
+static_assert(static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugScope) ==
+              static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugScope));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugNoScope) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugNoScope));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugInlinedAt) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugInlinedAt));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugLocalVariable) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugLocalVariable));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugInlinedVariable) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugInlinedVariable));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugDeclare) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugDeclare));
+static_assert(static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugValue) ==
+              static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugValue));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugOperation) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugOperation));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugExpression) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugExpression));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugMacroDef) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugMacroDef));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugMacroUndef) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugMacroUndef));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugImportedEntity) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugImportedEntity));
+static_assert(static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugSource) ==
+              static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugSource));
+static_assert(
+    static_cast<uint32_t>(
+        NonSemanticShaderDebugInfo100DebugFunctionDefinition) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugFunctionDefinition));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugSourceContinued) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugSourceContinued));
+static_assert(static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugLine) ==
+              static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugLine));
+static_assert(static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugNoLine) ==
+              static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugNoLine));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugBuildIdentifier) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugBuildIdentifier));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugStoragePath) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugStoragePath));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugEntryPoint) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugEntryPoint));
+static_assert(
+    static_cast<uint32_t>(NonSemanticShaderDebugInfo100DebugTypeMatrix) ==
+    static_cast<uint32_t>(NonSemanticShaderDebugInfoDebugTypeMatrix));
 
 namespace spvtools {
 namespace val {
@@ -86,7 +228,7 @@ using ValidateVulkan100DebugInfoDebugValue =
 using ValidateVulkan100DebugInfo = spvtest::ValidateBase<std::string>;
 using ValidateVulkan101DebugInfo = spvtest::ValidateBase<std::string>;
 
-const static std::string shader_extension = R"(
+const static std::string shader_extension_100 = R"(
 OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
@@ -364,7 +506,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceInFunction) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", "", dbg_inst, shader_extension, "Vertex"));
+      src, "", "", dbg_inst, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -432,8 +574,9 @@ TEST_P(ValidateLocalDebugInfoOutOfFunction, VulkanDebugInfo100DebugScope) {
 %foo_val = OpLoad %u32 %foo
 )";
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header + GetParam(), body, shader_extension, "Vertex"));
+  CompileSuccessfully(
+      GenerateShaderCodeForDebugInfo(src, "", dbg_inst_header + GetParam(),
+                                     body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugScope, DebugNoScope, DebugDeclare, DebugValue "
@@ -747,7 +890,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugCompilationUnitFail) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst, "", shader_extension, "Vertex"));
+      src, "", dbg_inst, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Source must be a result id of "
@@ -801,7 +944,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailName) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Name must be a result id of "
@@ -855,7 +998,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailSize) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Size must be a result id of "
@@ -880,7 +1023,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicFailFlags) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Flags must be a result id of 32-bit "
@@ -1019,7 +1162,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifier) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1042,7 +1185,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeQualifierFail) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -1288,7 +1431,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArray) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1317,7 +1460,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayWithVariableSize) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1336,7 +1479,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailBaseType) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type is not a valid debug "
@@ -1358,7 +1501,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCount) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be a constant instruction with a "
@@ -1382,7 +1525,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailComponentCountFloat) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be a constant instruction with a "
@@ -1406,7 +1549,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayComponentCountZero) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1433,7 +1576,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayFailVariableSizeTypeFloat) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be a constant instruction with a "
@@ -1461,7 +1604,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeArrayOpSpecConstantComponentCount) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1487,7 +1630,7 @@ TEST_F(ValidateVulkan100DebugInfo,
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1607,7 +1750,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVector) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1626,7 +1769,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFail) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Base Type must be a result id of "
@@ -1648,7 +1791,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentZero) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1670,7 +1813,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorFailComponentFive) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Component Count must be positive "
@@ -1697,7 +1840,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrix) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1721,7 +1864,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorTypeType) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Vector Type must be a result id of "
@@ -1748,7 +1891,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountType) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Vector Count must be a result id of "
@@ -1775,7 +1918,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountZero) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Vector Count must be positive "
@@ -1802,7 +1945,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeMatrixFailVectorCountFive) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Vector Count must be positive "
@@ -1892,7 +2035,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypedef) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -1915,7 +2058,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypedef, Fail) {
   ss << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second +
@@ -2035,7 +2178,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionAndParams) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2054,7 +2197,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailReturn) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2076,7 +2219,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeFunctionFailParam) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -2187,7 +2330,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeEnum) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2210,7 +2353,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugTypeEnum, Fail) {
   ss << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2502,7 +2645,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2540,7 +2683,7 @@ main() {}
   ss << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, ss.str(), "", shader_extension, "Vertex"));
+      src, constants, ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second + " must be "));
@@ -2601,7 +2744,7 @@ main() {}
   ss << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, ss.str(), "", shader_extension, "Vertex"));
+      src, constants, ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   if (!param.second.empty()) {
     EXPECT_THAT(getDiagnosticString(),
@@ -2776,7 +2919,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -2802,7 +2945,7 @@ main() {}
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2852,7 +2995,7 @@ main() {}
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -2900,7 +3043,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugFunctionType) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunction: expected operand Type must be a result "
@@ -3008,7 +3151,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLexicalBlock) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3028,7 +3171,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugLexicalBlock, Fail) {
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3060,7 +3203,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailScope) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -3081,7 +3224,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugScopeFailInlinedAt) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined At"));
 }
@@ -3176,7 +3319,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLocalVariable) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3203,7 +3346,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugLocalVariable, Fail) {
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, ss.str(), "", shader_extension, "Vertex"));
+      src, constants, ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3388,7 +3531,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugDeclare) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3488,8 +3631,9 @@ TEST_P(ValidateVulkan100DebugInfoDebugDeclare, Fail) {
 %decl = OpExtInst %void %DbgExt DebugDeclare )"
      << param.first;
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, ss.str(), shader_extension, "Vertex"));
+  CompileSuccessfully(
+      GenerateShaderCodeForDebugInfo(src, constants, dbg_inst_header, ss.str(),
+                                     shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -3538,7 +3682,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugExpression) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      "", "", dbg_inst_header, "", shader_extension, "Vertex"));
+      "", "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3549,7 +3693,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugExpressionFail) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      "", "", dbg_inst_header, "", shader_extension, "Vertex"));
+      "", "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -3745,7 +3889,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3773,7 +3917,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3800,7 +3944,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -3825,7 +3969,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand Target must be DebugTypeComposite or "
@@ -3854,7 +3998,7 @@ main() {}
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -4030,7 +4174,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariable) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4052,7 +4196,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableStaticMember) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4073,7 +4217,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableDebugInfoNone) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4093,7 +4237,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugGlobalVariableConst) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4116,7 +4260,7 @@ TEST_P(ValidateVulkan100DebugInfoDebugGlobalVariable, Fail) {
      << param.first;
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", ss.str(), "", shader_extension, "Vertex"));
+      src, "", ss.str(), "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4243,7 +4387,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAt) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4268,7 +4412,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Scope"));
 }
@@ -4294,7 +4438,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugInlinedAtFail2) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(), HasSubstr("expected operand Inlined"));
 }
@@ -4433,7 +4577,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValue) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4467,7 +4611,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugValueWithVariableIndex) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4499,8 +4643,9 @@ TEST_P(ValidateVulkan100DebugInfoDebugValue, Fail) {
 %decl = OpExtInst %void %DbgExt DebugValue )"
      << param.first;
 
-  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, ss.str(), shader_extension, "Vertex"));
+  CompileSuccessfully(
+      GenerateShaderCodeForDebugInfo(src, constants, dbg_inst_header, ss.str(),
+                                     shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("expected operand " + param.second));
@@ -4693,7 +4838,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugFunctionDefinition) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4715,7 +4860,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugFunctionDefinitionFailFunction) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: expected operand Function "
@@ -4740,7 +4885,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugFunctionDefinitionFailDefinition) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: expected operand Definition "
@@ -4768,7 +4913,7 @@ TEST_F(ValidateVulkan100DebugInfo, DISABLED_DebugFunctionDefinitionDuplicate) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: Was used multiple times in "
@@ -4801,7 +4946,7 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: Was referenced a "
@@ -4833,7 +4978,7 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: operand Definition must "
@@ -4867,7 +5012,7 @@ OpReturn
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, body, shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunctionDefinition: must be in the entry basic "
@@ -4899,7 +5044,7 @@ OpFunctionEnd
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4922,7 +5067,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -4938,7 +5083,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugNoLineOutOfBlock) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("debug info extension must appear in a function body"));
@@ -4956,7 +5101,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineOutOfBlock) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_LAYOUT, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("debug info extension must appear in a function body"));
@@ -4979,7 +5124,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineSource) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: expected operand Source must be a result "
@@ -5001,7 +5146,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineFloat) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: expected operand Line Start must be a "
@@ -5023,7 +5168,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineInt64) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: expected operand Line Start must be a "
@@ -5046,7 +5191,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineSpecConstant) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: expected operand Line Start must be a "
@@ -5068,7 +5213,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineLineStartZero) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Line Start (0) is not allowed, "
@@ -5090,7 +5235,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineLineEndSmaller) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5112,7 +5257,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineColumnEndSmaller) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Column End (0) is less than Column "
@@ -5135,7 +5280,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineColumnEndSmallerMultiline) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5156,7 +5301,7 @@ int main() {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Line End (4) is larger then the 3 "
@@ -5179,7 +5324,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugLineColumnOutOfBounds) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Column End (5) is larger then Line "
@@ -5203,7 +5348,7 @@ line 3"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Column End (2) is larger then Line "
@@ -5227,7 +5372,7 @@ line 3"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5248,7 +5393,7 @@ line 3"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5273,7 +5418,7 @@ line 3"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Column End (5) is larger then Line "
@@ -5301,7 +5446,7 @@ line 5"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5325,7 +5470,7 @@ line 4"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Line End (5) is larger then the 4 "
@@ -5356,7 +5501,7 @@ line 3
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5383,7 +5528,7 @@ line 3
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugLine: operand Column End (3) is larger then Line "
@@ -5404,7 +5549,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceLineNoText) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5430,7 +5575,7 @@ line 3"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypeMember: operand Line (4) is larger then the "
@@ -5459,7 +5604,7 @@ line 2
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5485,7 +5630,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugFunctionLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugFunction: operand Line (2) is larger then the "
@@ -5507,7 +5652,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugFunctionDeclarationLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5528,7 +5673,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugLexicalBlockLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5552,7 +5697,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugTypedefLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypedef: operand Line (2) is larger then the "
@@ -5576,7 +5721,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugEnumLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypeEnum: operand Line (2) is larger then the "
@@ -5600,7 +5745,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugTypeCompositeLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5626,7 +5771,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugGlobalVariableLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5652,7 +5797,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugLocalVariableLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5679,7 +5824,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceDebugTypeTemplateParameterLine) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -5726,7 +5871,7 @@ TEST_F(ValidateVulkan100DebugInfo, UnknownInstructionAccepted) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5765,7 +5910,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugSourceExtraOperand) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5783,7 +5928,7 @@ TEST_F(ValidateVulkan100DebugInfo, UnknownInstructionNoOperands) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5801,7 +5946,7 @@ TEST_F(ValidateVulkan100DebugInfo, UnknownInstructionManyOperands) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5825,7 +5970,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugNoScopeExtraOperandInBody) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, body, shader_extension, "Vertex"));
+      src, "", dbg_inst_header, body, shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5855,7 +6000,7 @@ line 4 is really long and hold 32char here"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5889,7 +6034,7 @@ line 3
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
@@ -5919,7 +6064,7 @@ line 4 and there is no line 5"
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypeComposite: operand Line (5) is larger then "
@@ -5949,7 +6094,7 @@ TEST_F(ValidateVulkan100DebugInfo,
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
@@ -6083,7 +6228,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXTFailVersion) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+      src, "", dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypeVectorIdEXT: requires "
@@ -6156,7 +6301,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRFailVersion) {
 )";
 
   CompileSuccessfully(GenerateShaderCodeForDebugInfo(
-      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+      src, constants, dbg_inst_header, "", shader_extension_100, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("DebugTypeCooperativeMatrixKHR: requires "

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -90,6 +90,11 @@ OpExtension "SPV_KHR_non_semantic_info"
 %DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 )";
 
+const static std::string shader_extension_101 = R"(
+OpExtension "SPV_KHR_non_semantic_info"
+%DbgExt = OpExtInstImport "NonSemantic.Shader.DebugInfo.101"
+)";
+
 // Extension string for a future NSDI version; exercises forward-compatibility.
 const static std::string shader_extension_9999 = R"(
 OpExtension "SPV_KHR_non_semantic_info"
@@ -5949,6 +5954,117 @@ TEST_F(ValidateVulkan100DebugInfo,
       getDiagnosticString(),
       HasSubstr("DebugTypeComposite: operand Column End (32) is larger then "
                 "Line 1 column length of 31 found in the DebugSource text"));
+}
+
+// Tests for NonSemantic.Shader.DebugInfo.101 instructions
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXT) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%vecid_info = OpExtInst %void %DbgExt DebugTypeVectorIdEXT %float_info %u32_4
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXTWithSpecConst) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%spec_count = OpSpecConstant %u32 4
+%vecid_info = OpExtInst %void %DbgExt DebugTypeVectorIdEXT %float_info %spec_count
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHR) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+%u32_16 = OpConstant %u32 16
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%coopmtx_info = OpExtInst %void %DbgExt DebugTypeCooperativeMatrixKHR %float_info %u32_3 %u32_8 %u32_16 %u32_0
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRWithSpecConst) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%spec_scope = OpSpecConstant %u32 3
+%spec_rows = OpSpecConstant %u32 8
+%spec_cols = OpSpecConstant %u32 16
+%spec_use = OpSpecConstant %u32 0
+%coopmtx_info = OpExtInst %void %DbgExt DebugTypeCooperativeMatrixKHR %float_info %spec_scope %spec_rows %spec_cols %spec_use
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicWithFPEncoding) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+%u32_4214 = OpConstant %u32 4214
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%fp8_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_8 %u32_3 %u32_0 %u32_4214
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 }  // namespace

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -6068,6 +6068,180 @@ TEST_F(ValidateVulkan101DebugInfo, DebugTypeBasicWithFPEncoding) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXTFailVersion) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%vecid_info = OpExtInst %void %DbgExt DebugTypeVectorIdEXT %float_info %u32_4
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("DebugTypeVectorIdEXT: requires "
+                        "NonSemantic.Shader.DebugInfo version"));
+}
+
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeVectorIdEXTFailComponentType) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%float_vec = OpExtInst %void %DbgExt DebugTypeVector %float_info %u32_4
+%vecid_info = OpExtInst %void %DbgExt DebugTypeVectorIdEXT %float_vec %u32_4
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected operand Component Type must be a result id "
+                        "of DebugTypeBasic"));
+}
+
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeVectorIdEXTFailComponentCount) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%vecid_info = OpExtInst %void %DbgExt DebugTypeVectorIdEXT %float_info %float_info
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Component Count must be a result id of a constant or "
+                        "specialization constant instruction"));
+}
+
+TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRFailVersion) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+%u32_16 = OpConstant %u32 16
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%coopmtx_info = OpExtInst %void %DbgExt DebugTypeCooperativeMatrixKHR %float_info %u32_3 %u32_8 %u32_16 %u32_0
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("DebugTypeCooperativeMatrixKHR: requires "
+                        "NonSemantic.Shader.DebugInfo version"));
+}
+
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailComponentType) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+%u32_16 = OpConstant %u32 16
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%float_vec = OpExtInst %void %DbgExt DebugTypeVector %float_info %u32_4
+%coopmtx_info = OpExtInst %void %DbgExt DebugTypeCooperativeMatrixKHR %float_vec %u32_3 %u32_8 %u32_16 %u32_0
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("expected operand Component Type must be a result id "
+                        "of DebugTypeBasic"));
+}
+
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailScopeNotConst) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+%u32_16 = OpConstant %u32 16
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%float_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_32 %u32_3 %u32_0
+%coopmtx_info = OpExtInst %void %DbgExt DebugTypeCooperativeMatrixKHR %float_info %dbg_src %u32_8 %u32_16 %u32_0
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Scope must be a result id of a constant or "
+                        "specialization constant instruction"));
+}
+
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeBasicFPEncodingFailNotConst) {
+  const std::string src = R"(
+%src = OpString "simple.hlsl"
+%code = OpString "main() {}"
+%float_name = OpString "float"
+)";
+
+  const std::string constants = R"(
+%u32_8 = OpConstant %u32 8
+)";
+
+  const std::string dbg_inst_header = R"(
+%dbg_src = OpExtInst %void %DbgExt DebugSource %src %code
+%comp_unit = OpExtInst %void %DbgExt DebugCompilationUnit %u32_2 %u32_4 %dbg_src %u32_5
+%fp8_info = OpExtInst %void %DbgExt DebugTypeBasic %float_name %u32_8 %u32_3 %u32_0 %dbg_src
+)";
+
+  CompileSuccessfully(GenerateShaderCodeForDebugInfo(
+      src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FPEncoding must be a result id of 32-bit unsigned "
+                        "OpConstant"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -6163,7 +6163,8 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRFailVersion) {
                         "NonSemantic.Shader.DebugInfo version"));
 }
 
-TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailComponentType) {
+TEST_F(ValidateVulkan101DebugInfo,
+       DebugTypeCooperativeMatrixKHRFailComponentType) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
@@ -6191,7 +6192,8 @@ TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailComponentTyp
                         "of DebugTypeBasic"));
 }
 
-TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailScopeNotConst) {
+TEST_F(ValidateVulkan101DebugInfo,
+       DebugTypeCooperativeMatrixKHRFailScopeNotConst) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -6131,8 +6131,9 @@ TEST_F(ValidateVulkan101DebugInfo, DebugTypeVectorIdEXTFailComponentCount) {
       src, "", dbg_inst_header, "", shader_extension_101, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Component Count must be a result id of a constant or "
-                        "specialization constant instruction"));
+              HasSubstr("Component Count must be a result id of a 32-bit "
+                        "unsigned integer constant or specialization "
+                        "constant"));
 }
 
 TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRFailVersion) {
@@ -6213,8 +6214,8 @@ TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRFailScopeNotCons
       src, constants, dbg_inst_header, "", shader_extension_101, "Vertex"));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Scope must be a result id of a constant or "
-                        "specialization constant instruction"));
+              HasSubstr("Scope must be a result id of a 32-bit unsigned "
+                        "integer constant or specialization constant"));
 }
 
 TEST_F(ValidateVulkan101DebugInfo, DebugTypeBasicFPEncodingFailNotConst) {

--- a/test/val/val_ext_inst_debug_test.cpp
+++ b/test/val/val_ext_inst_debug_test.cpp
@@ -84,6 +84,7 @@ using ValidateOpenCL100DebugInfoDebugValue =
 using ValidateVulkan100DebugInfoDebugValue =
     spvtest::ValidateBase<std::pair<std::string, std::string>>;
 using ValidateVulkan100DebugInfo = spvtest::ValidateBase<std::string>;
+using ValidateVulkan101DebugInfo = spvtest::ValidateBase<std::string>;
 
 const static std::string shader_extension = R"(
 OpExtension "SPV_KHR_non_semantic_info"
@@ -5958,7 +5959,7 @@ TEST_F(ValidateVulkan100DebugInfo,
 
 // Tests for NonSemantic.Shader.DebugInfo.101 instructions
 
-TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXT) {
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeVectorIdEXT) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
@@ -5977,7 +5978,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXT) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXTWithSpecConst) {
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeVectorIdEXTWithSpecConst) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
@@ -5997,7 +5998,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeVectorIdEXTWithSpecConst) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHR) {
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHR) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
@@ -6021,7 +6022,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHR) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRWithSpecConst) {
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeCooperativeMatrixKHRWithSpecConst) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"
@@ -6044,7 +6045,7 @@ TEST_F(ValidateVulkan100DebugInfo, DebugTypeCooperativeMatrixKHRWithSpecConst) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateVulkan100DebugInfo, DebugTypeBasicWithFPEncoding) {
+TEST_F(ValidateVulkan101DebugInfo, DebugTypeBasicWithFPEncoding) {
   const std::string src = R"(
 %src = OpString "simple.hlsl"
 %code = OpString "main() {}"

--- a/utils/ggt.py
+++ b/utils/ggt.py
@@ -71,6 +71,10 @@ class ExtInst():
         if self.enum_name == "SPV_EXT_INST_TYPE_OPENCL_STD_100":
             # Live with an old decision, by adjusting this name.
             self.enum_name = "SPV_EXT_INST_TYPE_OPENCL_STD"
+        if self.enum_name == "SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO":
+            # The version-agnostic grammar file name omits "_100", but the
+            # public enum in libspirv.h retains the suffix for compatibility.
+            self.enum_name = "SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100"
 
         self.load()
 


### PR DESCRIPTION
This is the next step in implementing NSDI 101 (https://github.com/KhronosGroup/SPIRV-Registry/pull/390)).

This PR updates SPIRV-Tools to validate NSDI.101 modules:

- DEPS: Update `spirv_headers_revision` to the NSDI.101 SPIRV-Headers changes.
- Change build system files to use the version-agnostic headers and grammar files. In `utils/ggt.py`, I added a special case to map `SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO` back to `SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100`. I didn't want to make an API breaking change here.
- Since we are now including the unified version header, all the embedded `100` strings can be removed.  I updated all references across `source/opt/` and `source/val/`. The numeric values are identical; none of these symbols are part of the public API.
- Finally, the actual validator changes:

1. `GetNSDIVersion` parses the declared version from the `OpExtInstImport` string (e.g., `NonSemantic.Shader.DebugInfo.101` returns `101`).
2. `kNSDIKnownVersion` is set to `NonSemanticShaderDebugInfoVersion` (= 101). A `has_optional_at(n)` lambda replaces the previous `num_words == n` checks for optional trailing operands. It accepts the optional operand when the module declares a version newer than `kNSDIKnownVersion` or when the word count is exactly `n`.
3. Added a new helper `ValidateUint32ConstOrSpecConstOperandForDebugInfo` and macro `CHECK_CONST_OR_SPEC_UINT_OPERAND`. This accepts both constants and spec constants.
4. Two new cases in the `vulkanDebugInfo` branch of `ValidateExtInst`:
   - `DebugTypeVectorIdEXT`
   - `DebugTypeCooperativeMatrixKHR`
5. `DebugTypeBasic` validation is updated to accept the new optional `FPEncoding` operand.
6. Added new tests for the validator for all the new opcodes.