### PR TITLE
spirv-val: Print source line in Validation message

### DIFF
--- a/source/diagnostic.cpp
+++ b/source/diagnostic.cpp
@@ -106,8 +106,10 @@ DiagnosticStream::~DiagnosticStream() {
       default:
         break;
     }
-    if (disassembled_instruction_.size() > 0)
+    if (!disassembled_instruction_.empty())
       stream_ << std::endl << "  " << disassembled_instruction_ << std::endl;
+
+    if (!shader_debug_info_.empty()) stream_ << shader_debug_info_;
 
     consumer_(level, "input", position_, stream_.str().c_str());
   }

--- a/source/diagnostic.h
+++ b/source/diagnostic.h
@@ -30,11 +30,12 @@ class DiagnosticStream {
  public:
   DiagnosticStream(spv_position_t position, const MessageConsumer& consumer,
                    const std::string& disassembled_instruction,
-                   spv_result_t error)
+                   spv_result_t error, std::string shader_debug_info = "")
       : position_(position),
         consumer_(consumer),
         disassembled_instruction_(disassembled_instruction),
-        error_(error) {}
+        error_(error),
+        shader_debug_info_(shader_debug_info) {}
 
   // Creates a DiagnosticStream from an expiring DiagnosticStream.
   // The new object takes the contents of the other, and prevents the
@@ -62,6 +63,8 @@ class DiagnosticStream {
   MessageConsumer consumer_;  // Message consumer callback.
   std::string disassembled_instruction_;
   spv_result_t error_;
+  // Provide way to pass optional information from ShaderDebugInfo
+  std::string shader_debug_info_;
 };
 
 // Changes the MessageConsumer in |context| to one that updates |diagnostic|

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1350,6 +1350,8 @@ spv_result_t ValidateExtInstImport(ValidationState_t& _,
              << "NonSemantic.Shader.DebugInfo import version " << ver
              << " is below the minimum supported version " << kNSDIMinVersion;
     }
+
+    _.RegisterShaderDebugInfo(inst->id());
   }
 
   return SPV_SUCCESS;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -18,7 +18,9 @@
 
 #include <cassert>
 #include <cstdint>
+#include <sstream>
 #include <stack>
+#include <string>
 #include <utility>
 
 #include "source/opcode.h"
@@ -29,7 +31,10 @@
 #include "source/val/basic_block.h"
 #include "source/val/construct.h"
 #include "source/val/function.h"
+#include "source/val/instruction.h"
 #include "spirv-tools/libspirv.h"
