### PR TITLE
spirv-val: Print DebugLocalVariable in error message

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2187,8 +2187,13 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   }
 
   std::ostringstream ss;
-  if (inst.function() != nullptr) {
-    InspectDebugLine(ss, inst);
+  const Function* func = inst.function();
+  if (func != nullptr) {
+    if (inst.opcode() == spv::Op::OpVariable) {
+      InspectDebugLocalVariable(ss, *func, inst);
+    } else {
+      InspectDebugLine(ss, inst);
+    }
   } else if (inst.opcode() == spv::Op::OpVariable) {
     // Know are global because not in any function
     // TODO - test with OpUntypedVariable as well
@@ -2281,6 +2286,60 @@ void ValidationState_t::InspectDebugGlobalVariable(
       EvalInt32IfConst(debug_gloabl_var_inst->word(8));
   std::tie(is_int32, is_const_int32, column_start) =
       EvalInt32IfConst(debug_gloabl_var_inst->word(9));
+
+  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_start,
+                             column_start);
+}
+
+void ValidationState_t::InspectDebugLocalVariable(
+    std::ostringstream& ss, const Function& func,
+    const Instruction& variable_inst) {
+  const uint32_t set_id = ShaderDebugInfoSet();
+  const Instruction* debug_declare_inst = nullptr;
+
+  const Instruction* function_inst = FindDef(func.id());
+  // Loop through the Function block as the DebugDeclare needs to be inside it
+  size_t first_inst_id = (function_inst - &ordered_instructions()[0]) + 1;
+  for (size_t i = first_inst_id + 1; i < ordered_instructions().size(); ++i) {
+    const Instruction& current_inst = ordered_instructions()[i];
+    if (current_inst.opcode() == spv::Op::OpFunctionEnd) {
+      break;  // we hit the next Funciton block
+    }
+
+    if (current_inst.opcode() == spv::Op::OpExtInst &&
+        current_inst.GetOperandAs<uint32_t>(2) == set_id &&
+        current_inst.GetOperandAs<uint32_t>(3) ==
+            NonSemanticShaderDebugInfoDebugDeclare &&
+        current_inst.GetOperandAs<uint32_t>(5) == variable_inst.id()) {
+      debug_declare_inst = &current_inst;
+      break;
+    }
+  }
+
+  if (!debug_declare_inst) return;
+
+  const Instruction* debug_local_variable =
+      FindDef(debug_declare_inst->GetOperandAs<uint32_t>(4));
+  if (!debug_local_variable ||
+      debug_local_variable->GetOperandAs<uint32_t>(3) !=
+          NonSemanticShaderDebugInfoDebugLocalVariable) {
+    return;
+  }
+
+  const Instruction* debug_source =
+      FindDef(debug_local_variable->GetOperandAs<uint32_t>(6));
+  if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
+                           NonSemanticShaderDebugInfoDebugSource) {
+    return;
+  }
+
+  bool is_int32 = false, is_const_int32 = false;
+  uint32_t line_start = 0;
+  uint32_t column_start = 0;
+  std::tie(is_int32, is_const_int32, line_start) =
+      EvalInt32IfConst(debug_local_variable->word(8));
+  std::tie(is_int32, is_const_int32, column_start) =
+      EvalInt32IfConst(debug_local_variable->word(9));
 
   PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_start,
                              column_start);

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1010,6 +1010,8 @@ class ValidationState_t {
   void InspectDebugLine(std::ostringstream& ss, const Instruction& inst);
   void InspectDebugGlobalVariable(std::ostringstream& ss,
                                   const Instruction& inst);
+  void InspectDebugLocalVariable(std::ostringstream& ss, const Function& func,
+                                 const Instruction& inst);
   void PrintShaderDebugInfoSource(std::ostringstream& ss,
                                   const Instruction& debug_source,
                                   uint32_t line_start, uint32_t line_end,

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -363,6 +363,148 @@ TEST_F(ValidateShaderDebugInfo, NoDebugGlobalVariable) {
   EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
 }
 
+TEST_F(ValidateShaderDebugInfo, DebugLocalVariable) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+void main() {
+    uint x = 0;
+    int y = int(x);
+}"
+         %32 = OpString "x"
+         %37 = OpString "int"
+         %43 = OpString "y"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_3 %uint_0 %20 %16 %uint_3 %uint_3
+%_ptr_Function_uint = OpTypePointer Function %uint
+     %uint_7 = OpConstant %uint 7
+         %29 = OpExtInst %void %1 DebugTypePointer %9 %uint_7 %uint_0
+         %31 = OpExtInst %void %1 DebugLocalVariable %32 %9 %18 %uint_4 %uint_0 %17 %uint_4
+         %34 = OpExtInst %void %1 DebugExpression
+        %int = OpTypeInt 32 1
+         %38 = OpExtInst %void %1 DebugTypeBasic %37 %uint_32 %uint_4 %uint_0
+%_ptr_Function_int = OpTypePointer Function %int
+         %40 = OpExtInst %void %1 DebugTypePointer %38 %uint_7 %uint_0
+     %uint_5 = OpConstant %uint 5
+         %42 = OpExtInst %void %1 DebugLocalVariable %43 %38 %18 %uint_5 %uint_0 %17 %uint_4
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+          %x = OpVariable %_ptr_Function_uint Uniform
+          %y = OpVariable %_ptr_Function_int Function
+         %25 = OpExtInst %void %1 DebugScope %17
+         %26 = OpExtInst %void %1 DebugLine %18 %uint_3 %uint_3 %uint_0 %uint_0
+         %24 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+         %35 = OpExtInst %void %1 DebugLine %18 %uint_4 %uint_4 %uint_0 %uint_0
+         %33 = OpExtInst %void %1 DebugDeclare %31 %x %34
+               OpStore %x %uint_0
+         %46 = OpExtInst %void %1 DebugLine %18 %uint_5 %uint_5 %uint_0 %uint_0
+         %45 = OpExtInst %void %1 DebugDeclare %42 %y %34
+         %47 = OpLoad %uint %x
+         %48 = OpBitcast %int %47
+               OpStore %y %48
+         %49 = OpExtInst %void %1 DebugLine %18 %uint_6 %uint_6 %uint_0 %uint_0
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:4:0
+  |
+4 |     uint x = 0;
+  |)"));
+}
+
+// Test if no DebugLocalVariable is found, things still work
+TEST_F(ValidateShaderDebugInfo, NoDebugLocalVariable) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+void main() {
+    uint x = 0;
+    int y = int(x);
+}"
+         %32 = OpString "x"
+         %37 = OpString "int"
+         %43 = OpString "y"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_3 %uint_0 %20 %16 %uint_3 %uint_3
+%_ptr_Function_uint = OpTypePointer Function %uint
+     %uint_7 = OpConstant %uint 7
+         %29 = OpExtInst %void %1 DebugTypePointer %9 %uint_7 %uint_0
+         %31 = OpExtInst %void %1 DebugLocalVariable %32 %9 %18 %uint_4 %uint_0 %17 %uint_4
+         %34 = OpExtInst %void %1 DebugExpression
+        %int = OpTypeInt 32 1
+         %38 = OpExtInst %void %1 DebugTypeBasic %37 %uint_32 %uint_4 %uint_0
+%_ptr_Function_int = OpTypePointer Function %int
+         %40 = OpExtInst %void %1 DebugTypePointer %38 %uint_7 %uint_0
+     %uint_5 = OpConstant %uint 5
+         %42 = OpExtInst %void %1 DebugLocalVariable %43 %38 %18 %uint_5 %uint_0 %17 %uint_4
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+          %x = OpVariable %_ptr_Function_uint Uniform
+          %y = OpVariable %_ptr_Function_int Function
+         %25 = OpExtInst %void %1 DebugScope %17
+         %26 = OpExtInst %void %1 DebugLine %18 %uint_3 %uint_3 %uint_0 %uint_0
+         %24 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+         %35 = OpExtInst %void %1 DebugLine %18 %uint_4 %uint_4 %uint_0 %uint_0
+               OpStore %x %uint_0
+         %46 = OpExtInst %void %1 DebugLine %18 %uint_5 %uint_5 %uint_0 %uint_0
+         %47 = OpLoad %uint %x
+         %48 = OpBitcast %int %47
+               OpStore %y %48
+         %49 = OpExtInst %void %1 DebugLine %18 %uint_6 %uint_6 %uint_0 %uint_0
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
next part of #6617 

will print 

```
error: 42: Variables must have a function[7] storage class inside of a function
  %37 = OpVariable %_ptr_Function_uint Uniform

  --> a.comp:4:0
  |
4 |     uint x = 0;
  |
```

... Next goal will be how to combine it so when you have an error on the `OpLoad`/`OpStore` it can print **both** the line the access occured and the variable declaration