### PR TITLE
fix: SEGV in OrderBlocks via empty CFG when OpFunctionEnd has no preceding OpLabel

### DIFF
--- a/source/disassemble.cpp
+++ b/source/disassemble.cpp
@@ -204,7 +204,9 @@ spv_result_t Disassembler::HandleInstruction(
       }
       case spv::Op::OpFunctionEnd:
         // Process the CFG and output the instructions
-        EmitCFG();
+        if (!current_function_cfg_.blocks.empty()) {
+          EmitCFG();
+        }
         // Output OpFunctionEnd itself too
         [[fallthrough]];
       default:

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -167,6 +167,31 @@ TEST_F(BinaryToText, InvalidMagicNumber) {
   spvDiagnosticDestroy(diagnostic);
 }
 
+TEST_F(BinaryToText,
+       OpFunctionEndOnEmptyFunctionDoesNotCrashUnderDeferredCfgModes) {
+  CompileSuccessfully("");
+  std::vector<uint32_t> module(binary->code, binary->code + binary->wordCount);
+  const std::vector<uint32_t> end_only =
+      spvtest::MakeInstruction(spv::Op::OpFunctionEnd, {});
+  module.insert(module.end(), end_only.begin(), end_only.end());
+
+  for (const uint32_t cfg_option :
+       {SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
+        SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT}) {
+    spv_text text = nullptr;
+    spv_diagnostic diagnostic = nullptr;
+    EXPECT_EQ(SPV_SUCCESS,
+              spvBinaryToText(context, module.data(), module.size(),
+                              cfg_option, &text, &diagnostic))
+        << "option=0x" << std::hex << cfg_option;
+    EXPECT_EQ(nullptr, diagnostic);
+    ASSERT_NE(nullptr, text);
+    EXPECT_THAT(std::string(text->str), HasSubstr("OpFunctionEnd"));
+    spvTextDestroy(text);
+    spvDiagnosticDestroy(diagnostic);
+  }
+}
+
 struct FailedDecodeCase {
   std::string source_text;
   std::vector<uint32_t> appended_instruction;

--- a/test/binary_to_text_test.cpp
+++ b/test/binary_to_text_test.cpp
@@ -175,14 +175,13 @@ TEST_F(BinaryToText,
       spvtest::MakeInstruction(spv::Op::OpFunctionEnd, {});
   module.insert(module.end(), end_only.begin(), end_only.end());
 
-  for (const uint32_t cfg_option :
-       {SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
-        SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT}) {
+  for (const uint32_t cfg_option : {SPV_BINARY_TO_TEXT_OPTION_REORDER_BLOCKS,
+                                    SPV_BINARY_TO_TEXT_OPTION_NESTED_INDENT}) {
     spv_text text = nullptr;
     spv_diagnostic diagnostic = nullptr;
     EXPECT_EQ(SPV_SUCCESS,
-              spvBinaryToText(context, module.data(), module.size(),
-                              cfg_option, &text, &diagnostic))
+              spvBinaryToText(context, module.data(), module.size(), cfg_option,
+                              &text, &diagnostic))
         << "option=0x" << std::hex << cfg_option;
     EXPECT_EQ(nullptr, diagnostic);
     ASSERT_NE(nullptr, text);


### PR DESCRIPTION
## Summary

Fixes #6663.

`spvBinaryToText` with `REORDER_BLOCKS` or `NESTED_INDENT` crashes (SEGV, write to address `0x50`) at `source/disassemble.cpp:416` when the input contains `OpFunctionEnd` with no preceding `OpLabel`. In deferred CFG mode, `Disassembler::HandleInstruction` unconditionally calls `EmitCFG()` on `OpFunctionEnd`, which forwards an empty `current_function_cfg_.blocks` to `OrderBlocks`. `OrderBlocks` then writes to `cfg.blocks[0].nest_level` on an empty vector, hitting a NULL-region address.

## Root cause

In deferred CFG mode (`nested_indent_ || reorder_blocks_`), `HandleInstruction` only accumulates blocks after seeing `OpLabel`. The PoC has `OpFunctionEnd` (opcode 56) without any prior `OpLabel`, so `current_function_cfg_.blocks` stays empty.

I added some fprintf probes to trace the state transition and got:
1. `HandleInstruction` entered with `opcode=56` (OpFunctionEnd), `blocks=0`
2. `OpFunctionEnd` path called `EmitCFG` with `blocks=0`
3. `EmitCFG` entered with `blocks=0`
4. `BuildControlFlowGraph` entered/exited with `blocks=0` and `id_to_index=0`
5. `OrderBlocks` consumed empty `cfg.blocks` and ASan SEGV fired

ASan points to `disassemble.cpp:416:28` in `OrderBlocks`, SEGV write to address `0x50`.

So the actual problem is on the producer side: `HandleInstruction`'s `OpFunctionEnd` case just forwards the empty CFG into `EmitCFG` without checking. `OrderBlocks` is only consuming the bad state.

## Fix

Added a guard in `HandleInstruction`'s `OpFunctionEnd` case (`source/disassemble.cpp`): only call `EmitCFG()` when `!current_function_cfg_.blocks.empty()`. `OpFunctionEnd` still gets emitted through the existing `[[fallthrough]]` to the `default` path.

## Why this approach

I looked at three places to put the fix:
- **Guard in `OrderBlocks`** (crash site): this just masks the symptom. It would return an empty ordering on invalid state and could silently hide bugs in the future. Didn't go with this.
- **Guard in `EmitCFG` entry**: would work, but it's one layer below where the problem actually starts.
- **Guard at `HandleInstruction` `OpFunctionEnd`** (went with this): this is where the empty CFG first gets forwarded. It's consistent with how the deferred-mode contract already works, where non-block instructions get emitted directly via the `default` path. No new error handling needed since `OpFunctionEnd` still goes through `[[fallthrough]]`.

## Verification

Tested with ASan-instrumented build (`-fsanitize=address`, `detect_leaks=0`):
- **Before**: `SUMMARY: AddressSanitizer: SEGV /src/spirv-tools/source/disassemble.cpp:416:28 in OrderBlocks` (both `--reorder-blocks` and `--nested-indent`, exit=1)
- **After**: no SEGV, both modes exit cleanly (exit=0)

Control path (no CFG options) produces valid disassembly output pre- and post-patch (exit=0).
