### PR TITLE
spirv-val: Add remaining VUID check and unit tests for VK_QCOM_tile_s…

### DIFF
--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Google LLC.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,7 +124,7 @@ typedef enum VUIDError_ {
   VUIDErrorMax,
 } VUIDError;
 
-const static uint32_t NumVUIDBuiltins = 42;
+const static uint32_t NumVUIDBuiltins = 45;
 
 typedef struct {
   spv::BuiltIn builtIn;
@@ -176,7 +177,9 @@ std::array<BuiltinVUIDMapping, NumVUIDBuiltins> builtinVUIDInfo = {{
     {spv::BuiltIn::PrimitiveTriangleIndicesEXT, {7053, 7055, 7056}},
     {spv::BuiltIn::CullPrimitiveEXT,          {7034, 7035, 7036}},
     {spv::BuiltIn::HitTriangleVertexPositionsKHR, {8747, 8748, 8749}},
-
+    {spv::BuiltIn::TileOffsetQCOM,    {10626, 10627, 10628}},
+    {spv::BuiltIn::TileDimensionQCOM, {10629, 10630, 10631}},
+    {spv::BuiltIn::TileApronSizeQCOM, {10632, 10633, 10634}},
     // clang-format on
 }};
 
@@ -379,6 +382,9 @@ class BuiltInsValidator {
 
   spv_result_t ValidateMeshShadingEXTBuiltinsAtDefinition(
       const Decoration& decoration, const Instruction& inst);
+
+  spv_result_t ValidateTileQCOMBuiltinAtDefinition(const Decoration& decoration,
+                                                   const Instruction& inst);
 
   // Used as a common method for validating MeshEXT builtins
   spv_result_t ValidateMeshBuiltinInterfaceRules(
@@ -587,6 +593,11 @@ class BuiltInsValidator {
       const Instruction& referenced_inst,
       const Instruction& referenced_from_inst);
 
+  spv_result_t ValidateTileQCOMBuiltinAtReference(
+      const Decoration& decoration, const Instruction& built_in_inst,
+      const Instruction& referenced_inst,
+      const Instruction& referenced_from_inst);
+
   // Validates that |built_in_inst| is not (even indirectly) referenced from
   // within a function which can be called with |execution_model|.
   //
@@ -620,6 +631,10 @@ class BuiltInsValidator {
       const Decoration& decoration, const Instruction& inst,
       const std::function<spv_result_t(const std::string& message)>& diag);
   spv_result_t ValidateI32Vec(
+      const Decoration& decoration, const Instruction& inst,
+      uint32_t num_components,
+      const std::function<spv_result_t(const std::string& message)>& diag);
+  spv_result_t ValidateU32Vec(
       const Decoration& decoration, const Instruction& inst,
       uint32_t num_components,
       const std::function<spv_result_t(const std::string& message)>& diag);
@@ -789,6 +804,9 @@ class BuiltInsValidator {
   // Execution models with which the current function can be called.
   std::set<spv::ExecutionModel> execution_models_;
 
+  // Execution modes with which the current function can be called.
+  std::set<spv::ExecutionMode> execution_modes_;
+
   // For Builtin that can only be declared once in an entry point, keep track if
   // the entry point has it already
   std::set<uint32_t> cull_primitive_entry_points_;
@@ -801,12 +819,16 @@ void BuiltInsValidator::Update(const Instruction& inst) {
     assert(function_id_ == 0);
     function_id_ = inst.id();
     execution_models_.clear();
+    execution_modes_.clear();
     entry_points_ = &_.FunctionEntryPoints(function_id_);
     // Collect execution models from all entry points from which the current
     // function can be called.
     for (const uint32_t entry_point : *entry_points_) {
       if (const auto* models = _.GetExecutionModels(entry_point)) {
         execution_models_.insert(models->begin(), models->end());
+      }
+      if (const auto* modes = _.GetExecutionModes(entry_point)) {
+        execution_modes_.insert(modes->begin(), modes->end());
       }
     }
   }
@@ -817,6 +839,7 @@ void BuiltInsValidator::Update(const Instruction& inst) {
     function_id_ = 0;
     entry_points_ = &no_entry_points;
     execution_models_.clear();
+    execution_modes_.clear();
   }
 }
 
@@ -1089,6 +1112,40 @@ spv_result_t BuiltInsValidator::ValidateI32Vec(
     std::ostringstream ss;
     ss << GetDefinitionDesc(decoration, inst) << " has "
        << actual_num_components << " components.";
+    return diag(ss.str());
+  }
+
+  const uint32_t bit_width = _.GetBitWidth(underlying_type);
+  if (bit_width != 32) {
+    std::ostringstream ss;
+    ss << GetDefinitionDesc(decoration, inst)
+       << " has components with bit width " << bit_width << ".";
+    return diag(ss.str());
+  }
+
+  return SPV_SUCCESS;
+}
+
+spv_result_t BuiltInsValidator::ValidateU32Vec(
+    const Decoration& decoration, const Instruction& inst,
+    uint32_t num_components,
+    const std::function<spv_result_t(const std::string& message)>& diag) {
+  uint32_t underlying_type = 0;
+  if (spv_result_t error =
+          GetUnderlyingType(_, decoration, inst, &underlying_type)) {
+    return error;
+  }
+
+  if (!_.IsUnsignedIntVectorType(underlying_type)) {
+    return diag(GetDefinitionDesc(decoration, inst) +
+                " is not an unsigned int vector.");
+  }
+
+  const uint32_t actual = _.GetDimension(underlying_type);
+  if (actual != num_components) {
+    std::ostringstream ss;
+    ss << GetDefinitionDesc(decoration, inst) << " has " << actual
+       << " components.";
     return diag(ss.str());
   }
 
@@ -3792,6 +3849,8 @@ spv_result_t BuiltInsValidator::ValidateWorkgroupSizeAtReference(
     const Instruction& referenced_inst,
     const Instruction& referenced_from_inst) {
   if (spvIsVulkanEnv(_.context()->target_env)) {
+    const spv::StorageClass storage_class =
+        GetStorageClass(referenced_from_inst);
     for (const spv::ExecutionModel execution_model : execution_models_) {
       if (execution_model != spv::ExecutionModel::GLCompute &&
           execution_model != spv::ExecutionModel::TaskNV &&
@@ -3809,6 +3868,19 @@ spv_result_t BuiltInsValidator::ValidateWorkgroupSizeAtReference(
                << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
                                    referenced_from_inst, execution_model);
       }
+    }
+    if (execution_modes_.count(spv::ExecutionMode::TileShadingRateQCOM) &&
+        storage_class != spv::StorageClass::Max &&
+        storage_class != spv::StorageClass::Input) {
+      return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
+             << _.VkErrorID(10635)
+             << spvLogStringForEnv(_.context()->target_env)
+             << " spec allows BuiltIn WorkgroupSize to be only used for "
+                "variables with Input storage class when "
+                "TileShadingRateQCOM Execution Mode is used. "
+             << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
+                                 referenced_from_inst)
+             << " " << GetStorageClassDesc(referenced_from_inst);
     }
   }
 
@@ -4905,6 +4977,76 @@ spv_result_t BuiltInsValidator::ValidateMeshShadingEXTBuiltinsAtReference(
   return SPV_SUCCESS;
 }
 
+spv_result_t BuiltInsValidator::ValidateTileQCOMBuiltinAtDefinition(
+    const Decoration& decoration, const Instruction& inst) {
+  const spv::BuiltIn builtin = decoration.builtin();
+  const uint32_t num_components =
+      (builtin == spv::BuiltIn::TileDimensionQCOM) ? 3 : 2;
+  if (spv_result_t error = ValidateU32Vec(
+          decoration, inst, num_components,
+          [this, &inst, builtin,
+           num_components](const std::string& msg) -> spv_result_t {
+            uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorType);
+            return _.diag(SPV_ERROR_INVALID_DATA, &inst)
+                   << _.VkErrorID(vuid)
+                   << "According to the Vulkan spec BuiltIn "
+                   << _.grammar().lookupOperandName(
+                          SPV_OPERAND_TYPE_BUILT_IN,
+                          static_cast<uint32_t>(builtin))
+                   << " variable must be a " << num_components
+                   << "-component 32-bit unsigned int vector. " << msg;
+          })) {
+    return error;
+  }
+
+  return ValidateTileQCOMBuiltinAtReference(decoration, inst, inst, inst);
+}
+
+spv_result_t BuiltInsValidator::ValidateTileQCOMBuiltinAtReference(
+    const Decoration& decoration, const Instruction& built_in_inst,
+    const Instruction& referenced_inst,
+    const Instruction& referenced_from_inst) {
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    const spv::BuiltIn builtin = decoration.builtin();
+    const spv::StorageClass sc = GetStorageClass(referenced_from_inst);
+    if (sc != spv::StorageClass::Max && sc != spv::StorageClass::Input) {
+      uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorStorageClass);
+      return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
+             << _.VkErrorID(vuid) << "Vulkan spec allows BuiltIn "
+             << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
+                                              static_cast<uint32_t>(builtin))
+             << " to be only used for variables with Input storage class. "
+             << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
+                                 referenced_from_inst)
+             << " " << GetStorageClassDesc(referenced_from_inst);
+    }
+
+    for (const spv::ExecutionModel model : execution_models_) {
+      if (model != spv::ExecutionModel::Fragment &&
+          model != spv::ExecutionModel::GLCompute) {
+        uint32_t vuid = GetVUIDForBuiltin(builtin, VUIDErrorExecutionModel);
+        return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
+               << _.VkErrorID(vuid) << "Vulkan spec allows BuiltIn "
+               << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
+                                                static_cast<uint32_t>(builtin))
+               << " to be used only with Fragment or GLCompute execution "
+                  "model. "
+               << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
+                                   referenced_from_inst, model);
+      }
+    }
+  }
+
+  if (function_id_ == 0) {
+    id_to_at_reference_checks_[referenced_from_inst.id()].push_back(
+        std::bind(&BuiltInsValidator::ValidateTileQCOMBuiltinAtReference, this,
+                  decoration, built_in_inst, referenced_from_inst,
+                  std::placeholders::_1));
+  }
+
+  return SPV_SUCCESS;
+}
+
 spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   const spv::BuiltIn label = decoration.builtin();
