### PR TITLE
spirv-val: Validate OpConstantDataKHR

### DIFF
--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -693,6 +693,49 @@ spv_result_t ValidateConstantFunctionPointerINTEL(ValidationState_t& _,
   return SPV_SUCCESS;
 }
 
+spv_result_t ValidateConstantData(ValidationState_t& _,
+                                  const Instruction* inst) {
+  const auto array_inst = _.FindDef(inst->type_id());
+  if (array_inst->opcode() != spv::Op::OpTypeArray) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Result type must be an array.";
+  }
+
+  const auto element_type_inst =
+      _.FindDef(array_inst->GetOperandAs<uint32_t>(1));
+  if (!_.IsIntScalarType(element_type_inst->id())) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Result type must be an array of integer scalar type.";
+  }
+
+  const uint32_t int_width = element_type_inst->word(2);
+  const uint32_t data_words = static_cast<uint32_t>(inst->words().size() - 3);
+
+  if (data_words == 0) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "There must be at least 1 literal integer (because an array of "
+              "zero is not allowed).";
+  }
+
+  uint64_t array_length = 0;
+  if (!_.EvalConstantValUint64(array_inst->GetOperandAs<uint32_t>(2),
+                               &array_length)) {
+    // The length could be a SpecConstant, will need to be frozen to validate
+    return SPV_SUCCESS;
+  }
+
+  const uint32_t words_needed =
+      (((int_width / 8) * static_cast<uint32_t>(array_length) + 3) & ~3) / 4;
+  if (data_words != words_needed) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "contains " << data_words << " words of data, but needs to have "
+           << words_needed << " words to match the array of " << array_length
+           << " of " << int_width << "-bit ints.";
+  }
+
+  return SPV_SUCCESS;
+}
+
 }  // namespace
 
 spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst) {
@@ -730,6 +773,9 @@ spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpConstantFunctionPointerINTEL:
       if (auto error = ValidateConstantFunctionPointerINTEL(_, inst))
         return error;
+      break;
+    case spv::Op::OpConstantDataKHR:
+      if (auto error = ValidateConstantData(_, inst)) return error;
       break;
     default:
       break;

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -442,7 +442,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataNull) {
               HasSubstr("There must be at least 1 literal integer"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint32) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthOverUint32) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -468,7 +468,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint32) {
                         "to match the array of 2 of 32-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint32) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUnderUint32) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -494,7 +494,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint32) {
                         "to match the array of 2 of 32-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint8) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthOverUint8) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -522,7 +522,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint8) {
                         "to match the array of 5 of 8-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint8) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUnderUint8) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -550,7 +550,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint8) {
                         "to match the array of 4 of 8-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Good) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUint64Good) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -575,7 +575,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Good) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUint64Short) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -603,7 +603,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short) {
                         "to match the array of 1 of 64-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short2) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUint64Short2) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -631,7 +631,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short2) {
                         "to match the array of 2 of 64-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint64) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthOverUint64) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR
@@ -659,7 +659,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint64) {
                         "to match the array of 1 of 64-bit ints"));
 }
 
-TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint64) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUnderUint64) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -256,6 +256,437 @@ TEST_F(ValidateSpvKHRAbort, MismatchedCompositeOperandTypes) {
                         "the type of the Message Type operand"));
 }
 
