### PR TITLE
build: Fix BUILD.gn for NonSemanticShaderDebugInfo

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -156,9 +156,9 @@ spvtools_language_header("cldebuginfo100") {
   name = "OpenCLDebugInfo100"
   grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json"
 }
-spvtools_language_header("vkdebuginfo100") {
-  name = "NonSemanticShaderDebugInfo100"
-  grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json"
+spvtools_language_header("vkdebuginfo") {
+  name = "NonSemanticShaderDebugInfo"
+  grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json"
 }
 
 config("spvtools_public_config") {
@@ -218,7 +218,7 @@ group("spvtools_language_headers") {
   public_deps = [
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
-    ":spvtools_language_header_vkdebuginfo100",
+    ":spvtools_language_header_vkdebuginfo",
   ]
 }
 
@@ -228,7 +228,7 @@ static_library("spvtools") {
     ":spvtools_generators_inc",
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
-    ":spvtools_language_header_vkdebuginfo100",
+    ":spvtools_language_header_vkdebuginfo",
   ]
 
   sources = [
@@ -387,7 +387,7 @@ static_library("spvtools_val") {
     ":spvtools",
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
-    ":spvtools_language_header_vkdebuginfo100",
+    ":spvtools_language_header_vkdebuginfo",
   ]
   public_deps = [ ":spvtools_headers" ]
 
@@ -655,7 +655,7 @@ static_library("spvtools_opt") {
   public_deps = [
     ":spvtools_headers",
     ":spvtools_language_header_cldebuginfo100",
-    ":spvtools_language_header_vkdebuginfo100",
+    ":spvtools_language_header_vkdebuginfo",
   ]
 
   if (build_with_chromium) {
@@ -1258,7 +1258,7 @@ if (build_with_chromium && spvtools_build_executables) {
       ":spvtools",
       ":spvtools_language_header_cldebuginfo100",
       ":spvtools_language_header_debuginfo",
-      ":spvtools_language_header_vkdebuginfo100",
+      ":spvtools_language_header_vkdebuginfo",
       ":spvtools_tools_io",
       ":spvtools_val",
       "//testing/gmock",


### PR DESCRIPTION
Fix for @y-novikov (https://github.com/KhronosGroup/SPIRV-Tools/pull/6635#issuecomment-4283010149)

