### PR TITLE
spirv-val: Interpolation functions with half

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -1996,11 +1996,16 @@ spv_result_t ValidateExtInstGlslStd450(ValidationState_t& _,
       }
 
       if (!_.IsFloatScalarOrVectorType(result_type) ||
-          _.GetBitWidth(result_type) != 32) {
+          (_.GetBitWidth(result_type) != 32 &&
+           (!_.HasExtension(kSPV_AMD_gpu_shader_half_float) ||
+            _.GetBitWidth(result_type) != 16))) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << GetExtInstName(_, inst) << ": "
-               << "expected Result Type to be a 32-bit float scalar "
-               << "or vector type";
+               << "expected Result Type to be a "
+               << (_.HasExtension(kSPV_AMD_gpu_shader_half_float)
+                       ? "16-bit or 32-bit "
+                       : "32-bit ")
+               << "float scalar or vector type";
       }
 
       // If HLSL legalization and first operand is an OpLoad, use load
@@ -2047,10 +2052,16 @@ spv_result_t ValidateExtInstGlslStd450(ValidationState_t& _,
         const uint32_t offset_type = _.GetOperandTypeId(inst, 5);
         if (!_.IsFloatVectorType(offset_type) ||
             _.GetDimension(offset_type) != 2 ||
-            _.GetBitWidth(offset_type) != 32) {
+            (_.GetBitWidth(offset_type) != 32 &&
+             (!_.HasExtension(kSPV_AMD_gpu_shader_half_float) ||
+              _.GetBitWidth(offset_type) != 16))) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
                  << GetExtInstName(_, inst) << ": "
-                 << "expected Offset to be a vector of 2 32-bit floats";
+                 << "expected Offset to be a vector of 2 "
+                 << (_.HasExtension(kSPV_AMD_gpu_shader_half_float)
+                         ? "16-bit or 32-bit "
+                         : "32-bit ")
+                 << "floats";
         }
       }
 

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -97,17 +97,10 @@ OpCapability Int64
   ss << "%extinst = OpExtInstImport \"GLSL.std.450\"\n";
   ss << "OpMemoryModel Logical GLSL450\n";
   ss << "OpEntryPoint " << execution_model << " %main \"main\""
-     << " %f32_output"
-     << " %f32vec2_output"
-     << " %u32_output"
-     << " %u32vec2_output"
-     << " %u64_output"
-     << " %f32_input"
-     << " %f32vec2_input"
-     << " %u32_input"
-     << " %u32vec2_input"
-     << " %u64_input"
-     << "\n";
+     << " %f32_output" << " %f32vec2_output" << " %u32_output"
+     << " %u32vec2_output" << " %u64_output" << " %f16_input"
+     << " %f16vec2_input" << " %f32_input" << " %f32vec2_input" << " %u32_input"
+     << " %u32vec2_input" << " %u64_input" << "\n";
   if (execution_model == "Fragment") {
     ss << "OpExecutionMode %main OriginUpperLeft\n";
   }
@@ -125,6 +118,7 @@ OpCapability Int64
 %s64 = OpTypeInt 64 1
 %u16 = OpTypeInt 16 0
 %s16 = OpTypeInt 16 1
+%f16vec2 = OpTypeVector %f16 2
 %f32vec2 = OpTypeVector %f32 2
 %f32vec3 = OpTypeVector %f32 3
 %f32vec4 = OpTypeVector %f32 4
@@ -168,6 +162,7 @@ OpCapability Int64
 %f16_0 = OpConstant %f16 0
 %f16_1 = OpConstant %f16 1
 %f16_h = OpConstant %f16 0.5
+%f16vec2_01 = OpConstantComposite %f16vec2 %f16_0 %f16_1
 
 %u32_0 = OpConstant %u32 0
 %u32_1 = OpConstant %u32 1
@@ -220,6 +215,9 @@ OpCapability Int64
 
 %u64_output = OpVariable %u64_ptr_output Output
 
+%f16_ptr_input = OpTypePointer Input %f16
+%f16vec2_ptr_input = OpTypePointer Input %f16vec2
+
 %f32_ptr_input = OpTypePointer Input %f32
 %f32vec2_ptr_input = OpTypePointer Input %f32vec2
 
@@ -227,6 +225,9 @@ OpCapability Int64
 %u32vec2_ptr_input = OpTypePointer Input %u32vec2
 
 %u64_ptr_input = OpTypePointer Input %u64
