### PR TITLE
spirv-as: Fix OpConstantDataKHR new grammar

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': '972a15cedd008d846f1a39b2e88ce48d7f166cbd',
 
-  'spirv_headers_revision': '869266ad9e6050197d87cf0a22aab59abf7ad008',
+  'spirv_headers_revision': 'ad9184e76a66b1001c29db9b0a3e87f646c64de0',
 
   'mimalloc_revision': '75d69f4ab736ad9f56cdd76c7eb883f60ac48869',
 }

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -1630,17 +1630,55 @@ INSTANTIATE_TEST_SUITE_P(
             {"OpCapability ConstantDataKHR\n",
              MakeInstruction(spv::Op::OpCapability,
                              {(uint32_t)spv::Capability::ConstantDataKHR})},
-            {"%2 = OpConstantDataKHR %1 \"foo\"\n",
-             MakeInstruction(spv::Op::OpConstantDataKHR, {1, 2},
-                             MakeVector("foo"))},
-            {"%2 = OpSpecConstantDataKHR %1 \"foo\"\n",
-             MakeInstruction(spv::Op::OpSpecConstantDataKHR, {1, 2},
-                             MakeVector("foo"))},
+            {"%2 = OpConstantDataKHR %1 1718578944\n",
+             MakeInstruction(spv::Op::OpConstantDataKHR, {1, 2, 0x666F6F00})},
+            {"%2 = OpSpecConstantDataKHR %1 1718578944\n",
+             MakeInstruction(spv::Op::OpSpecConstantDataKHR,
+                             {1, 2, 0x666F6F00})},
             {"OpDecorate %1 UTFEncodedKHR\n",
              MakeInstruction(spv::Op::OpDecorate,
                              {1, (uint32_t)spv::Decoration::UTFEncodedKHR})},
 
         })));
+
+TEST_F(TextToBinaryTest, ConstantDataNonUTF) {
+  const std::string source = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int8
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %char = OpTypeInt 8 1
+    %uint_20 = OpConstant %uint 20
+ %char_array = OpTypeArray %char %uint_20
+               ; "abcd" where "a" is 0x61 ascii
+       %data = OpConstantDataKHR %char_array 0x10203040
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+  auto context = spvContextCreate(SPV_ENV_UNIVERSAL_1_1);
+  spv_binary binary = nullptr;
+  EXPECT_EQ(SPV_SUCCESS, spvTextToBinary(context, source.c_str(), source.size(),
+                                         &binary, nullptr));
+
+  // Opcode for OpConstantDataKHR
+  EXPECT_EQ((binary->code[50] & 0x0ffffu), 5147);
+  EXPECT_EQ(((binary->code[53] & 0xff000000u) >> 24), 0x10);
+  EXPECT_EQ(((binary->code[53] & 0x00ff0000u) >> 16), 0x20);
+  EXPECT_EQ(((binary->code[53] & 0x0000ff00u) >> 8), 0x30);
+  EXPECT_EQ(((binary->code[53] & 0x000000ffu)), 0x40);
+
+  spvBinaryDestroy(binary);
+  spvContextDestroy(context);
+}
 
 }  // namespace
 }  // namespace spvtools

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -178,10 +178,12 @@ TEST_F(ValidateSpvKHRAbort, ValidCompositeOperandTypes) {
  %uint32_t = OpTypeInt 32 0
   %str1len = OpConstant %uint32_t 6
 %string1_t = OpTypeArray %char_t %str1len
-  %string1 = OpConstantDataKHR %string1_t "test: "
+  ; "test: "
+  %string1 = OpConstantDataKHR %string1_t 0x74736574 0x0000203A
   %str2len = OpSpecConstant %uint32_t 2
 %string2_t = OpTypeArray %char_t %str2len
-  %string2 = OpSpecConstantDataKHR %string2_t "%u"
+  ; "%u"
+  %string2 = OpSpecConstantDataKHR %string2_t 0x00007525
 %message_t = OpTypeStruct %string1_t %string2_t %uint32_t
 %uintval   = OpConstant %uint32_t 6
 
@@ -228,10 +230,12 @@ TEST_F(ValidateSpvKHRAbort, MismatchedCompositeOperandTypes) {
  %uint32_t = OpTypeInt 32 0
   %str1len = OpConstant %uint32_t 6
 %string1_t = OpTypeArray %char_t %str1len
-  %string1 = OpConstantDataKHR %string1_t "test: "
+  ; "test: "
+  %string1 = OpConstantDataKHR %string1_t 0x74736574 0x0000203A
   %str2len = OpSpecConstant %uint32_t 2
 %string2_t = OpTypeArray %char_t %str2len
-  %string2 = OpSpecConstantDataKHR %string2_t "%u"
+  ; "%u"
+  %string2 = OpSpecConstantDataKHR %string2_t 0x00007525
 %message_t = OpTypeStruct %string1_t %string2_t
 %uintval   = OpConstant %uint32_t 6
 


### PR DESCRIPTION
Talked to David at F2F and we decided for now, to just get a fix in to `OpConstantDataKHR`  from https://github.com/KhronosGroup/SPIRV-Headers/commit/ad9184e76a66b1001c29db9b0a3e87f646c64de0

in the future, we can apply the "joy to use" `UTFEncodedKHR` decoration to allow `spirv-as`/`spirv-dis` to handle strings 