### PR TITLE
spirv-val: Add DebugGlobalVariable to spirv-val messages

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2180,15 +2180,27 @@ std::vector<uint32_t>& ValidationState_t::GetDebugSourceLineLength(
   return it->second;
 }
 
+// Main entrypoint to using ShaderDebugInfo to get better error messages
 std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
-  const uint32_t set_id = ShaderDebugInfoSet();
-  if (set_id == 0) {
+  if (ShaderDebugInfoSet() == 0) {
     return "";  // no ShaderDebugInfo found
-  } else if (inst.function() == nullptr) {
-    // currently only checking for code in function blocks
-    return "";
   }
 
+  std::ostringstream ss;
+  if (inst.function() != nullptr) {
+    InspectDebugLine(ss, inst);
+  } else if (inst.opcode() == spv::Op::OpVariable) {
+    // Know are global because not in any function
+    // TODO - test with OpUntypedVariable as well
+    InspectDebugGlobalVariable(ss, inst);
+  }
+
+  return ss.str();
+}
+
+void ValidationState_t::InspectDebugLine(std::ostringstream& ss,
+                                         const Instruction& inst) {
+  const uint32_t set_id = ShaderDebugInfoSet();
   // Find the DebugLine that is preceding
   const Instruction* debug_line_inst = nullptr;
   size_t idx = &inst - &ordered_instructions()[0];
@@ -2207,13 +2219,13 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
     }
   }
 
-  if (!debug_line_inst) return "";
+  if (!debug_line_inst) return;
 
   const Instruction* debug_source =
       FindDef(debug_line_inst->GetOperandAs<uint32_t>(4));
   if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
                            NonSemanticShaderDebugInfoDebugSource) {
-    return "";
+    return;
   }
 
   bool is_int32 = false, is_const_int32 = false;
@@ -2230,8 +2242,53 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   std::tie(is_int32, is_const_int32, column_end) =
       EvalInt32IfConst(debug_line_inst->word(9));
 
-  std::ostringstream ss;
+  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_end,
+                             column_start);
+}
 
+void ValidationState_t::InspectDebugGlobalVariable(
+    std::ostringstream& ss, const Instruction& variable_inst) {
+  const uint32_t set_id = ShaderDebugInfoSet();
+
+  const Instruction* debug_gloabl_var_inst = nullptr;
+  for (const auto& inst : ordered_instructions()) {
+    if (inst.opcode() == spv::Op::OpFunction) {
+      return;  // validated to not be in a function block
+    }
+
+    if (inst.opcode() == spv::Op::OpExtInst &&
+        inst.GetOperandAs<uint32_t>(2) == set_id &&
+        inst.GetOperandAs<uint32_t>(3) ==
+            NonSemanticShaderDebugInfoDebugGlobalVariable &&
+        inst.GetOperandAs<uint32_t>(11) == variable_inst.id()) {
+      debug_gloabl_var_inst = &inst;
+      break;
+    }
+  }
+  if (!debug_gloabl_var_inst) return;
+
+  const Instruction* debug_source =
+      FindDef(debug_gloabl_var_inst->GetOperandAs<uint32_t>(6));
+  if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
+                           NonSemanticShaderDebugInfoDebugSource) {
+    return;
+  }
+
+  bool is_int32 = false, is_const_int32 = false;
+  uint32_t line_start = 0;
+  uint32_t column_start = 0;
+  std::tie(is_int32, is_const_int32, line_start) =
+      EvalInt32IfConst(debug_gloabl_var_inst->word(8));
+  std::tie(is_int32, is_const_int32, column_start) =
+      EvalInt32IfConst(debug_gloabl_var_inst->word(9));
+
+  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_start,
+                             column_start);
+}
+
+void ValidationState_t::PrintShaderDebugInfoSource(
+    std::ostringstream& ss, const Instruction& debug_source,
+    uint32_t line_start, uint32_t line_end, uint32_t column_start) {
   // The left hand side line number, need to make sure if going from line number
   // 99 to 100 that all lines have the same padding
   const size_t vertical_line_padding = std::to_string(line_end).length();
@@ -2271,7 +2328,7 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   };
 
   const Instruction* file_string =
-      FindDef(debug_source->GetOperandAs<uint32_t>(4));
+      FindDef(debug_source.GetOperandAs<uint32_t>(4));
   ss << "\n  --> " << file_string->GetOperandAs<std::string>(1) << ":"
      << line_start << ":" << column_start << '\n';
 
@@ -2279,12 +2336,14 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   ss << '\n';
 
   const Instruction* source_string =
-      FindDef(debug_source->GetOperandAs<uint32_t>(5));
+      FindDef(debug_source.GetOperandAs<uint32_t>(5));
   add_vertical_line(line_start);
   stream_text(source_string);
 
+  const uint32_t set_id = ShaderDebugInfoSet();
+
   // Look for any DebugSourceContinued
