### PR TITLE
fix: skip ParseInstruction for retried-as-unknown instructions

### DIFF
--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -164,6 +164,8 @@ void FriendlyNameMapper::SaveBuiltInName(uint32_t target_id,
 spv_result_t FriendlyNameMapper::ParseInstruction(
     const spv_parsed_instruction_t& inst) {
   const auto result_id = inst.result_id;
+  if (inst.num_operands == 0) return SPV_SUCCESS;
+
   switch (spv::Op(inst.opcode)) {
     case spv::Op::OpName:
       SaveName(inst.words[1], spvDecodeLiteralStringOperand(inst, 1));


### PR DESCRIPTION
## Summary

Fixes #6664.

`spvBinaryToText` with `FRIENDLY_NAMES` + `HANDLE_UNKNOWN_OPCODES` reads past the instruction buffer at `name_mapper.cpp:268` when the module contains a malformed known instruction (e.g. `OpTypePointer` with declared word count 3 and an invalid `StorageClass` enum 42). The `HANDLE_UNKNOWN_OPCODES` retry path (`emitAsUnknown`) bypasses the parser's mandatory-operand completeness check and dispatches the instruction to `FriendlyNameMapper::ParseInstruction` with `inst.num_operands == 0`, but the opcode switch arms unconditionally index `inst.words[N]`.

## Root cause

When `parseOperand` fails on an invalid enum and `HANDLE_UNKNOWN_OPCODES` is set, `parseInstruction` retries via `emitAsUnknown()` (binary.cpp ~409-412). `emitAsUnknown` repopulates raw words but clears the operand array and sets `inst.num_operands = 0` (binary.cpp ~367-371) before invoking the callback. `FriendlyNameMapper::ParseInstruction` then enters its opcode switch with a known opcode but no decoded operands, and direct `inst.words[N]` reads go out of bounds.

This affects not just `OpTypePointer` but all opcode arms that do direct word indexing: `OpTypeInt`, `OpTypeFloat`, `OpTypeVector`, `OpTypeMatrix`, `OpTypeArray`, `OpDecorate`, `OpTypeRuntimeArray`, `OpTypeNodePayloadArrayAMDX`, `OpTypeUntypedPointerKHR`, `OpTypePipe`, etc.

## Fix

Guard `ParseInstruction` to return early when `inst.num_operands == 0`:

```cpp
if (inst.num_operands == 0) return SPV_SUCCESS;
```

`num_operands == 0` is the parser's marker for instructions emitted via the retry-as-unknown path. These instructions have no decoded operand metadata and their raw word arrays may be truncated, so the mapper has nothing useful to extract from them. The early return lets the mapper's internal parse continue past the instruction, so friendly names are still collected from subsequent valid instructions.

This is a single central guard that covers all current and future opcode arms, rather than per-case bounds checks scattered across the switch.

## Previous iterations

v1 added per-case `inst.num_words` bounds checks in the `OpTypePointer` arm of `ParseInstruction`:

```diff
// source/name_mapper.cpp — v1
  case spv::Op::OpTypePointer: {
-   const auto storage_class = spv::StorageClass(inst.words[2]);
+   const auto storage_class = inst.num_words > 2
+       ? spv::StorageClass(inst.words[2]) : spv::StorageClass::Max;
    ...
-   SaveName(result_id, ...);
+   if (inst.num_words > 3) SaveName(result_id, ...);
+   else SaveName(result_id, "unknown_pointer");
  }
```

As @alan-baker pointed out, this fixed one type but left ~12 other cases exposed through the same `emitAsUnknown` path.

v2 masked `HANDLE_UNKNOWN_OPCODES` from the `FriendlyNameMapper` construction in `disassemble.cpp`:

```diff
// source/disassemble.cpp — v2
  if (options & SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES) {
+   const uint32_t mapper_options =
+       options & ~SPV_BINARY_TO_TEXT_OPTION_HANDLE_UNKNOWN_OPCODES;
    friendly_mapper = MakeUnique<FriendlyNameMapper>(
-       context, code, wordCount, options);
+       context, code, wordCount, mapper_options);
  }
```

This covered all cases centrally but introduced a regression: the mapper's pre-parse could no longer continue past legitimate unknown opcodes, so IDs declared after an unknown instruction lost their friendly names (fell back to `%6`, `%7` instead of `%uint`, `%v2uint`).

The current fix uses the parser's own invariant (`emitAsUnknown` sets `num_operands = 0`) to skip only the dangerous instructions while keeping `HANDLE_UNKNOWN_OPCODES` active for the mapper's pre-parse. This covers all cases like v2, but without the friendly-name regression.

## Regression risk

The fix does not mask any disassembler options and does not change the mapper's pre-parse behavior for legitimate unknown opcodes. `HANDLE_UNKNOWN_OPCODES` remains active in the mapper's `spvBinaryParseWithOptions` call, so when the binary contains a genuine unknown opcode (e.g. a future extension), the parser retries it as unknown, `ParseInstruction` skips it (since `num_operands == 0`), and parsing continues normally. Friendly names for IDs declared after the unknown opcode are preserved.

Tested by injecting unknown opcode 65000 between valid type definitions and verifying output:

```
OpUnknown(65000, 1)
%void = OpTypeVoid
%uint = OpTypeInt 32 0
%v2uint = OpTypeVector %uint 2
```

All friendly names (`%void`, `%uint`, `%v2uint`) are present after the unknown instruction, identical to the unpatched baseline.

## Verification

Tested with ASan-instrumented build (`-fsanitize=address`, `detect_leaks=1`):
- Before: `ERROR: AddressSanitizer: heap-buffer-overflow` at `name_mapper.cpp:268:47` in `FriendlyNameMapper::ParseInstruction`
- After: no heap-buffer-overflow. Malformed instruction emitted as `OpUnknown(32, 3)` by the main disassembly path

Valgrind memcheck on post-patch binary: `ERROR SUMMARY: 0 errors`, all heap blocks freed.

Post-patch process exits non-zero due to a pre-existing LeakSanitizer report (74 bytes in `spvDiagnosticCreate`). This leak exists before and after the patch and is unrelated to the OOB fix.

Valid SPIR-V sample disassembly: identical output pre/post patch.