### PR TITLE
spirv-val: Handle OpSpecConstantDataKHR

### DIFF
--- a/source/opcode.cpp
+++ b/source/opcode.cpp
@@ -167,17 +167,6 @@ bool spvOpcodeIsConstantOrUndef(const spv::Op opcode) {
   return opcode == spv::Op::OpUndef || spvOpcodeIsConstant(opcode);
 }
 
-bool spvOpcodeIsScalarSpecConstant(const spv::Op opcode) {
-  switch (opcode) {
-    case spv::Op::OpSpecConstantTrue:
-    case spv::Op::OpSpecConstantFalse:
-    case spv::Op::OpSpecConstant:
-      return true;
-    default:
-      return false;
-  }
-}
-
 int32_t spvOpcodeIsComposite(const spv::Op opcode) {
   switch (opcode) {
     case spv::Op::OpTypeVector:

--- a/source/opcode.h
+++ b/source/opcode.h
@@ -58,9 +58,6 @@ int32_t spvOpcodeIsConstant(const spv::Op opcode);
 // Returns true if the given opcode is a constant or undef.
 bool spvOpcodeIsConstantOrUndef(const spv::Op opcode);
 
-// Returns true if the given opcode is a scalar specialization constant.
-bool spvOpcodeIsScalarSpecConstant(const spv::Op opcode);
-
 // Determines if the given opcode is a composite type. Returns zero if false,
 // non-zero otherwise.
 int32_t spvOpcodeIsComposite(const spv::Op opcode);

--- a/source/opt/canonicalize_ids_pass.cpp
+++ b/source/opt/canonicalize_ids_pass.cpp
@@ -276,6 +276,7 @@ spv::Id CanonicalizeIdsPass::HashTypeAndConst(spv::Id const id) const {
     case spv::Op::OpSpecConstantCompositeReplicateEXT:
     case spv::Op::OpSpecConstantOp:
     case spv::Op::OpSpecConstantStringAMDX:
+    case spv::Op::OpSpecConstantDataKHR:
       value = unmapped_;
       break;
     // TODO: Add additional types/constants as needed. See

--- a/source/opt/freeze_spec_constant_value_pass.cpp
+++ b/source/opt/freeze_spec_constant_value_pass.cpp
@@ -35,6 +35,10 @@ Pass::Status FreezeSpecConstantValuePass::Process() {
         inst->SetOpcode(spv::Op::OpConstantFalse);
         modified = true;
         break;
+      case spv::Op::OpSpecConstantDataKHR:
+        inst->SetOpcode(spv::Op::OpConstantDataKHR);
+        modified = true;
+        break;
       case spv::Op::OpDecorate:
         if (spv::Decoration(inst->GetSingleWordInOperand(1)) ==
             spv::Decoration::SpecId) {

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
-#include <tuple>
 #include <vector>
 
 #include "source/opt/def_use_manager.h"
@@ -127,6 +126,11 @@ std::vector<uint32_t> ParseDefaultValueBitPattern(
       }
       return result;
     }
+  } else if (type->AsArray()) {
+    // This is only for OpSpecConstantDataKHR
+    // Since the length can be a spec constant as well,
+    // we just pass through the bit pattern
+    return std::vector<uint32_t>(input_bit_pattern);
   }
   result.clear();
   return result;
@@ -139,6 +143,7 @@ bool CanHaveSpecIdDecoration(const Instruction& inst) {
     case spv::Op::OpSpecConstant:
     case spv::Op::OpSpecConstantFalse:
     case spv::Op::OpSpecConstantTrue:
+    case spv::Op::OpSpecConstantDataKHR:
       return true;
     default:
       return false;
@@ -224,6 +229,9 @@ Pass::Status SetSpecConstantDefaultValuePass::Process() {
   constexpr uint32_t kOpDecorateSpecIdNumOperands = 3;
   // The in-operand index of the default value in a OpSpecConstant instruction.
   constexpr uint32_t kOpSpecConstantLiteralInOperandIndex = 0;
+  // The in-operand index of the default value in a OpSpecConstantData
+  // instruction.
+  constexpr uint32_t kOpSpecConstantDataLiteralInOperandIndex = 0;
 
   bool modified = false;
   // Scan through all the annotation instructions to find 'OpDecorate SpecId'
@@ -324,6 +332,21 @@ Pass::Status SetSpecConstantDefaultValuePass::Process() {
           modified = true;
         }
         break;
+      case spv::Op::OpSpecConstantDataKHR: {
+        if (spec_inst->GetInOperand(kOpSpecConstantDataLiteralInOperandIndex)
+                .words != bit_pattern) {
+          std::vector<Operand> operands;
+          // keep the result/type
+          operands.push_back(spec_inst->GetOperand(0u));
+          operands.push_back(spec_inst->GetOperand(1u));
+          // always update, the validator is in charge of making sure the length
+          // matches
+          operands.emplace_back(SPV_OPERAND_TYPE_LITERAL_INTEGER, bit_pattern);
+          spec_inst->ReplaceOperands(operands);
+          modified = true;
+        }
+        break;
+      }
       default:
         break;
     }

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -16,7 +16,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <vector>
 
 #include "source/opt/def_use_manager.h"
@@ -339,9 +341,11 @@ Pass::Status SetSpecConstantDefaultValuePass::Process() {
           // keep the result/type
           operands.push_back(spec_inst->GetOperand(0u));
           operands.push_back(spec_inst->GetOperand(1u));
-          // always update, the validator is in charge of making sure the length
-          // matches
-          operands.emplace_back(SPV_OPERAND_TYPE_LITERAL_INTEGER, bit_pattern);
+          // the validator is in charge of making sure the length matches
+          for (uint32_t word : bit_pattern) {
+            operands.emplace_back(SPV_OPERAND_TYPE_LITERAL_INTEGER,
+                                  std::initializer_list<uint32_t>{word});
+          }
           spec_inst->ReplaceOperands(operands);
           modified = true;
         }

--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -119,8 +119,12 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
   };
   switch (dec) {
     case spv::Decoration::SpecId:
-      if (!spvOpcodeIsScalarSpecConstant(target->opcode())) {
-        return fail(0) << "must be a scalar specialization constant";
+      if (target->opcode() != spv::Op::OpSpecConstantTrue &&
+          target->opcode() != spv::Op::OpSpecConstantFalse &&
+          target->opcode() != spv::Op::OpSpecConstant &&
+          target->opcode() != spv::Op::OpSpecConstantDataKHR) {
+        return fail(0) << "must be OpSpecConstantTrue, OpSpecConstantFalse, "
+                          "OpSpecConstant, or OpSpecConstantDataKHR";
       }
       break;
     case spv::Decoration::Block:

--- a/test/opt/freeze_spec_const_test.cpp
+++ b/test/opt/freeze_spec_const_test.cpp
@@ -172,6 +172,52 @@ TEST_F(FreezeSpecConstantValueRemoveDecorationTest,
                                                      /* skip_nop = */ true);
 }
 
+TEST_F(FreezeSpecConstantValueRemoveDecorationTest, ConstantData) {
+  std::vector<const char*> text = {
+      // clang-format off
+               "OpCapability Shader",
+               "OpCapability ConstantDataKHR",
+               "OpExtension \"SPV_KHR_constant_data\"",
+               "OpMemoryModel Logical GLSL450",
+               "OpEntryPoint GLCompute %uint_1 \"main\"",
+               "OpExecutionMode %2 LocalSize 1 1 1",
+               "OpDecorate %uint_1 SpecId 1",
+               "OpDecorate %3 SpecId 2",
+       "%void = OpTypeVoid",
+       "%uint = OpTypeInt 32 0",
+     "%uint_1 = OpSpecConstant %uint 1",
+"%_arr_uint_2 = OpTypeArray %uint %2",
+          "%3 = OpSpecConstantDataKHR %_arr_uint_2 1",
+          "%7 = OpTypeFunction %void",
+          "%8 = OpFunction %void None %7",
+          "%9 = OpLabel",
+               "OpReturn",
+               "OpFunctionEnd",
+
+      // clang-format on
+  };
+  std::string expected_disassembly = SelectiveJoin(text, [](const char* line) {
+    return std::string(line).find("SpecId") != std::string::npos;
+  });
+  std::vector<std::pair<const char*, const char*>> replacement_pairs = {
+      {"%uint_1 = OpSpecConstant %uint 1", "%uint_1 = OpConstant %uint 1"},
+      {"%3 = OpSpecConstantDataKHR %_arr_uint_2 1",
+       "%3 = OpConstantDataKHR %_arr_uint_2 1"},
+  };
+  for (auto& p : replacement_pairs) {
+    EXPECT_TRUE(FindAndReplace(&expected_disassembly, p.first, p.second))
+        << "text:\n"
+        << expected_disassembly << "\n"
+        << "find_str:\n"
+        << p.first << "\n"
+        << "replace_str:\n"
+        << p.second << "\n";
+  }
+  SinglePassRunAndCheck<FreezeSpecConstantValuePass>(JoinAllInsts(text),
+                                                     expected_disassembly,
+                                                     /* skip_nop = */ true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/set_spec_const_default_value_test.cpp
+++ b/test/opt/set_spec_const_default_value_test.cpp
@@ -1027,6 +1027,114 @@ INSTANTIATE_TEST_SUITE_P(
             "%3 = OpSpecConstant %uchar 0\n"
             "%4 = OpSpecConstant %uchar 214\n",
         },
+        // 23. ConstantData - no spec provided
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 1\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{888, {0x01020304}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 1\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 0\n",
+        },
+        // 24. ConstantData - only data - uint32
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_1 = OpConstant %uint 1\n"
+            "%_arr_uint_uint_1 = OpTypeArray %uint %uint_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_1 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x01020304}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_1 = OpConstant %uint 1\n"
+            "%_arr_uint_uint_1 = OpTypeArray %uint %uint_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_1 16909060\n",
+        },
+        // 25. ConstantData - only data - int8
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%char = OpTypeInt 8 1\n"
+            "%char_1 = OpConstant %char 1\n"
+            "%_arr_char_char_1 = OpTypeArray %char %char_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_char_char_1 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x01020304}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%char = OpTypeInt 8 1\n"
+            "%char_1 = OpConstant %char 1\n"
+            "%_arr_char_char_1 = OpTypeArray %char %char_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_char_char_1 16909060\n",
+        },
+        // 26. ConstantData - only data - uint64
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%ulong_1 = OpConstant %ulong 1\n"
+            "%_arr_ulong_ulong_1 = OpTypeArray %ulong %ulong_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_ulong_ulong_1 0 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x01020304, 0x1}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%ulong = OpTypeInt 64 0\n"
+            "%ulong_1 = OpConstant %ulong 1\n"
+            "%_arr_ulong_ulong_1 = OpTypeArray %ulong %ulong_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_ulong_ulong_1 16909060 1\n",
+        },
+        // 27. ConstantData - expand length - uint32
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 1\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x1, 0x2, 0x3, 0x4}}, {101, {4}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 4\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 1 2 3 4\n",
+        },
+        // 28. ConstantData - shrink length - uint32
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 4\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 1 2 3 4\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x5, 0x6}}, {101, {2}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "OpDecorate %2 SpecId 101\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%2 = OpSpecConstant %uint 2\n"
+            "%_arr_uint_2 = OpTypeArray %uint %2\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_2 5 6\n",
+        },
     }));
 
 INSTANTIATE_TEST_SUITE_P(
@@ -1161,6 +1269,40 @@ INSTANTIATE_TEST_SUITE_P(
             "%1 = OpSpecConstant %int 100\n"
             "%2 = OpSpecConstant %ulong 200\n"
             "%3 = OpSpecConstant %double 3.141592653\n",
+        },
+        // 7. ConstantData - expand length
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_1 = OpConstant %uint 1\n"
+            "%_arr_uint_uint_1 = OpTypeArray %uint %uint_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_1 0\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {0x01020304, 0x0, 0x1, 0x2}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_1 = OpConstant %uint 1\n"
+            "%_arr_uint_uint_1 = OpTypeArray %uint %uint_1\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_1 16909060 0 1 2\n",
+        },
+        // 8. ConstantData - shrink length
+        {
+            // code
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_4 = OpConstant %uint 4\n"
+            "%_arr_uint_uint_4 = OpTypeArray %uint %uint_4\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_4 0 1 2 3\n",
+            // default values
+            SpecIdToValueBitPatternMap{{100, {4, 5}}},
+            // expected
+            "OpDecorate %1 SpecId 100\n"
+            "%uint = OpTypeInt 32 0\n"
+            "%uint_4 = OpConstant %uint 4\n"
+            "%_arr_uint_uint_4 = OpTypeArray %uint %uint_4\n"
+            "%1 = OpSpecConstantDataKHR %_arr_uint_uint_4 4 5\n",
         },
     }));
 

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -388,9 +388,7 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataSpecLength) {
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
-// TODO - We never tested this when writting the spec
-// https://gitlab.khronos.org/spirv/SPIR-V/-/issues/927
-TEST_F(ValidateSpvKHRAbort, DISABLED_ConstantDataSpecLengthAndData) {
+TEST_F(ValidateSpvKHRAbort, ConstantDataSpecLengthAndData) {
   const std::string str = R"(
                OpCapability Shader
                OpCapability ConstantDataKHR

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -5995,9 +5995,10 @@ OpFunctionEnd
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(
       getDiagnosticString(),
-      HasSubstr(make_message("SpecId decoration on target <id> "
-                             "'1[%uint_3]' must be a scalar specialization "
-                             "constant")));
+      HasSubstr(make_message(
+          "SpecId decoration on target <id> "
+          "'1[%uint_3]' must be OpSpecConstantTrue, OpSpecConstantFalse, "
+          "OpSpecConstant, or OpSpecConstantDataKHR")));
 }
 
 TEST_P(ValidateIdWithMessage, SpecIdTargetOpSpecConstantOpBad) {
@@ -6019,7 +6020,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(make_message("SpecId decoration on target <id> '1[%1]' "
-                             "must be a scalar specialization constant")));
+                             "must be OpSpecConstantTrue, OpSpecConstantFalse, "
+                             "OpSpecConstant, or OpSpecConstantDataKHR")));
 }
 
 TEST_P(ValidateIdWithMessage, SpecIdTargetOpSpecConstantCompositeBad) {
@@ -6040,7 +6042,8 @@ OpFunctionEnd
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr(make_message("SpecId decoration on target <id> '1[%1]' "
-                             "must be a scalar specialization constant")));
+                             "must be OpSpecConstantTrue, OpSpecConstantFalse, "
+                             "OpSpecConstant, or OpSpecConstantDataKHR")));
 }
 
 TEST_P(ValidateIdWithMessage, SpecIdTargetGood) {


### PR DESCRIPTION
@alan-baker this adds the `spirv-val` to handle `OpSpecConstantDataKHR`

I took out of `opcode.h` because it was only used in `spirv-val` in that one spot. The next (and hopefully final) PR after this is to fix all the `spirv-opt` passes to handle this "joy to use" spec constant instruction correctly

----

**Edit:** - Just added the `CreateSetSpecConstantDefaultValuePass` and `CreateFreezeSpecConstantValuePass` pass as well