### PR TITLE
Test spvtools::TextToBinaryTestBase::MaybeFlipWords

### DIFF
--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -48,6 +48,24 @@ using ::testing::Eq;
 using ::testing::InSequence;
 using ::testing::Return;
 
+using MaybeFlipWordsTest = spvtest::TextToBinaryTest;
+
+TEST_F(MaybeFlipWordsTest, DoNotFlip) {
+  std::vector<uint32_t> words{0x01234567, 0x89abcdef};
+  MaybeFlipWords(false, words.begin(), words.end());
+  EXPECT_EQ(words.size(), size_t(2));
+  EXPECT_EQ(words[0], 0x01234567);
+  EXPECT_EQ(words[1], 0x89abcdef);
+}
+
+TEST_F(MaybeFlipWordsTest, Flip) {
+  std::vector<uint32_t> words{0x01234567, 0x89abcdef};
+  MaybeFlipWords(true, words.begin(), words.end());
+  EXPECT_EQ(words.size(), size_t(2));
+  EXPECT_EQ(words[0], 0x67452301);
+  EXPECT_EQ(words[1], 0xefcdab89);
+}
+
 // An easily-constructible and comparable object for the contents of an
 // spv_parsed_instruction_t.  Unlike spv_parsed_instruction_t, owns the memory
 // of its components.


### PR DESCRIPTION
MaybeFlipWords is used in the tests for parsing
binaries in both endiannesses.