### PR TITLE
Only run autoroll workflow on upstream repository

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-dependencies:
+    if: github.repository == 'KhronosGroup/SPIRV-Tools'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Avoid creating 'roll deps' PRs in forks