### PR TITLE
Remove redundant iterations from inliner passes

### DIFF
--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -16,6 +16,7 @@
 
 #include "source/opt/inline_exhaustive_pass.h"
 
+#include <iterator>
 #include <utility>
 
 namespace spvtools {
@@ -27,6 +28,9 @@ Pass::Status InlineExhaustivePass::InlineExhaustive(Function* func) {
   for (auto bi = func->begin(); bi != func->end(); ++bi) {
     for (auto ii = bi->begin(); ii != bi->end();) {
       if (IsInlinableFunctionCall(&*ii)) {
+        // Save instruction before the call to avoid redundant re-scanning.
+        Instruction* prev_inst = (ii == bi->begin()) ? nullptr : &*std::prev(ii);
+
         // Inline call.
         std::vector<std::unique_ptr<BasicBlock>> newBlocks;
         std::vector<std::unique_ptr<Instruction>> newVars;
@@ -47,8 +51,8 @@ Pass::Status InlineExhaustivePass::InlineExhaustive(Function* func) {
         // Insert new function variables.
         if (newVars.size() > 0)
           func->begin()->begin().InsertBefore(std::move(newVars));
-        // Restart inlining at beginning of calling block.
-        ii = bi->begin();
+        // Restart inlining at the first instruction of the inlined code.
+        ii = prev_inst ? ++InstructionList::iterator(prev_inst) : bi->begin();
         modified = true;
       } else {
         ++ii;

--- a/source/opt/inline_exhaustive_pass.cpp
+++ b/source/opt/inline_exhaustive_pass.cpp
@@ -29,7 +29,8 @@ Pass::Status InlineExhaustivePass::InlineExhaustive(Function* func) {
     for (auto ii = bi->begin(); ii != bi->end();) {
       if (IsInlinableFunctionCall(&*ii)) {
         // Save instruction before the call to avoid redundant re-scanning.
-        Instruction* prev_inst = (ii == bi->begin()) ? nullptr : &*std::prev(ii);
+        Instruction* prev_inst =
+            (ii == bi->begin()) ? nullptr : &*std::prev(ii);
 
         // Inline call.
         std::vector<std::unique_ptr<BasicBlock>> newBlocks;

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -16,6 +16,7 @@
 
 #include "source/opt/inline_opaque_pass.h"
 
+#include <iterator>
 #include <utility>
 
 namespace spvtools {
@@ -67,6 +68,9 @@ Pass::Status InlineOpaquePass::InlineOpaque(Function* func) {
   for (auto bi = func->begin(); bi != func->end(); ++bi) {
     for (auto ii = bi->begin(); ii != bi->end();) {
       if (IsInlinableFunctionCall(&*ii) && HasOpaqueArgsOrReturn(&*ii)) {
+        // Save instruction before the call to avoid redundant re-scanning.
+        Instruction* prev_inst = (ii == bi->begin()) ? nullptr : &*std::prev(ii);
+
         // Inline call.
         std::vector<std::unique_ptr<BasicBlock>> newBlocks;
         std::vector<std::unique_ptr<Instruction>> newVars;
@@ -79,18 +83,27 @@ Pass::Status InlineOpaquePass::InlineOpaque(Function* func) {
         if (newBlocks.size() > 1) UpdateSucceedingPhis(newBlocks);
         // Replace old calling block with new block(s).
         bi = bi.Erase();
+
+        for (auto& bb : newBlocks) {
+          bb->SetParent(func);
+        }
         bi = bi.InsertBefore(&newBlocks);
         // Insert new function variables.
         if (newVars.size() > 0)
           func->begin()->begin().InsertBefore(std::move(newVars));
-        // Restart inlining at beginning of calling block.
-        ii = bi->begin();
+        // Restart inlining at the first instruction of the inlined code.
+        ii = prev_inst ? ++InstructionList::iterator(prev_inst) : bi->begin();
         modified = true;
       } else {
         ++ii;
       }
     }
   }
+
+  if (modified) {
+    FixDebugDeclares(func);
+  }
+
   return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
 }
 

--- a/source/opt/inline_opaque_pass.cpp
+++ b/source/opt/inline_opaque_pass.cpp
@@ -69,7 +69,8 @@ Pass::Status InlineOpaquePass::InlineOpaque(Function* func) {
     for (auto ii = bi->begin(); ii != bi->end();) {
       if (IsInlinableFunctionCall(&*ii) && HasOpaqueArgsOrReturn(&*ii)) {
         // Save instruction before the call to avoid redundant re-scanning.
-        Instruction* prev_inst = (ii == bi->begin()) ? nullptr : &*std::prev(ii);
+        Instruction* prev_inst =
+            (ii == bi->begin()) ? nullptr : &*std::prev(ii);
 
         // Inline call.
         std::vector<std::unique_ptr<BasicBlock>> newBlocks;


### PR DESCRIPTION
Implemented in both the exhaustive/opaque inliner even though it appears the opaque one is not fully functional.

In my benchmark tests I found it reduced the time needed to run the exhaustive pass by 50% on average with the shaders I was testing with.

Also fixes two bugs in the opaque inliner. One is from not updating the parent of each new block and the other for debug. These could be split into another PR if desired but it's still pretty small overall.