@@ -5094,6 +5236,11 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinitionVulkan(
     case spv::BuiltIn::SamplerHeapEXT:
     case spv::BuiltIn::ResourceHeapEXT: {
       return ValidateDescriptorHeapAtDefinition(decoration, inst);
+    }
+    case spv::BuiltIn::TileOffsetQCOM:
+    case spv::BuiltIn::TileDimensionQCOM:
+    case spv::BuiltIn::TileApronSizeQCOM: {
+      return ValidateTileQCOMBuiltinAtDefinition(decoration, inst);
     }
     default:
       // No validation rules (for the moment).

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -1251,6 +1251,14 @@ spv_result_t CheckDecorationsOfVariables(ValidationState_t& vstate) {
                     "decorations specified";
         }
       }
+      if (storageClass == spv::StorageClass::TileImageEXT) {
+        if (!hasDecoration(var_id, spv::Decoration::Location, vstate)) {
+          return vstate.diag(SPV_ERROR_INVALID_DATA, vstate.FindDef(var_id))
+                 << vstate.VkErrorID(8723)
+                 << "Variable with TileImageEXT Storage Class must be "
+                    "decorated with Location.";
+        }
+      }
     }
   }
   return SPV_SUCCESS;

--- a/source/val/validate_interfaces.cpp
+++ b/source/val/validate_interfaces.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Google LLC.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -572,6 +573,8 @@ spv_result_t ValidateLocations(ValidationState_t& _,
       output_locations_per_stream;
   std::unordered_map<uint32_t, std::unordered_set<uint32_t>>
       output_index1_locations_per_stream;
+  // For SPIR-V >= 1.4, TileImageEXT variables are always visible.
+  std::unordered_map<uint32_t, uint32_t> tile_image_locations;
   std::unordered_set<uint32_t> seen;
   for (uint32_t i = 3; i < entry_point->operands().size(); ++i) {
     auto interface_id = entry_point->GetOperandAs<uint32_t>(i);
@@ -580,12 +583,30 @@ spv_result_t ValidateLocations(ValidationState_t& _,
     auto storage_class =
         interface_var->GetOperandAs<spv::StorageClass>(sc_index);
     if (storage_class != spv::StorageClass::Input &&
-        storage_class != spv::StorageClass::Output) {
+        storage_class != spv::StorageClass::Output &&
+        storage_class != spv::StorageClass::TileImageEXT) {
       continue;
     }
     if (!seen.insert(interface_id).second) {
       // Pre-1.4 an interface variable could be listed multiple times in an
       // entry point. Validation for 1.4 or later is done elsewhere.
+      continue;
+    }
+
+    if (storage_class == spv::StorageClass::TileImageEXT) {
+      for (auto& dec : _.id_decorations(interface_var->id())) {
+        if (dec.dec_type() == spv::Decoration::Location) {
+          const auto result = tile_image_locations.emplace(dec.params()[0],
+                                                           interface_var->id());
+          if (!result.second) {
+            return _.diag(SPV_ERROR_INVALID_DATA, interface_var)
+                   << _.VkErrorID(8723)
+                   << "Variables with TileImageEXT Storage Class must not have "
+                      "conflicting Locations.";
+          }
+          break;
+        }
+      }
       continue;
     }
 

--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Google LLC.
 // Modifications Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All
 // rights reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -613,6 +614,15 @@ spv_result_t ValidateVariableStorageClass(ValidationState_t& _,
     return _.diag(SPV_ERROR_INVALID_ID, inst)
            << "PhysicalStorageBuffer must not be used with OpVariable.";
   }
+
+  if (storage_class == spv::StorageClass::TileAttachmentQCOM &&
+      !_.HasCapability(spv::Capability::TileShadingQCOM)) {
+    return _.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
+           << _.VkErrorID(10689)
+           << "the TileAttachmentQCOM storage class variable requires "
+              "TileShadingQCOM capability enabled.";
+  }
+
   return SPV_SUCCESS;
 }
 
@@ -1076,6 +1086,7 @@ spv_result_t ValidateVariableTileShadingQCOM(ValidationState_t& _,
       spv::Dim dim = static_cast<spv::Dim>(pointee_type->word(3));
       if (dim != spv::Dim::Dim2D) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(10693)
                << "Any OpTypeImage variable in the TileAttachmentQCOM "
                   "Storage Class must "
                   "have 2D as its dimension";
@@ -1083,7 +1094,8 @@ spv_result_t ValidateVariableTileShadingQCOM(ValidationState_t& _,
       unsigned sampled = pointee_type->word(7);
       if (sampled != 1 && sampled != 2) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << "Any OpyTpeImage variable in the TileAttachmentQCOM "
+               << _.VkErrorID(10694)
+               << "Any OpTypeImage variable in the TileAttachmentQCOM "
                   "Storage Class must "
                   "have 1 or 2 as Image 'Sampled' parameter";
       }
@@ -1101,6 +1113,7 @@ spv_result_t ValidateVariableTileShadingQCOM(ValidationState_t& _,
               case spv::Op::OpImageQueryLevels:
               case spv::Op::OpImageQuerySamples:
                 return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                       << _.VkErrorID(10697)
                        << "Any variable in the TileAttachmentQCOM Storage "
                           "Class must "
                           "not be consumed by an OpImageQuery* instruction";
@@ -1116,11 +1129,13 @@ spv_result_t ValidateVariableTileShadingQCOM(ValidationState_t& _,
   if (!(_.HasDecoration(inst->id(), spv::Decoration::DescriptorSet) &&
         _.HasDecoration(inst->id(), spv::Decoration::Binding))) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << _.VkErrorID(10695)
            << "Any variable in the TileAttachmentQCOM Storage Class must "
               "be decorated with DescriptorSet and Binding";
   }
   if (_.HasDecoration(inst->id(), spv::Decoration::Component)) {
     return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << _.VkErrorID(10696)
            << "Any variable in the TileAttachmentQCOM Storage Class must "
               "not be decorated with Component decoration";
   }

--- a/source/val/validate_mode_setting.cpp
+++ b/source/val/validate_mode_setting.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Google LLC.
 // Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -355,17 +356,20 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
             (has_mode(spv::ExecutionMode::LocalSize) ||
              has_mode(spv::ExecutionMode::LocalSizeId))) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(10692)
                  << "If the TileShadingRateQCOM execution mode is used, "
                  << "LocalSize and LocalSizeId must not be specified.";
         }
         if (has_mode(spv::ExecutionMode::NonCoherentTileAttachmentReadQCOM)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(10687)
                  << "The NonCoherentTileAttachmentQCOM execution mode must "
                     "not be used in any stage other than fragment.";
         }
       } else {
         if (has_mode(spv::ExecutionMode::TileShadingRateQCOM)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(10691)
                  << "If the TileShadingRateQCOM execution mode is used, the "
                     "TileShadingQCOM capability must be enabled.";
         }
@@ -373,17 +377,20 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
     } else {
       if (has_mode(spv::ExecutionMode::TileShadingRateQCOM)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
+               << _.VkErrorID(10688)
                << "The TileShadingRateQCOM execution mode must not be used "
                   "in any stage other than compute.";
       }
       if (execution_model != spv::ExecutionModel::Fragment) {
         if (has_mode(spv::ExecutionMode::NonCoherentTileAttachmentReadQCOM)) {
           return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                 << _.VkErrorID(10687)
                  << "The NonCoherentTileAttachmentQCOM execution mode must "
                     "not be used in any stage other than fragment.";
         }
         if (_.HasCapability(spv::Capability::TileShadingQCOM)) {
           return _.diag(SPV_ERROR_INVALID_CAPABILITY, inst)
+                 << _.VkErrorID(10686)
                  << "The TileShadingQCOM capability must not be enabled in "
                     "any stage other than compute or fragment.";
         }
@@ -391,6 +398,7 @@ spv_result_t ValidateEntryPoint(ValidationState_t& _, const Instruction* inst) {
         if (has_mode(spv::ExecutionMode::NonCoherentTileAttachmentReadQCOM)) {
           if (!_.HasCapability(spv::Capability::TileShadingQCOM)) {
             return _.diag(SPV_ERROR_INVALID_DATA, inst)
+                   << _.VkErrorID(10690)
                    << "If the NonCoherentTileAttachmentReadQCOM execution "
                       "mode is used, the TileShadingQCOM capability must be "
                       "enabled.";

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-2016 The Khronos Group Inc.
 // Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -3286,6 +3287,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-OpEntryPoint-08721);
     case 8722:
       return VUID_WRAP(VUID-StandaloneSpirv-OpEntryPoint-08722);
+    case 8723:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileImageEXT-08723);
     case 8747:
       return VUID_WRAP(VUID-HitTriangleVertexPositionsKHR-HitTriangleVertexPositionsKHR-08747);
     case 8748:
@@ -3341,10 +3344,54 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-ViewportIndex-ViewportIndex-10602);
     case 10603:
       return VUID_WRAP(VUID-ViewportIndex-ViewportIndex-10603);
+    case 10626:
+      return VUID_WRAP(VUID-TileOffsetQCOM-TileOffsetQCOM-10626);
+    case 10627:
+      return VUID_WRAP(VUID-TileOffsetQCOM-TileOffsetQCOM-10627);
+    case 10628:
+      return VUID_WRAP(VUID-TileOffsetQCOM-TileOffsetQCOM-10628);
+    case 10629:
+      return VUID_WRAP(VUID-TileDimensionQCOM-TileDimensionQCOM-10629);
+    case 10630:
+      return VUID_WRAP(VUID-TileDimensionQCOM-TileDimensionQCOM-10630);
+    case 10631:
+      return VUID_WRAP(VUID-TileDimensionQCOM-TileDimensionQCOM-10631);
+    case 10632:
+      return VUID_WRAP(VUID-TileApronSizeQCOM-TileApronSizeQCOM-10632);
+    case 10633:
+      return VUID_WRAP(VUID-TileApronSizeQCOM-TileApronSizeQCOM-10633);
+    case 10634:
+      return VUID_WRAP(VUID-TileApronSizeQCOM-TileApronSizeQCOM-10634);
+    case 10635:
+      return VUID_WRAP(VUID-WorkgroupSize-TileShadingRateQCOM-10635);
     case 10684:
       return VUID_WRAP(VUID-StandaloneSpirv-None-10684);
     case 10685:
       return VUID_WRAP(VUID-StandaloneSpirv-None-10685); // formally 04683/06426
+    case 10686:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileShadingQCOM-10686);
+    case 10687:
+      return VUID_WRAP(VUID-StandaloneSpirv-Execution-10687);
+    case 10688:
+      return VUID_WRAP(VUID-StandaloneSpirv-Execution-10688);
+    case 10689:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileAttachmentQCOM-10689);
+    case 10690:
+      return VUID_WRAP(VUID-StandaloneSpirv-NonCoherentTileAttachmentReadQCOM-10690);
+    case 10691:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileShadingRateQCOM-10691);
+    case 10692:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileShadingRateQCOM-10692);
+    case 10693:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-10693);
+    case 10694:
+      return VUID_WRAP(VUID-StandaloneSpirv-OpTypeImage-10694);
+    case 10695:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileAttachmentQCOM-10695);
+    case 10696:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileAttachmentQCOM-10696);
+    case 10697:
+      return VUID_WRAP(VUID-StandaloneSpirv-TileAttachmentQCOM-10697);
     case 10823:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeFloat-10823);
     case 10824:

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Google LLC.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -7241,6 +7242,303 @@ TEST_F(ValidateBuiltIns, HitTriangleVertexPositionType) {
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-HitTriangleVertexPositionsKHR-"
                       "HitTriangleVertexPositionsKHR-08749"));
