### PR TITLE
Update abseil

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -3,7 +3,7 @@ use_relative_paths = True
 vars = {
   'github': 'https://github.com',
 
-  'abseil_revision': '351086314d46e73d430296c9eca1f6d6c0372cd1',
+  'abseil_revision': '7dcc24cf19674efc75b8e8de06b9617838b8e0e9',
 
   'effcee_revision': 'ae38e040cbb7e83efa8bfbb4967e5b8c8c89b55a',
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,12 +26,13 @@ endif()
 # Add a SPIR-V Tools unit test. Signature:
 #   add_spvtools_unittest(
 #     TARGET target_name
+#     SKIP_EFFCEE ON # optional
 #     SRCS   src_file.h src_file.cpp
 #     LIBS   lib1 lib2
 #   )
 function(add_spvtools_unittest)
   if (NOT "${SPIRV_SKIP_TESTS}" AND TARGET gmock_main)
-    set(one_value_args TARGET PCH_FILE)
+    set(one_value_args TARGET PCH_FILE SKIP_EFFCEE)
     set(multi_value_args SRCS LIBS ENVIRONMENT DEFINES)
     cmake_parse_arguments(
       ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -68,13 +69,14 @@ function(add_spvtools_unittest)
       ${gtest_SOURCE_DIR}/include
       ${gmock_SOURCE_DIR}/include
     )
-    if (TARGET effcee)
-      # If using Effcee for testing, then add its include directory.
-      target_include_directories(${target} PRIVATE ${effcee_SOURCE_DIR})
-    endif()
     target_link_libraries(${target} PRIVATE ${ARG_LIBS})
     if (TARGET effcee)
-      target_link_libraries(${target} PRIVATE effcee)
+      if ("${ARG_SKIP_EFFCEE}")
+      else()
+        # If using Effcee for testing, then add its include directory.
+        target_include_directories(${target} PRIVATE ${effcee_SOURCE_DIR})
+        target_link_libraries(${target} PRIVATE effcee)
+      endif()
     endif()
     target_link_libraries(${target} PRIVATE gmock_main)
     add_test(NAME spirv-tools-${target} COMMAND ${target})
@@ -174,11 +176,17 @@ add_spvtools_unittest(
 
 add_spvtools_unittest(
   TARGET c_interface
+  SKIP_EFFCEE ON
   SRCS c_interface_test.cpp
   LIBS ${SPIRV_TOOLS_FULL_VISIBILITY})
 
 add_spvtools_unittest(
   TARGET c_interface_shared
+  # Effcee pulls in Abseil. But if the executable is compiled
+  # with the shared C++ runtime, then Abseil also needs the shared
+  # C++ runtime. Skip linking effcee to avoid the problem in the
+  # first place.  The C interface test doesn't need it.
+  SKIP_EFFCEE ON
   SRCS c_interface_test.cpp
   LIBS ${SPIRV_TOOLS}-shared
   ENVIRONMENT PATH=$<TARGET_FILE_DIR:${SPIRV_TOOLS}-shared>)


### PR DESCRIPTION
For test_c_interface_shared, avoid linking against effcee. Linking effcee pulls in abseil, which will have been compiled with conflicting C++ Runtime options (shared vs. static).