### PR TITLE
Allow no derivative layout for SPV_NV_compute_shader_derivatives

### DIFF
--- a/source/val/validate_derivatives.cpp
+++ b/source/val/validate_derivatives.cpp
@@ -91,6 +91,7 @@ spv_result_t DerivativesPass(ValidationState_t& _, const Instruction* inst) {
                      models->end() ||
                  models->find(spv::ExecutionModel::MeshEXT) != models->end() ||
                  models->find(spv::ExecutionModel::TaskEXT) != models->end()) &&
+                (state.HasExtension(kSPV_KHR_compute_shader_derivatives)) &&
                 (!modes ||
                  (modes->find(spv::ExecutionMode::DerivativeGroupLinearKHR) ==
                       modes->end() &&

--- a/test/val/val_derivatives_test.cpp
+++ b/test/val/val_derivatives_test.cpp
@@ -163,6 +163,8 @@ TEST_F(ValidateDerivatives, OpDPdxWrongExecutionModel) {
 TEST_F(ValidateDerivatives, NoExecutionModeGLCompute) {
   const std::string spirv = R"(
 OpCapability Shader
+OpCapability ComputeDerivativeGroupQuadsKHR
+OpExtension "SPV_KHR_compute_shader_derivatives"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
 %void = OpTypeVoid


### PR DESCRIPTION
While adding glslang support for GL_KHR_compute_shader_derivatives I ran into some compatibility issues with the prior NV version of this extension. 

The KHR SPIR-V spec differs from the NV version in that is requires one of the DerivativeGroup*KHR modes to be set, while the NV spec says they don't need to be specified:
> DerivativeGroup*NV execution mode that was specified for the entry point. If neither derivative group mode was specified, the derivatives return zero.

(From https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/NV/SPV_NV_compute_shader_derivatives.asciidoc)
 
The issue raised in https://github.com/KhronosGroup/glslang/issues/4239 shows that there are GLSL shaders using the NV extension that assume that the modes don't have to be set.

I modified glslang to allow this behavior for the NV extension in https://github.com/KhronosGroup/glslang/pull/4247, but the generated SPIR-V fails validation.

-- 

For this PR, I've made the execution mode check dependent on the KHR extension. (The execution and capability tokens are aliased between the KHR and NV extensions.)

That change caused a unit test regression. AFAICT, that test has never been valid since it uses explicit derivatives in a compute shader without enabling any extensions. I turned that into a test for the KHR extension.