+TEST_F(ValidateSpvKHRAbort, ConstantDataNonArray) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %data = OpConstantDataKHR %uint 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type must be an array."));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataFloat) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %float = OpTypeFloat 32
+  %uint_size = OpConstant %uint 1
+ %uint_array = OpTypeArray %float %uint_size
+       %data = OpConstantDataKHR %uint_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type must be an array of integer scalar type"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataIntVector) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+      %uvec3 = OpTypeVector %uint 3
+  %uint_size = OpConstant %uint 1
+ %uint_array = OpTypeArray %uvec3 %uint_size
+       %data = OpConstantDataKHR %uint_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type must be an array of integer scalar type"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataMultiLength) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int8
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %char = OpTypeInt 8 1
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+ %char_array_1 = OpTypeArray %char %uint_1
+ %char_array_2 = OpTypeArray %char %uint_2
+ %char_array_3 = OpTypeArray %char %uint_3
+ %char_array_4 = OpTypeArray %char %uint_4
+       %data_1 = OpConstantDataKHR %char_array_1 0
+       %data_2 = OpConstantDataKHR %char_array_2 0
+       %data_3 = OpConstantDataKHR %char_array_3 0
+       %data_4 = OpConstantDataKHR %char_array_4 0
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataSpecLength) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpSpecConstant %uint 4444
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpConstantDataKHR %uint_array 0
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+// TODO - We never tested this when writting the spec
+// https://gitlab.khronos.org/spirv/SPIR-V/-/issues/927
+TEST_F(ValidateSpvKHRAbort, DISABLED_ConstantDataSpecLengthAndData) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %uint_size SpecId 1
+               OpDecorate %data SpecId 2
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpSpecConstant %uint 4444
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpSpecConstantDataKHR %uint_array 1
+    ; No SpecID for this one
+     %data_2 = OpSpecConstantDataKHR %uint_array 2
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataNull) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpConstant %uint 1
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpConstantDataKHR %uint_array
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("There must be at least 1 literal integer"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint32) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpConstant %uint 2
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpConstantDataKHR %uint_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 1 words of data, but needs to have 2 words "
+                        "to match the array of 2 of 32-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint32) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpConstant %uint 2
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpConstantDataKHR %uint_array 1 2 3
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 3 words of data, but needs to have 2 words "
+                        "to match the array of 2 of 32-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint8) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int8
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %char = OpTypeInt 8 1
+  %uint_size = OpConstant %uint 5
+ %char_array = OpTypeArray %char %uint_size
+       %data = OpConstantDataKHR %char_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 1 words of data, but needs to have 2 words "
+                        "to match the array of 5 of 8-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint8) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int8
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+       %char = OpTypeInt 8 1
+  %uint_size = OpConstant %uint 4
+ %char_array = OpTypeArray %char %uint_size
+       %data = OpConstantDataKHR %char_array 1 2
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 2 words of data, but needs to have 1 words "
+                        "to match the array of 4 of 8-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Good) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u64 = OpTypeInt 64 0
+  %uint_size = OpConstant %uint 2
+ %u64_array = OpTypeArray %u64 %uint_size
+       %data = OpConstantDataKHR %u64_array 1 2 3 4
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u64 = OpTypeInt 64 0
+  %uint_size = OpConstant %uint 1
+ %u64_array = OpTypeArray %u64 %uint_size
+       %data = OpConstantDataKHR %u64_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 1 words of data, but needs to have 2 words "
+                        "to match the array of 1 of 64-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUint64Short2) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u64 = OpTypeInt 64 0
+  %uint_size = OpConstant %uint 2
+ %u64_array = OpTypeArray %u64 %uint_size
+       %data = OpConstantDataKHR %u64_array 1 2 3
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 3 words of data, but needs to have 4 words "
+                        "to match the array of 2 of 64-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtOverUint64) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u64 = OpTypeInt 64 0
+  %uint_size = OpConstant %uint 1
+ %u64_array = OpTypeArray %u64 %uint_size
+       %data = OpConstantDataKHR %u64_array 1 2 3 4
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 4 words of data, but needs to have 2 words "
+                        "to match the array of 1 of 64-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ConstantDataLenghtUnderUint64) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u64 = OpTypeInt 64 0
+  %uint_size = OpConstant %uint 2
+ %u64_array = OpTypeArray %u64 %uint_size
+       %data = OpConstantDataKHR %u64_array 1 2
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("contains 2 words of data, but needs to have 4 words "
+                        "to match the array of 2 of 64-bit ints"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
(based on https://github.com/KhronosGroup/SPIRV-Tools/pull/6642)

adds the missing validation for `OpConstantDataKHR`