+}
+
+TEST_F(ValidateBuiltIns, TileOffsetRequiresFragmentOrGLComputeExecutionModel) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %gl_TileOffsetQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileOffsetQCOM BuiltIn TileOffsetQCOM
+               OpDecorate %gl_TileOffsetQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+%_ptr_Function_v2uint = OpTypePointer Function %v2uint
+%_ptr_Input_v2uint = OpTypePointer Input %v2uint
+%gl_TileOffsetQCOM = OpVariable %_ptr_Input_v2uint Input
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+ %tileOffset = OpVariable %_ptr_Function_v2uint Function
+         %13 = OpLoad %v2uint %gl_TileOffsetQCOM
+               OpStore %tileOffset %13
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: TileShadingQCOM"));
+}
+
+TEST_F(ValidateBuiltIns, TileOffsetRequiresInputStorageClass) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileOffsetQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileOffsetQCOM BuiltIn TileOffsetQCOM
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+%_ptr_Output_v2uint = OpTypePointer Output %v2uint
+%gl_TileOffsetQCOM = OpVariable %_ptr_Output_v2uint Output
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileOffsetQCOM-TileOffsetQCOM-10627"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Vulkan spec allows BuiltIn TileOffsetQCOM to be "
+                        "only used for variables with Input storage class."));
+}
+
+TEST_F(ValidateBuiltIns,
+       TileOffsetRequiresTwoComponent32BitUnsignedIntegerVector) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileOffsetQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileOffsetQCOM BuiltIn TileOffsetQCOM
+               OpDecorate %gl_TileOffsetQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Function_v3uint = OpTypePointer Function %v3uint
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_TileOffsetQCOM = OpVariable %_ptr_Input_v3uint Input
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+ %tileOffset = OpVariable %_ptr_Function_v3uint Function
+         %13 = OpLoad %v3uint %gl_TileOffsetQCOM
+               OpStore %tileOffset %13
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileOffsetQCOM-TileOffsetQCOM-10628"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("According to the Vulkan spec BuiltIn TileOffsetQCOM "
+                        "variable must be a 2-component 32-bit "
+                        "unsigned int vector."));
+}
+
+TEST_F(ValidateBuiltIns,
+       TileDimensionRequiresFragmentOrGLComputeExecutionModel) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %gl_TileDimensionQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileDimensionQCOM BuiltIn TileDimensionQCOM
+               OpDecorate %gl_TileDimensionQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Function_v3uint = OpTypePointer Function %v3uint
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_TileDimensionQCOM = OpVariable %_ptr_Input_v3uint Input
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+    %tileDim = OpVariable %_ptr_Function_v3uint Function
+         %13 = OpLoad %v3uint %gl_TileDimensionQCOM
+               OpStore %tileDim %13
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: TileShadingQCOM"));
+}
+
+TEST_F(ValidateBuiltIns, TileDimensionRequiresInputStorageClass) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileDimensionQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileDimensionQCOM BuiltIn TileDimensionQCOM
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Output_v3uint = OpTypePointer Output %v3uint
+%gl_TileDimensionQCOM = OpVariable %_ptr_Output_v3uint Output
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileDimensionQCOM-TileDimensionQCOM-10630"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Vulkan spec allows BuiltIn TileDimensionQCOM to be "
+                        "only used for variables with Input storage class."));
+}
+
+TEST_F(ValidateBuiltIns,
+       TileDimensionRequiresThreeComponent32BitUnsignedIntegerVector) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileDimensionQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileDimensionQCOM BuiltIn TileDimensionQCOM
+               OpDecorate %gl_TileDimensionQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+%_ptr_Function_v2uint = OpTypePointer Function %v2uint
+%_ptr_Input_v2uint = OpTypePointer Input %v2uint
+%gl_TileDimensionQCOM = OpVariable %_ptr_Input_v2uint Input
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+    %tileDim = OpVariable %_ptr_Function_v2uint Function
+         %13 = OpLoad %v2uint %gl_TileDimensionQCOM
+               OpStore %tileDim %13
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileDimensionQCOM-TileDimensionQCOM-10631"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("According to the Vulkan spec BuiltIn TileDimensionQCOM "
+                "variable must be a 3-component 32-bit "
+                "unsigned int vector."));
+}
+
+TEST_F(ValidateBuiltIns,
+       TileApronSizeRequiresFragmentOrGLComputeExecutionModel) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Vertex %main "main" %gl_TileApronSizeQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileApronSizeQCOM BuiltIn TileApronSizeQCOM
+               OpDecorate %gl_TileApronSizeQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+%_ptr_Function_v2uint = OpTypePointer Function %v2uint
+%_ptr_Input_v2uint = OpTypePointer Input %v2uint
+%gl_TileApronSizeQCOM = OpVariable %_ptr_Input_v2uint Input
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+  %apronSize = OpVariable %_ptr_Function_v2uint Function
+         %13 = OpLoad %v2uint %gl_TileApronSizeQCOM
+               OpStore %apronSize %13
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_CAPABILITY,
+            ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: TileShadingQCOM"));
+}
+
+TEST_F(ValidateBuiltIns, TileApronSizeRequiresInputStorageClass) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileApronSizeQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileApronSizeQCOM BuiltIn TileApronSizeQCOM
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v2uint = OpTypeVector %uint 2
+%_ptr_Output_v2uint = OpTypePointer Output %v2uint
+%gl_TileApronSizeQCOM = OpVariable %_ptr_Output_v2uint Output     
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileApronSizeQCOM-TileApronSizeQCOM-10633"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Vulkan spec allows BuiltIn TileApronSizeQCOM to be "
+                        "only used for variables with Input storage class."));
+}
+
+TEST_F(ValidateBuiltIns,
+       TileApronSizeRequiresTwoComponent32BitUnsignedIntegerVector) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %gl_TileApronSizeQCOM
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %gl_TileApronSizeQCOM BuiltIn TileApronSizeQCOM
+               OpDecorate %gl_TileApronSizeQCOM Flat
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+%gl_TileApronSizeQCOM = OpVariable %_ptr_Input_v3uint Input     
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_4);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-TileApronSizeQCOM-TileApronSizeQCOM-10634"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("According to the Vulkan spec BuiltIn TileApronSizeQCOM "
+                "variable must be a 2-component 32-bit "
+                "unsigned int vector."));
 }
 
 }  // namespace