-  size_t src_idx = debug_source - &ordered_instructions()[0] + 1;
+  size_t src_idx = &debug_source - &ordered_instructions()[0] + 1;
   for (; src_idx < ordered_instructions().size(); ++src_idx) {
     const Instruction& continued_insn = ordered_instructions()[src_idx];
     if (continued_insn.opcode() != spv::Op::OpExtInst ||
@@ -2304,7 +2363,6 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
 
   add_vertical_line(0);
   ss << "\n";
-  return ss.str();
 }
 
 bool ValidationState_t::IsValidStorageClass(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1007,6 +1007,13 @@ class ValidationState_t {
   void RegisterShaderDebugInfo(uint32_t id) { shader_debug_info_set_id = id; }
   uint32_t ShaderDebugInfoSet() const { return shader_debug_info_set_id; }
   std::string InspectShaderDebugInfo(const Instruction& inst);
+  void InspectDebugLine(std::ostringstream& ss, const Instruction& inst);
+  void InspectDebugGlobalVariable(std::ostringstream& ss,
+                                  const Instruction& inst);
+  void PrintShaderDebugInfoSource(std::ostringstream& ss,
+                                  const Instruction& debug_source,
+                                  uint32_t line_start, uint32_t line_end,
+                                  uint32_t column_start);
 
  private:
   ValidationState_t(const ValidationState_t&);

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -232,6 +232,137 @@ TEST_F(ValidateShaderDebugInfo, UnusedOpFunction) {
           "OpFunction Function Type <id> '3[%uint]' is not a function type."));
 }
 
+TEST_F(ValidateShaderDebugInfo, VariableBasic) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %x
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+layout(set = 0, binding = 1, std430) buffer SSBO {
+    vec4 data;
+} x;
+
+void main() {
+    x.data = vec4(0.0);
+}"
+         %25 = OpString "float"
+         %31 = OpString "data"
+         %34 = OpString "SSBO"
+         %40 = OpString "x"
+         %46 = OpString "int"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %x Binding 1
+               OpDecorate %x DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_6 %uint_0 %20 %16 %uint_3 %uint_6
+      %float = OpTypeFloat 32
+         %26 = OpExtInst %void %1 DebugTypeBasic %25 %uint_32 %uint_3 %uint_0
+    %v4float = OpTypeVector %float 4
+         %28 = OpExtInst %void %1 DebugTypeVector %26 %uint_4
+       %SSBO = OpTypeStruct %v4float
+    %uint_10 = OpConstant %uint 10
+         %30 = OpExtInst %void %1 DebugTypeMember %31 %28 %18 %uint_3 %uint_10 %uint_0 %uint_0 %uint_3
+         %33 = OpExtInst %void %1 DebugTypeComposite %34 %uint_1 %18 %uint_2 %uint_0 %20 %34 %uint_0 %uint_3 %30
+%_ptr_StorageBuffer_SSBO = OpTypePointer Uniform %SSBO
+    %uint_12 = OpConstant %uint 12
+         %37 = OpExtInst %void %1 DebugTypePointer %33 %uint_12 %uint_0
+          %x = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+     %uint_8 = OpConstant %uint 8
+         %39 = OpExtInst %void %1 DebugGlobalVariable %40 %33 %18 %uint_2 %uint_0 %20 %40 %x %uint_8
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %x %uint_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:2:0
+  |
+2 | layout(set = 0, binding = 1, std430) buffer SSBO {
+  |)"));
+}
+
+// Test if no DebugGlobalVariable is found, things still work
+TEST_F(ValidateShaderDebugInfo, NoDebugGlobalVariable) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %x
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %19 = OpString "BAD"
+         %25 = OpString "float"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %x Binding 1
+               OpDecorate %x DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+      %float = OpTypeFloat 32
+         %26 = OpExtInst %void %1 DebugTypeBasic %25 %uint_32 %uint_3 %uint_0
+    %v4float = OpTypeVector %float 4
+         %28 = OpExtInst %void %1 DebugTypeVector %26 %uint_4
+       %SSBO = OpTypeStruct %v4float
+    %uint_10 = OpConstant %uint 10
+%_ptr_StorageBuffer_SSBO = OpTypePointer Uniform %SSBO
+    %uint_12 = OpConstant %uint 12
+          %x = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+     %uint_8 = OpConstant %uint 8
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %x %uint_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
next small step for https://github.com/KhronosGroup/SPIRV-Tools/issues/6617

If the error is an `OpVariable` will look like

```
error: 46: Storage class must match result type storage class
  %3 = OpVariable %_ptr_Uniform__struct_13 StorageBuffer

  --> a.comp:2:0
  |
2 | layout(set = 0, binding = 1, std430) buffer SSBO {
  |
```

Goal was to make the `PrintShaderDebugInfoSource` they could both share. View as a very small step forward