+
+%f16_input = OpVariable %f16_ptr_input Input
+%f16vec2_input = OpVariable %f16vec2_ptr_input Input
 
 %f32_input = OpVariable %f32_ptr_input Input
 %f32vec2_input = OpVariable %f32vec2_ptr_input Input
@@ -2471,6 +2472,21 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidSuccess) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF16Success) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtCentroid %f16_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtCentroid %f16vec2_input
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidInternalSuccess) {
   const std::string body = R"(
 %ld1  = OpLoad %f32 %f32_input
@@ -2481,6 +2497,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidInternalSuccess) {
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  getValidatorOptions()->before_hlsl_legalization = true;
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF16InternalSuccess) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtCentroid %ld1
+%ld2  = OpLoad %f16vec2 %f16vec2_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtCentroid %ld2
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   getValidatorOptions()->before_hlsl_legalization = true;
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
@@ -2499,6 +2533,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidInternalInvalidDataF32) {
                         "expected Interpolant to be a pointer"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidInternalInvalidDataF16) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtCentroid %ld1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
+                        "expected Interpolant to be a pointer"));
+}
+
 TEST_F(ValidateExtInst,
        GlslStd450InterpolateAtCentroidInternalInvalidDataF32Vec2) {
   const std::string body = R"(
@@ -2508,6 +2560,25 @@ TEST_F(ValidateExtInst,
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
+                        "expected Interpolant to be a pointer"));
+}
+
+TEST_F(ValidateExtInst,
+       GlslStd450InterpolateAtCentroidInternalInvalidDataF16Vec2) {
+  const std::string body = R"(
+%ld2  = OpLoad %f16vec2 %f16vec2_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtCentroid %ld2
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
@@ -2540,6 +2611,20 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidIntResultType) {
                         "or vector type"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF16ResultType) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtCentroid %f16_input
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
+                        "expected Result Type to be a 32-bit float scalar "
+                        "or vector type"));
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF64ResultType) {
   const std::string body = R"(
 %val1 = OpExtInst %f64 %extinst InterpolateAtCentroid %f32_input
@@ -2552,6 +2637,25 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF64ResultType) {
               HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
                         "expected Result Type to be a 32-bit float scalar "
                         "or vector type"));
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidF64ResultTypeAmdExt) {
+  const std::string body = R"(
+%val1 = OpExtInst %f64 %extinst InterpolateAtCentroid %f32_input
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 InterpolateAtCentroid: "
+                "expected Result Type to be a 16-bit or 32-bit float scalar "
+                "or vector type"));
 }
 
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtCentroidNotPointer) {
@@ -2618,6 +2722,21 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleSuccess) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF16Success) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtSample %f16_input %u32_1
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtSample %f16vec2_input %u32_1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleInternalSuccess) {
   const std::string body = R"(
 %ld1  = OpLoad %f32 %f32_input
@@ -2628,6 +2747,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleInternalSuccess) {
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  getValidatorOptions()->before_hlsl_legalization = true;
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF16InternalSuccess) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtSample %ld1 %u32_1
+%ld2  = OpLoad %f16vec2 %f16vec2_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtSample %ld2 %u32_1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   getValidatorOptions()->before_hlsl_legalization = true;
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
@@ -2646,6 +2783,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleInternalInvalidDataF32) {
                         "expected Interpolant to be a pointer"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleInternalInvalidDataF16) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtSample %ld1 %u32_1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtSample: "