--- a/test/val/val_capability_test.cpp
+++ b/test/val/val_capability_test.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The Khronos Group Inc.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -3397,8 +3398,55 @@ OpEntryPoint Vertex %func "main"
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileShadingQCOM-10686"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("The TileShadingQCOM capability must not be enabled "
                         "in any stage other than compute or fragment"));
+}
+
+TEST_F(ValidateCapability, TileAttachmentRequiresTileShadingQCOMCapability) {
+  const auto spirv = R"(
+OpCapability Shader
+OpExtension "SPV_QCOM_tile_shading"
+OpMemoryModel Logical GLSL450
+OpEntryPoint Fragment %main "main"
+OpExecutionMode %main OriginUpperLeft
+OpSource GLSL 450
+OpDecorate %color1 Binding 0
+OpDecorate %color1 DescriptorSet 0
+%void = OpTypeVoid
+%int = OpTypeInt 32 1
+%44 = OpTypeImage %int 2D 0 0 0 2 Rgba32i
+%_ptr_TileAttachmentQCOM_44 = OpTypePointer TileAttachmentQCOM %44
+%color1 = OpVariable %_ptr_TileAttachmentQCOM_44 TileAttachmentQCOM
+%3 = OpTypeFunction %void
+%main = OpFunction %void None %3
+%5 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  spv_target_env env = SPV_ENV_VULKAN_1_4;
+  CompileSuccessfully(spirv, env);
+  EXPECT_THAT(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: TileShadingQCOM"));
+}
+
+TEST_F(ValidateCapability, TileShadingRateRequiresTileShadingQCOMCapability) {
+  const auto spirv = R"(
+OpCapability Shader
+OpExtension "SPV_QCOM_tile_shading"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main TileShadingRateQCOM 2 2 1
+)" + std::string(kVoidFVoid);
+
+  spv_target_env env = SPV_ENV_VULKAN_1_4;
+  CompileSuccessfully(spirv, env);
+  EXPECT_THAT(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires one of these capabilities: TileShadingQCOM"));
 }
 
 TEST_F(ValidateCapability, ColorAttachmentReadEXTRequireCapability) {

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2017 Google Inc.
 // Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11474,6 +11475,7 @@ TEST_F(ValidateImage, TileImageNotFragment) {
     OpMemoryModel Logical GLSL450
     OpEntryPoint GLCompute %main "main"
     OpExecutionMode %main LocalSize 1 1 1
+    OpDecorate %var Location 0
     %void = OpTypeVoid
     %func = OpTypeFunction %void
     %float = OpTypeFloat 32
@@ -11495,6 +11497,98 @@ TEST_F(ValidateImage, TileImageNotFragment) {
       getDiagnosticString(),
       HasSubstr(
           "TileImageEXT Storage Class is limited to Fragment execution model"));
+}
+
+TEST_F(ValidateImage, TileImageRequiresLocationDecoration) {
+  const std::string body = R"(
+               OpCapability Shader
+               OpCapability TileImageColorReadAccessEXT
+               OpExtension "SPV_EXT_shader_tile_image"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %color0 %fragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %fragColor Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+         %11 = OpTypeImage %float TileImageDataEXT 0 0 0 2 Unknown
+%_ptr_TileImageEXT_11 = OpTypePointer TileImageEXT %11
+     %color0 = OpVariable %_ptr_TileImageEXT_11 TileImageEXT    
+    %float_2 = OpConstant %float 2
+         %17 = OpConstantComposite %v4float %float_2 %float_2 %float_2 %float_2
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %fragColor = OpVariable %_ptr_Output_v4float Output   
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+      %value = OpVariable %_ptr_Function_v4float Function
+         %14 = OpLoad %11 %color0
+         %15 = OpColorAttachmentReadEXT %v4float %14
+         %18 = OpFDiv %v4float %15 %17
+               OpStore %value %18
+         %21 = OpLoad %v4float %value
+               OpStore %fragColor %21
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_4);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileImageEXT-08723"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("Variable with TileImageEXT Storage Class must be decorated "
+                "with Location."));
+}
+
+TEST_F(ValidateImage, TileImageRequiresNoLocationConflict) {
+  const std::string body = R"(
+               OpCapability Shader
+               OpCapability TileImageColorReadAccessEXT
+               OpExtension "SPV_EXT_shader_tile_image"
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main" %color0 %color1 %fragColor
+               OpExecutionMode %main OriginUpperLeft
+               OpDecorate %color0 Location 1
+               OpDecorate %color1 Location 1
+               OpDecorate %fragColor Location 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+         %11 = OpTypeImage %float TileImageDataEXT 0 0 0 2 Unknown
+%_ptr_TileImageEXT_11 = OpTypePointer TileImageEXT %11
+     %color0 = OpVariable %_ptr_TileImageEXT_11 TileImageEXT    
+     %color1 = OpVariable %_ptr_TileImageEXT_11 TileImageEXT    
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+  %fragColor = OpVariable %_ptr_Output_v4float Output   
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+      %value = OpVariable %_ptr_Function_v4float Function
+         %14 = OpLoad %11 %color0
+         %15 = OpColorAttachmentReadEXT %v4float %14
+         %17 = OpLoad %11 %color1
+         %18 = OpColorAttachmentReadEXT %v4float %17
+         %19 = OpFAdd %v4float %15 %18
+               OpStore %value %19
+         %22 = OpLoad %v4float %value
+               OpStore %fragColor %22
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(body.c_str(), SPV_ENV_VULKAN_1_4);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_4));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileImageEXT-08723"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Variables with TileImageEXT Storage Class must not "
+                        "have conflicting Locations."));
 }
 
 TEST_F(ValidateImage, SubpassDataNonZero) {

--- a/test/val/val_modes_test.cpp
+++ b/test/val/val_modes_test.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 Google LLC.
 // Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights
 // reserved.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -3040,6 +3041,8 @@ OpExecutionMode %main LocalSize 16 16 1
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileShadingRateQCOM-10692"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("If the TileShadingRateQCOM execution mode is used, "
                         "LocalSize and LocalSizeId must not be specified."));
 }
