### PR TITLE
kokoro: linux uses clang-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ also work, but are not verified.
 SPIRV-Tools is regularly tested with the following compilers:
 
 On Linux
-- GCC version 9.4
-- Clang version 10.0
+- GCC version 13
+- Clang version 18
 
 On MacOS
 - AppleClang 15.0

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -30,7 +30,7 @@ git config --global --add safe.directory '*'
 using python-3.12
 
 if [ $COMPILER = "clang" ]; then
-  using clang-13.0.1
+  using clang-18
 elif [ $COMPILER = "gcc" ]; then
   using gcc-13
 fi


### PR DESCRIPTION
Google-internal bug 393437270