+                        "expected Interpolant to be a pointer"));
+}
+
 TEST_F(ValidateExtInst,
        GlslStd450InterpolateAtSampleInternalInvalidDataF32Vec2) {
   const std::string body = R"(
@@ -2655,6 +2810,25 @@ TEST_F(ValidateExtInst,
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtSample: "
+                        "expected Interpolant to be a pointer"));
+}
+
+TEST_F(ValidateExtInst,
+       GlslStd450InterpolateAtSampleInternalInvalidDataF16Vec2) {
+  const std::string body = R"(
+%ld2  = OpLoad %f16vec2 %f16vec2_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtSample %ld2 %u32_1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("GLSL.std.450 InterpolateAtSample: "
@@ -2687,6 +2861,20 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleIntResultType) {
                         "or vector type"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF16ResultType) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtSample %f16_input %u32_1
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtSample: "
+                        "expected Result Type to be a 32-bit float scalar "
+                        "or vector type"));
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF64ResultType) {
   const std::string body = R"(
 %val1 = OpExtInst %f64 %extinst InterpolateAtSample %f32_input %u32_1
@@ -2699,6 +2887,25 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF64ResultType) {
               HasSubstr("GLSL.std.450 InterpolateAtSample: "
                         "expected Result Type to be a 32-bit float scalar "
                         "or vector type"));
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleF64ResultTypeAmdExt) {
+  const std::string body = R"(
+%val1 = OpExtInst %f64 %extinst InterpolateAtSample %f32_input %u32_1
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 InterpolateAtSample: "
+                "expected Result Type to be a 16-bit or 32-bit float scalar "
+                "or vector type"));
 }
 
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtSampleNotPointer) {
@@ -2791,6 +2998,21 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetSuccess) {
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF16Success) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtOffset %f16_input %f16vec2_01
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtOffset %f16vec2_input %f16vec2_01
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetInternalSuccess) {
   const std::string body = R"(
 %ld1  = OpLoad %f32 %f32_input
@@ -2801,6 +3023,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetInternalSuccess) {
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  getValidatorOptions()->before_hlsl_legalization = true;
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF16InternalSuccess) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtOffset %ld1 %f16vec2_01
+%ld2  = OpLoad %f16vec2 %f16vec2_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtOffset %ld2 %f16vec2_01
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   getValidatorOptions()->before_hlsl_legalization = true;
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
@@ -2819,6 +3059,24 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetInternalInvalidDataF32) {
                         "expected Interpolant to be a pointer"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetInternalInvalidDataF16) {
+  const std::string body = R"(
+%ld1  = OpLoad %f16 %f16_input
+%val1 = OpExtInst %f16 %extinst InterpolateAtOffset %ld1 %f16vec2_01
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtOffset: "
+                        "expected Interpolant to be a pointer"));
+}
+
 TEST_F(ValidateExtInst,
        GlslStd450InterpolateAtOffsetInternalInvalidDataF32Vec2) {
   const std::string body = R"(
@@ -2828,6 +3086,25 @@ TEST_F(ValidateExtInst,
 
   CompileSuccessfully(
       GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtOffset: "
+                        "expected Interpolant to be a pointer"));
+}
+
+TEST_F(ValidateExtInst,
+       GlslStd450InterpolateAtOffsetInternalInvalidDataF16Vec2) {
+  const std::string body = R"(
+%ld2  = OpLoad %f16 %f16_input
+%val2 = OpExtInst %f16vec2 %extinst InterpolateAtOffset %ld2 %f16vec2_01
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("GLSL.std.450 InterpolateAtOffset: "
@@ -2860,6 +3137,20 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetIntResultType) {
                         "or vector type"));
 }
 
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF16ResultType) {
+  const std::string body = R"(
+%val1 = OpExtInst %f16 %extinst InterpolateAtOffset %f16_input %f16vec2_01
+)";
+
+  CompileSuccessfully(
+      GenerateShaderCode(body, "OpCapability InterpolationFunction\n"));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("GLSL.std.450 InterpolateAtOffset: "
+                        "expected Result Type to be a 32-bit float scalar "
+                        "or vector type"));
+}
+
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF64ResultType) {
   const std::string body = R"(
 %val1 = OpExtInst %f64 %extinst InterpolateAtOffset %f32_input %f32vec2_01
@@ -2872,6 +3163,25 @@ TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF64ResultType) {
               HasSubstr("GLSL.std.450 InterpolateAtOffset: "
                         "expected Result Type to be a 32-bit float scalar "
                         "or vector type"));
+}
+
+TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetF64ResultTypeAmdExt) {
+  const std::string body = R"(
+%val1 = OpExtInst %f64 %extinst InterpolateAtOffset %f32_input %f32vec2_01
+)";
+
+  const std::string capabilities_and_extensions = R"(
+OpCapability InterpolationFunction
+OpExtension  "SPV_AMD_gpu_shader_half_float"
+)";
+
+  CompileSuccessfully(GenerateShaderCode(body, capabilities_and_extensions));
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("GLSL.std.450 InterpolateAtOffset: "
+                "expected Result Type to be a 16-bit or 32-bit float scalar "
+                "or vector type"));
 }
 
 TEST_F(ValidateExtInst, GlslStd450InterpolateAtOffsetNotPointer) {


### PR DESCRIPTION
The SPV_AMD_gpu_shader_half_float extension allows us to use half type in interpolation functions. If this extension is declared in the SPIR-V, interpolation functions with half are considered valid. Other cases are still invalid.