+#include "spirv/unified1/NonSemanticShaderDebugInfo.h"
+#include "spirv/unified1/spirv.hpp11"
 
 namespace spvtools {
 namespace val {
@@ -348,10 +353,15 @@ DiagnosticStream ValidationState_t::diag(spv_result_t error_code,
   }
 
   std::string disassembly;
-  if (inst) disassembly = Disassemble(*inst);
+  std::string shader_debug_info;
+  if (inst) {
+    disassembly = Disassemble(*inst);
+    shader_debug_info = InspectShaderDebugInfo(*inst);
+  }
 
   return DiagnosticStream({0, 0, inst ? inst->LineNum() : 0},
-                          context_->consumer, disassembly, error_code);
+                          context_->consumer, disassembly, error_code,
+                          shader_debug_info);
 }
 
 std::vector<Function>& ValidationState_t::functions() {
@@ -2168,6 +2178,133 @@ std::vector<uint32_t>& ValidationState_t::GetDebugSourceLineLength(
     return debug_source_line_length_[id];
   }
   return it->second;
+}
+
+std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
+  const uint32_t set_id = ShaderDebugInfoSet();
+  if (set_id == 0) {
+    return "";  // no ShaderDebugInfo found
+  } else if (inst.function() == nullptr) {
+    // currently only checking for code in function blocks
+    return "";
+  }
+
+  // Find the DebugLine that is preceding
+  const Instruction* debug_line_inst = nullptr;
+  size_t idx = &inst - &ordered_instructions()[0];
+  while (idx > 0) {
+    const Instruction* prev = &ordered_instructions()[--idx];
+    if (prev->opcode() == spv::Op::OpFunction) {
+      break;
+    }
+
+    if (prev->opcode() == spv::Op::OpExtInst &&
+        prev->GetOperandAs<uint32_t>(2) == set_id &&
+        prev->GetOperandAs<uint32_t>(3) ==
+            NonSemanticShaderDebugInfoDebugLine) {
+      debug_line_inst = prev;
+      break;
+    }
+  }
+
+  if (!debug_line_inst) return "";
+
+  const Instruction* debug_source =
+      FindDef(debug_line_inst->GetOperandAs<uint32_t>(4));
+  if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
+                           NonSemanticShaderDebugInfoDebugSource) {
+    return "";
+  }
+
+  bool is_int32 = false, is_const_int32 = false;
+  uint32_t line_start = 0;
+  uint32_t line_end = 0;
+  uint32_t column_start = 0;
+  uint32_t column_end = 0;
+  std::tie(is_int32, is_const_int32, line_start) =
+      EvalInt32IfConst(debug_line_inst->word(6));
+  std::tie(is_int32, is_const_int32, line_end) =
+      EvalInt32IfConst(debug_line_inst->word(7));
+  std::tie(is_int32, is_const_int32, column_start) =
+      EvalInt32IfConst(debug_line_inst->word(8));
+  std::tie(is_int32, is_const_int32, column_end) =
+      EvalInt32IfConst(debug_line_inst->word(9));
+
+  std::ostringstream ss;
+
+  // The left hand side line number, need to make sure if going from line number
+  // 99 to 100 that all lines have the same padding
+  const size_t vertical_line_padding = std::to_string(line_end).length();
+  auto add_vertical_line = [&](uint32_t line_number) {
+    size_t padding = 1;
+    if (line_number != 0) {
+      ss << line_number;
+      padding += (vertical_line_padding - std::to_string(line_number).length());
+    } else {
+      padding += vertical_line_padding;
+    }
+    for (size_t p = 0; p < padding; p++) {
+      ss << " ";
+    }
+    ss << "|";
+    if (line_number != 0) {
+      ss << " ";  // otherwise test will fail from trailing whitespace being
+                  // trimmed
+    }
+  };
+
+  uint32_t current_line_num = 1;
+  auto stream_text = [&](const Instruction* op_string) {
+    const std::string text = op_string->GetOperandAs<std::string>(1);
+    for (const char c : text) {
+      if (current_line_num >= line_start && current_line_num <= line_end) {
+        ss << c;
+        if (c == '\n' && current_line_num < line_end) {
+          add_vertical_line(current_line_num + 1);
+        }
+      }
+
+      if (c == '\n') {
+        current_line_num++;
+      }
+    }
+  };
+
+  const Instruction* file_string =
+      FindDef(debug_source->GetOperandAs<uint32_t>(4));
+  ss << "\n  --> " << file_string->GetOperandAs<std::string>(1) << ":"
+     << line_start << ":" << column_start << '\n';
+
+  add_vertical_line(0);
+  ss << '\n';
+
+  const Instruction* source_string =
+      FindDef(debug_source->GetOperandAs<uint32_t>(5));
+  add_vertical_line(line_start);
+  stream_text(source_string);
+
+  // Look for any DebugSourceContinued
+  size_t src_idx = debug_source - &ordered_instructions()[0] + 1;
+  for (; src_idx < ordered_instructions().size(); ++src_idx) {
+    const Instruction& continued_insn = ordered_instructions()[src_idx];
+    if (continued_insn.opcode() != spv::Op::OpExtInst ||
+        continued_insn.GetOperandAs<uint32_t>(2) != set_id ||
+        continued_insn.GetOperandAs<uint32_t>(3) !=
+            NonSemanticShaderDebugInfoDebugSourceContinued) {
+      break;
+    }
+
+    const Instruction* continued_string =
+        FindDef(continued_insn.GetOperandAs<uint32_t>(4));
+    stream_text(continued_string);
+  }
+
+  // This happens if the error is the last line of source
+  if (current_line_num == line_end) ss << "\n";
+
+  add_vertical_line(0);
+  ss << "\n";
+  return ss.str();
 }
 
 bool ValidationState_t::IsValidStorageClass(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1004,6 +1004,10 @@ class ValidationState_t {
   // instruction Will create a new vector if DebugSource is not found
   std::vector<uint32_t>& GetDebugSourceLineLength(uint32_t id);
 
+  void RegisterShaderDebugInfo(uint32_t id) { shader_debug_info_set_id = id; }
+  uint32_t ShaderDebugInfoSet() const { return shader_debug_info_set_id; }
+  std::string InspectShaderDebugInfo(const Instruction& inst);
+
  private:
   ValidationState_t(const ValidationState_t&);
 
@@ -1185,6 +1189,10 @@ class ValidationState_t {
   /// Maps an id of DebugSource to a vector that contains the length of each
   /// line side of it. (Also will have the DebugSourceContinued source included)
   std::unordered_map<uint32_t, std::vector<uint32_t>> debug_source_line_length_;
+
+  // Quick check if we have seen NonSemantic.Shader.DebugInfo.*
+  // to know to try and print out a source line on an error message
+  uint32_t shader_debug_info_set_id = 0;
 
   /// Maps ids to friendly names.
   std::unique_ptr<spvtools::FriendlyNameMapper> friendly_mapper_;

--- a/test/val/CMakeLists.txt
+++ b/test/val/CMakeLists.txt
@@ -108,6 +108,7 @@ add_spvtools_unittest(TARGET val_rstuvw
        val_ray_query_test.cpp
        val_ray_tracing_test.cpp
        val_ray_tracing_reorder_test.cpp
+       val_shader_debug_info_test.cpp
        val_small_type_uses_test.cpp
        val_ssa_test.cpp
        val_state_test.cpp

--- a/test/val/val_id_test.cpp
+++ b/test/val/val_id_test.cpp
@@ -4562,6 +4562,7 @@ TEST_P(ValidateIdWithMessage, OpFunctionFunctionTypeBad) {
 %5 = OpLabel
      OpReturn
 OpFunctionEnd)";
+  printf("%s\n", spirv.c_str());
   CompileSuccessfully(spirv.c_str());
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests displaying ShaderDebugInfo in validation error messages
+
+#include <string>
+
+#include "gmock/gmock.h"
+#include "test/val/val_fixtures.h"
+
+namespace spvtools {
+namespace val {
+namespace {
+
+using ::testing::HasSubstr;
+
+using ValidateShaderDebugInfo = spvtest::ValidateBase<bool>;
+
+TEST_F(ValidateShaderDebugInfo, DebugLineSingleLine) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+         %19 = OpString "#version 450
+layout(set = 0, binding = 1, std430) buffer SSBO {
+    vec4 data;
+};
+
+void main() {
+    data = vec4(0.0);
+}"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %_ Binding 1
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_0 = OpConstant %uint 0
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %SSBO = OpTypeStruct %v4float
+%_ptr_StorageBuffer_SSBO = OpTypePointer StorageBuffer %SSBO
+    %uint_12 = OpConstant %uint 12
+          %_ = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %uint_7 = OpConstant %uint 7
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %54 = OpExtInst %void %1 DebugLine %18 %uint_7 %uint_7 %uint_0 %uint_0
+         ;; invalid here
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %_ %int_0 %int_0 %int_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_1);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:7:0
+  |
+7 |     data = vec4(0.0);
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, DebugLineMultieLine) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+         %19 = OpString "#version 450
+layout(set = 0, binding = 1, std430) buffer SSBO {
+    vec4 data;
+};
+
+void main() {
+    data = vec4(0.0);
+}"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %_ Binding 1
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_0 = OpConstant %uint 0
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %SSBO = OpTypeStruct %v4float
+%_ptr_StorageBuffer_SSBO = OpTypePointer StorageBuffer %SSBO
+    %uint_12 = OpConstant %uint 12
+          %_ = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %uint_6 = OpConstant %uint 6
+     %uint_8 = OpConstant %uint 8
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %54 = OpExtInst %void %1 DebugLine %18 %uint_6 %uint_8 %uint_0 %uint_0
+         ;; invalid here
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %_ %int_0 %int_0 %int_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_1);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:6:0
+  |
+6 | void main() {
+7 |     data = vec4(0.0);
+8 | }
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, DebugSourceContinued) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+         %text = OpString "#version 450
+layout(set = 0, binding = 1, std430) buffer SSBO {
+    vec4 data;
+};
+
+"
+          %text1 = OpString "void main() {"
+          %text2 = OpString "
+    data = vec4"
+          %text3 = OpString "(0.0);
+}"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %_ Binding 1
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_0 = OpConstant %uint 0
+
+   %d_source = OpExtInst %void %1 DebugSource %2 %text
+         %d1 = OpExtInst %void %1 DebugSourceContinued %text1
+         %d2 = OpExtInst %void %1 DebugSourceContinued %text2
+         %d3 = OpExtInst %void %1 DebugSourceContinued %text3
+
+         %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %SSBO = OpTypeStruct %v4float
+%_ptr_StorageBuffer_SSBO = OpTypePointer StorageBuffer %SSBO
+    %uint_12 = OpConstant %uint 12
+          %_ = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %uint_6 = OpConstant %uint 6
+     %uint_8 = OpConstant %uint 8
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %54 = OpExtInst %void %1 DebugLine %d_source %uint_6 %uint_8 %uint_0 %uint_0
+         ;; invalid here
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %_ %int_0 %int_0 %int_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_1);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:6:0
+  |
+6 | void main() {
+7 |     data = vec4(0.0);
+8 | }
+  |)"));
+}
+
+// Make sure we can handle various instructions where there DebugInfo is unused
+TEST_F(ValidateShaderDebugInfo, UnusedOpFunction) {
+  const std::string str = R"(
+     OpCapability Shader
+     OpCapability Linkage
+     OpExtension "SPV_KHR_non_semantic_info"
+%d = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+     OpMemoryModel Logical GLSL450
+%1 = OpTypeVoid
+%2 = OpTypeInt 32 0
+%4 = OpFunction %1 None %2
+%5 = OpLabel
+     OpReturn
+     OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr(
+          "OpFunction Function Type <id> '3[%uint]' is not a function type."));
+}
+
+}  // namespace
+}  // namespace val
+}  // namespace spvtools


### PR DESCRIPTION
part 1 of https://github.com/KhronosGroup/SPIRV-Tools/issues/6617

This just adds line number, next will look into adding columns and things like `OpType*` or `OpVariable` (want to plumb in the whole ShaderDebugInfo stuff first)

Current output looks like

```
error: 34: OpAccessChain reached non-composite type while indexes still remain to be traversed.
  %25 = OpAccessChain %_ptr_StorageBuffer_v4float %6 %int_0 %int_0 %int_0

  --> a.comp:7:0
  |
7 |     data = vec4(0.0);
  |
```

and 

```
error: 41: OpAccessChain reached non-composite type while indexes still remain to be traversed.
  %32 = OpAccessChain %_ptr_StorageBuffer_v4float %9 %int_0 %int_0 %int_0

  --> a.comp:6:0
  |
6 | void main() {
7 |     data = vec4(0.0);
8 | }
  |
```