### PR TITLE
spirv-val: Add validation for 4-bit integer types

### DIFF
--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -60,7 +60,15 @@ spv_result_t ValidateTypeInt(ValidationState_t& _, const Instruction* inst) {
   // integers, respectively.
   auto num_bits = inst->GetOperandAs<const uint32_t>(1);
   if (num_bits != 32) {
-    if (num_bits == 8) {
+    if (num_bits == 4) {
+      if (_.HasCapability(spv::Capability::Int4TypeINTEL) ||
+          _.HasCapability(spv::Capability::ArbitraryPrecisionIntegersINTEL)) {
+        return SPV_SUCCESS;
+      }
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "Using a 4-bit integer type requires the Int4TypeINTEL "
+                "or ArbitraryPrecisionIntegersINTEL capability.";
+    } else if (num_bits == 8) {
       if (_.features().declare_int8_type) {
         return SPV_SUCCESS;
       }

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -468,10 +468,9 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
              << "Structure <id> " << _.getIdName(member_type_id)
              << " contains members with BuiltIn decoration. Therefore this "
              << "structure may not be contained as a member of another "
-             << "structure "
-             << "type. Structure <id> " << _.getIdName(struct_id)
-             << " contains structure <id> " << _.getIdName(member_type_id)
-             << ".";
+             << "structure " << "type. Structure  "
+             << _.getIdName(struct_id) << " contains structure  "
+             << _.getIdName(member_type_id) << ".";
     }
 
     if (spvIsVulkanEnv(_.context()->target_env) &&

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -468,8 +468,8 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
              << "Structure <id> " << _.getIdName(member_type_id)
              << " contains members with BuiltIn decoration. Therefore this "
              << "structure may not be contained as a member of another "
-             << "structure " << "type. Structure  "
-             << _.getIdName(struct_id) << " contains structure  "
+             << "structure " << "type. Structure <id> "
+             << _.getIdName(struct_id) << " contains structure <id> "
              << _.getIdName(member_type_id) << ".";
     }
 

--- a/source/val/validate_type.cpp
+++ b/source/val/validate_type.cpp
@@ -468,9 +468,10 @@ spv_result_t ValidateTypeStruct(ValidationState_t& _, const Instruction* inst) {
              << "Structure <id> " << _.getIdName(member_type_id)
              << " contains members with BuiltIn decoration. Therefore this "
              << "structure may not be contained as a member of another "
-             << "structure " << "type. Structure <id> "
-             << _.getIdName(struct_id) << " contains structure <id> "
-             << _.getIdName(member_type_id) << ".";
+             << "structure "
+             << "type. Structure <id> " << _.getIdName(struct_id)
+             << " contains structure <id> " << _.getIdName(member_type_id)
+             << ".";
     }
 
     if (spvIsVulkanEnv(_.context()->target_env) &&

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -143,6 +143,9 @@ std::string invalid_comp_error = "Illegal number of components";
 std::string missing_cap_error =
     "requires the Vector16 or LongVectorEXT capability";
 std::string missing_int8_cap_error = "requires the Int8 capability";
+std::string missing_int4_cap_error =
+    "Using a 4-bit integer type requires the Int4TypeINTEL "
+    "or ArbitraryPrecisionIntegersINTEL capability.";
 std::string missing_int16_cap_error =
     "requires the Int16 capability,"
     " or an extension that explicitly enables 16-bit integers.";
@@ -294,6 +297,31 @@ TEST_F(ValidateData, int8_with_storage_push_constant_8_good) {
                         "StoragePushConstant8 "
                         "OpExtension \"SPV_KHR_8bit_storage\"") +
                     " %2 = OpTypeInt 8 0";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
+}
+
+TEST_F(ValidateData, int4_bad) {
+  std::string str = header + "%2 = OpTypeInt 4 0";
+  CompileSuccessfully(str.c_str());
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(missing_int4_cap_error));
+}
+
+TEST_F(ValidateData, int4_with_arbitrary_precision_good) {
+  std::string str = HeaderWith(
+                        "ArbitraryPrecisionIntegersINTEL "
+                        "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
+                    " %2 = OpTypeInt 4 0";
+  CompileSuccessfully(str.c_str());
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
+}
+
+TEST_F(ValidateData, int4_signed_with_arbitrary_precision_good) {
+  std::string str = HeaderWith(
+                        "ArbitraryPrecisionIntegersINTEL "
+                        "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
+                    " %2 = OpTypeInt 4 1";
   CompileSuccessfully(str.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
 }

--- a/test/val/val_data_test.cpp
+++ b/test/val/val_data_test.cpp
@@ -309,19 +309,21 @@ TEST_F(ValidateData, int4_bad) {
 }
 
 TEST_F(ValidateData, int4_with_arbitrary_precision_good) {
-  std::string str = HeaderWith(
-                        "ArbitraryPrecisionIntegersINTEL "
-                        "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
-                    " %2 = OpTypeInt 4 0";
+  std::string str =
+      HeaderWith(
+          "ArbitraryPrecisionIntegersINTEL "
+          "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
+      " %2 = OpTypeInt 4 0";
   CompileSuccessfully(str.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
 }
 
 TEST_F(ValidateData, int4_signed_with_arbitrary_precision_good) {
-  std::string str = HeaderWith(
-                        "ArbitraryPrecisionIntegersINTEL "
-                        "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
-                    " %2 = OpTypeInt 4 1";
+  std::string str =
+      HeaderWith(
+          "ArbitraryPrecisionIntegersINTEL "
+          "OpExtension \"SPV_INTEL_arbitrary_precision_integers\"") +
+      " %2 = OpTypeInt 4 1";
   CompileSuccessfully(str.c_str());
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
 }


### PR DESCRIPTION
Allow 4-bit integers with Int4TypeINTEL

Required for test in LLVM tree: https://github.com/llvm/llvm-project/blob/6b0d268fe544b25fd1f82aad4e246f8a74e260ed/llvm/test/CodeGen/SPIRV/legalization/icmp_extended_int.ll

Extension ref: https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_int4.asciidoc