@@ -3060,6 +3063,8 @@ OpExecutionModeId %main LocalSizeId %int_1 %int_1 %int_1
   spv_target_env env = SPV_ENV_VULKAN_1_4;
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileShadingRateQCOM-10692"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("If the TileShadingRateQCOM execution mode is used, "
                         "LocalSize and LocalSizeId must not be specified."));
@@ -3101,6 +3106,8 @@ OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Execution-10687"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("The NonCoherentTileAttachmentQCOM execution mode must "
                         "not be used in any stage other than fragment"));
 }
@@ -3139,6 +3146,8 @@ OpExecutionMode %main OriginUpperLeft
   spv_target_env env = SPV_ENV_VULKAN_1_4;
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Execution-10688"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("The TileShadingRateQCOM execution mode must not be "
                         "used in any stage other than compute"));

--- a/test/val/val_storage_test.cpp
+++ b/test/val/val_storage_test.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The Khronos Group Inc.
+// Copyright (C) 2026 Qualcomm Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -277,6 +278,8 @@ TEST_F(ValidateStorage, TileAttachmentQCOMBad1) {
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-OpTypeImage-10693"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Any OpTypeImage variable in the TileAttachmentQCOM "
                         "Storage Class must have 2D as its dimension"));
 }
@@ -307,6 +310,8 @@ TEST_F(ValidateStorage, TileAttachmentQCOMBad2) {
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_ID, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileAttachmentQCOM-10695"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Any variable in the TileAttachmentQCOM Storage Class "
                         "must be decorated with DescriptorSet and Binding"));
 }
