### PR TITLE
spirv-val: Derivative instructions with half

### DIFF
--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -45,9 +45,15 @@ spv_result_t DerivativesPass(ValidationState_t& _, const Instruction* inst) {
                << spvOpcodeString(opcode);
       }
       if (!_.ContainsSizedIntOrFloatType(result_type, spv::Op::OpTypeFloat,
-                                         32)) {
+                                         32) &&
+          (!_.HasExtension(kSPV_AMD_gpu_shader_half_float) ||
+           !_.ContainsSizedIntOrFloatType(result_type, spv::Op::OpTypeFloat,
+                                          16))) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Result type component width must be 32 bits";
+               << "Result type component width must be "
+               << (_.HasExtension(kSPV_AMD_gpu_shader_half_float)
+                       ? "16 bits or 32 bits"
+                       : "32 bits");
       }
 
       const uint32_t p_type = _.GetOperandTypeId(inst, 2);

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -188,6 +188,19 @@ OpFunctionEnd
 
 using ValidateHalfDerivatives = spvtest::ValidateBase<std::string>;
 
+TEST_P(ValidateHalfDerivatives, ScalarSuccess) {
+  const std::string op = GetParam();
+  const std::string body = "%val = " + op + " %f16 %f16_0\n";
+  const std::string capabilities_and_extensions = R"(
+OpCapability Float16
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, capabilities_and_extensions).c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_P(ValidateHalfDerivatives, ScalarFailure) {
   const std::string op = GetParam();
   const std::string body = "%val = " + op + " %f16 %f16_0\n";
@@ -197,6 +210,19 @@ TEST_P(ValidateHalfDerivatives, ScalarFailure) {
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Result type component width must be 32 bits"));
+}
+
+TEST_P(ValidateHalfDerivatives, VectorSuccess) {
+  const std::string op = GetParam();
+  const std::string body = "%val = " + op + " %f16vec4 %f16vec4_0\n";
+  const std::string capabilities_and_extensions = R"(
+OpCapability Float16
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, capabilities_and_extensions).c_str());
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
 TEST_P(ValidateHalfDerivatives, VectorFailure) {


### PR DESCRIPTION
GL_AMD_gpu_shader_half_float allows us to use half type in derivative instructions. But the corresponding extension of SPIR-V appears to only explicitly allow half type for interpolation function, doesn't mention derivative functions.

Recently, one PR in SPIRV-Registry was updated this extension, and updated spec to match the behavior of GLSLang.

GLSLang extension:
https://registry.khronos.org/OpenGL/extensions/AMD/AMD_gpu_shader_half_float.txt

Extension update: https://github.com/KhronosGroup/SPIRV-Registry/pull/403