@@ -336,6 +341,8 @@ TEST_F(ValidateStorage, TileAttachmentQCOMBad3) {
   spv_target_env env = SPV_ENV_VULKAN_1_4;
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_ID, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileAttachmentQCOM-10695"));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("Any variable in the TileAttachmentQCOM Storage Class "
                         "must be decorated with DescriptorSet and Binding"));
@@ -404,6 +411,8 @@ TEST_F(ValidateStorage, TileAttachmentQCOMBad5) {
   spv_target_env env = SPV_ENV_VULKAN_1_4;
   CompileSuccessfully(spirv, env);
   EXPECT_THAT(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-TileAttachmentQCOM-10697"));
   EXPECT_THAT(
       getDiagnosticString(),
       HasSubstr("Any variable in the TileAttachmentQCOM Storage Class "
@@ -467,6 +476,40 @@ TEST_F(ValidateStorage, WrongDimTileImageEXT) {
       HasSubstr(
           "The TileImageEXT Storage Class must only be used for declaring "
           "tile image variables"));
+}
+
+TEST_F(ValidateStorage, TileAttachmentQCOMDecoratedWithComponent) {
+  const std::string spirv = R"(
+               OpCapability Shader
+               OpCapability TileShadingQCOM
+               OpExtension "SPV_QCOM_tile_shading"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource GLSL 450
+               OpDecorate %color1 Binding 0
+               OpDecorate %color1 Component 0
+               OpDecorate %color1 DescriptorSet 0
+        %void = OpTypeVoid 
+         %int = OpTypeInt 32 1
+          %44 = OpTypeImage %int 2D 0 0 0 2 Rgba32i
+%_ptr_TileAttachmentQCOM_44 = OpTypePointer TileAttachmentQCOM %44
+     %color1 = OpVariable %_ptr_TileAttachmentQCOM_44 TileAttachmentQCOM
+          %3 = OpTypeFunction %void
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  spv_target_env env = SPV_ENV_VULKAN_1_4;
+  CompileSuccessfully(spirv, env);
+  EXPECT_THAT(SPV_ERROR_INVALID_ID, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Location-06672"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Component decoration must not be applied to "
+                        "this storage class"));
 }
 
 std::string GenerateExecutionModelCode(const std::string& execution_model,


### PR DESCRIPTION
# VUID check
- `VUID-StandaloneSpirv-TileImageEXT-08723`
- `VUID-StandaloneSpirv-TileAttachmentQCOM-10689`
- `VUID-TileApronSizeQCOM-TileApronSizeQCOM-10632`
- `VUID-TileApronSizeQCOM-TileApronSizeQCOM-10633`
- `VUID-TileApronSizeQCOM-TileApronSizeQCOM-10634`
- `VUID-TileOffsetQCOM-TileOffsetQCOM-10626`
- `VUID-TileOffsetQCOM-TileOffsetQCOM-10627`
- `VUID-TileOffsetQCOM-TileOffsetQCOM-10628`
- `VUID-TileDimensionQCOM-TileDimensionQCOM-10629`
- `VUID-TileDimensionQCOM-TileDimensionQCOM-10630`
- `VUID-TileDimensionQCOM-TileDimensionQCOM-10631`
- `VUID-WorkgroupSize-TileShadingRateQCOM-10635`

# Unit tests
`VUID-08723`
`VUID-10633`
`VUID-10634`
`VUID-10627`
`VUID-10628`
`VUID-10630`
`VUID-10631`

# VUID check failed to reach, blocked by other VUID check
`VUID-10689`
`VUID-10632`
`VUID-10626`
`VUID-10629`
`VUID-10635`