### PR TITLE
spirv-val: Print OpFunctionCall with ShaderDebugInfo

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2191,7 +2191,10 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   if (func != nullptr) {
     if (inst.opcode() == spv::Op::OpVariable) {
       InspectDebugLocalVariable(ss, *func, inst);
+    } else if (inst.opcode() == spv::Op::OpFunctionCall) {
+      InspectDebugFunctionDefinition(ss, inst);
     } else {
+      // Currently a fall back for anything in a function
       InspectDebugLine(ss, inst);
     }
   } else if (inst.opcode() == spv::Op::OpVariable) {
@@ -2201,6 +2204,88 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
   }
 
   return ss.str();
+}
+
+ValidationState_t::DebugSourceInfo ValidationState_t::GetDebugSourceInfo(
+    const Instruction& inst) {
+  assert(inst.opcode() == spv::Op::OpExtInst);
+  assert(inst.word(3) == ShaderDebugInfoSet());
+
+  uint32_t line_start_id = 0, line_end_id = 0, column_start_id = 0,
+           column_end_id = 0;
+
+  switch (inst.word(4)) {
+    case NonSemanticShaderDebugInfoDebugLine:
+      line_start_id = 6;
+      line_end_id = 7;
+      column_start_id = 8;
+      column_end_id = 9;
+      break;
+    case NonSemanticShaderDebugInfoDebugTypeTemplateParameterPack:
+      line_start_id = 7;
+      column_start_id = 8;
+      break;
+    case NonSemanticShaderDebugInfoDebugLexicalBlock:
+      line_start_id = 6;
+      column_start_id = 7;
+      break;
+    case NonSemanticShaderDebugInfoDebugLocalVariable:
+    case NonSemanticShaderDebugInfoDebugGlobalVariable:
+    case NonSemanticShaderDebugInfoDebugTypedef:
+    case NonSemanticShaderDebugInfoDebugTypeEnum:
+    case NonSemanticShaderDebugInfoDebugTypeComposite:
+    case NonSemanticShaderDebugInfoDebugTypeMember:
+    case NonSemanticShaderDebugInfoDebugTypeTemplateTemplateParameter:
+    case NonSemanticShaderDebugInfoDebugFunctionDeclaration:
+    case NonSemanticShaderDebugInfoDebugFunction:
+      line_start_id = 8;
+      column_start_id = 9;
+      break;
+    case NonSemanticShaderDebugInfoDebugTypeTemplateParameter:
+    case NonSemanticShaderDebugInfoDebugImportedEntity:
+      line_start_id = 9;
+      column_start_id = 10;
+      break;
+    case NonSemanticShaderDebugInfoDebugMacroDef:
+    case NonSemanticShaderDebugInfoDebugMacroUndef:
+      line_start_id = 6;
+      break;
+    default:
+      return {0, 0, 0, 0};
+  }
+
+  // spirv-val enforces these are int32 constants
+  bool is_int32 = false, is_const_int32 = false;
+  uint32_t line_start = 0;
+  uint32_t line_end = 0;
+  uint32_t column_start = 0;
+  uint32_t column_end = 0;
+
+  std::tie(is_int32, is_const_int32, line_start) =
+      EvalInt32IfConst(inst.word(line_start_id));
+
+  // Some instructions only provide a line and column, so set the "end" to be
+  // same as "start"
+  if (line_end_id != 0) {
+    std::tie(is_int32, is_const_int32, line_end) =
+        EvalInt32IfConst(inst.word(line_end_id));
+  } else {
+    line_end = line_start;
+  }
+
+  if (column_start_id != 0) {
+    std::tie(is_int32, is_const_int32, column_start) =
+        EvalInt32IfConst(inst.word(column_start_id));
+  }
+
+  if (column_end_id != 0) {
+    std::tie(is_int32, is_const_int32, column_end) =
+        EvalInt32IfConst(inst.word(column_end_id));
+  } else {
+    column_end = column_start;
+  }
+
+  return {line_start, line_end, column_start, column_end};
 }
 
 void ValidationState_t::InspectDebugLine(std::ostringstream& ss,
@@ -2233,22 +2318,8 @@ void ValidationState_t::InspectDebugLine(std::ostringstream& ss,
     return;
   }
 
-  bool is_int32 = false, is_const_int32 = false;
-  uint32_t line_start = 0;
-  uint32_t line_end = 0;
-  uint32_t column_start = 0;
-  uint32_t column_end = 0;
-  std::tie(is_int32, is_const_int32, line_start) =
-      EvalInt32IfConst(debug_line_inst->word(6));
-  std::tie(is_int32, is_const_int32, line_end) =
-      EvalInt32IfConst(debug_line_inst->word(7));
-  std::tie(is_int32, is_const_int32, column_start) =
-      EvalInt32IfConst(debug_line_inst->word(8));
-  std::tie(is_int32, is_const_int32, column_end) =
-      EvalInt32IfConst(debug_line_inst->word(9));
-
-  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_end,
-                             column_start);
+  auto source_info = GetDebugSourceInfo(*debug_line_inst);
+  PrintShaderDebugInfoSource(ss, *debug_source, source_info);
 }
 
 void ValidationState_t::InspectDebugGlobalVariable(
@@ -2279,16 +2350,8 @@ void ValidationState_t::InspectDebugGlobalVariable(
     return;
   }
 
-  bool is_int32 = false, is_const_int32 = false;
-  uint32_t line_start = 0;
-  uint32_t column_start = 0;
-  std::tie(is_int32, is_const_int32, line_start) =
-      EvalInt32IfConst(debug_gloabl_var_inst->word(8));
-  std::tie(is_int32, is_const_int32, column_start) =
-      EvalInt32IfConst(debug_gloabl_var_inst->word(9));
-
-  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_start,
-                             column_start);
+  auto source_info = GetDebugSourceInfo(*debug_gloabl_var_inst);
+  PrintShaderDebugInfoSource(ss, *debug_source, source_info);
 }
 
 void ValidationState_t::InspectDebugLocalVariable(
@@ -2333,24 +2396,68 @@ void ValidationState_t::InspectDebugLocalVariable(
     return;
   }
 
-  bool is_int32 = false, is_const_int32 = false;
-  uint32_t line_start = 0;
-  uint32_t column_start = 0;
-  std::tie(is_int32, is_const_int32, line_start) =
-      EvalInt32IfConst(debug_local_variable->word(8));
-  std::tie(is_int32, is_const_int32, column_start) =
-      EvalInt32IfConst(debug_local_variable->word(9));
+  auto source_info = GetDebugSourceInfo(*debug_local_variable);
+  PrintShaderDebugInfoSource(ss, *debug_source, source_info);
+}
 
-  PrintShaderDebugInfoSource(ss, *debug_source, line_start, line_start,
-                             column_start);
+void ValidationState_t::InspectDebugFunctionDefinition(
+    std::ostringstream& ss, const Instruction& function_call_inst) {
+  // First print the caller, then print the callee if also found
+  InspectDebugLine(ss, function_call_inst);
+
+  const uint32_t set_id = ShaderDebugInfoSet();
+  const Instruction* debug_func_def = nullptr;
+
+  const uint32_t callee_function_id =
+      function_call_inst.GetOperandAs<uint32_t>(2);
+  const Instruction* function_inst = FindDef(callee_function_id);
+  if (!function_inst) return;
+
+  // Loop through the Function block as the DebugFunctionDefinition needs to be
+  // inside it
+  size_t first_inst_id = (function_inst - &ordered_instructions()[0]) + 1;
+  for (size_t i = first_inst_id + 1; i < ordered_instructions().size(); ++i) {
+    const Instruction& current_inst = ordered_instructions()[i];
+    if (current_inst.opcode() == spv::Op::OpFunctionEnd) {
+      break;  // we hit the next Funciton block
+    }
+
+    if (current_inst.opcode() == spv::Op::OpExtInst &&
+        current_inst.GetOperandAs<uint32_t>(2) == set_id &&
+        current_inst.GetOperandAs<uint32_t>(3) ==
+            NonSemanticShaderDebugInfoDebugFunctionDefinition &&
+        current_inst.GetOperandAs<uint32_t>(5) == callee_function_id) {
+      debug_func_def = &current_inst;
+      break;
+    }
+  }
+  if (!debug_func_def) return;
+
+  const Instruction* debug_function =
+      FindDef(debug_func_def->GetOperandAs<uint32_t>(4));
+  if (!debug_function || debug_function->GetOperandAs<uint32_t>(3) !=
+                             NonSemanticShaderDebugInfoDebugFunction) {
+    return;
+  }
+
+  const Instruction* debug_source =
+      FindDef(debug_function->GetOperandAs<uint32_t>(6));
+  if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
+                           NonSemanticShaderDebugInfoDebugSource) {
+    return;
+  }
+
+  auto source_info = GetDebugSourceInfo(*debug_function);
+  PrintShaderDebugInfoSource(ss, *debug_source, source_info);
 }
 
 void ValidationState_t::PrintShaderDebugInfoSource(
     std::ostringstream& ss, const Instruction& debug_source,
-    uint32_t line_start, uint32_t line_end, uint32_t column_start) {
+    const DebugSourceInfo& source_info) {
   // The left hand side line number, need to make sure if going from line number
   // 99 to 100 that all lines have the same padding
-  const size_t vertical_line_padding = std::to_string(line_end).length();
+  const size_t vertical_line_padding =
+      std::to_string(source_info.line_end).length();
   auto add_vertical_line = [&](uint32_t line_number) {
     size_t padding = 1;
     if (line_number != 0) {
@@ -2373,9 +2480,10 @@ void ValidationState_t::PrintShaderDebugInfoSource(
   auto stream_text = [&](const Instruction* op_string) {
     const std::string text = op_string->GetOperandAs<std::string>(1);
     for (const char c : text) {
-      if (current_line_num >= line_start && current_line_num <= line_end) {
+      if (current_line_num >= source_info.line_start &&
+          current_line_num <= source_info.line_end) {
         ss << c;
-        if (c == '\n' && current_line_num < line_end) {
+        if (c == '\n' && current_line_num < source_info.line_end) {
           add_vertical_line(current_line_num + 1);
         }
       }
@@ -2389,14 +2497,14 @@ void ValidationState_t::PrintShaderDebugInfoSource(
   const Instruction* file_string =
       FindDef(debug_source.GetOperandAs<uint32_t>(4));
   ss << "\n  --> " << file_string->GetOperandAs<std::string>(1) << ":"
-     << line_start << ":" << column_start << '\n';
+     << source_info.line_start << ":" << source_info.column_start << '\n';
 
   add_vertical_line(0);
   ss << '\n';
 
   const Instruction* source_string =
       FindDef(debug_source.GetOperandAs<uint32_t>(5));
-  add_vertical_line(line_start);
+  add_vertical_line(source_info.line_start);
   stream_text(source_string);
 
   const uint32_t set_id = ShaderDebugInfoSet();
@@ -2418,10 +2526,9 @@ void ValidationState_t::PrintShaderDebugInfoSource(
   }
 
   // This happens if the error is the last line of source
-  if (current_line_num == line_end) ss << "\n";
+  if (current_line_num == source_info.line_end) ss << "\n";
 
   add_vertical_line(0);
-  ss << "\n";
 }
 
 bool ValidationState_t::IsValidStorageClass(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1007,15 +1007,6 @@ class ValidationState_t {
   void RegisterShaderDebugInfo(uint32_t id) { shader_debug_info_set_id = id; }
   uint32_t ShaderDebugInfoSet() const { return shader_debug_info_set_id; }
   std::string InspectShaderDebugInfo(const Instruction& inst);
-  void InspectDebugLine(std::ostringstream& ss, const Instruction& inst);
-  void InspectDebugGlobalVariable(std::ostringstream& ss,
-                                  const Instruction& inst);
-  void InspectDebugLocalVariable(std::ostringstream& ss, const Function& func,
-                                 const Instruction& inst);
-  void PrintShaderDebugInfoSource(std::ostringstream& ss,
-                                  const Instruction& debug_source,
-                                  uint32_t line_start, uint32_t line_end,
-                                  uint32_t column_start);
 
  private:
   ValidationState_t(const ValidationState_t&);
@@ -1210,6 +1201,24 @@ class ValidationState_t {
   /// Variables used to reduce the number of diagnostic messages.
   uint32_t num_of_warnings_;
   uint32_t max_num_of_warnings_;
+
+  struct DebugSourceInfo {
+    uint32_t line_start;
+    uint32_t line_end;
+    uint32_t column_start;
+    uint32_t column_end;
+  };
+  DebugSourceInfo GetDebugSourceInfo(const Instruction& inst);
+  void InspectDebugLine(std::ostringstream& ss, const Instruction& inst);
+  void InspectDebugGlobalVariable(std::ostringstream& ss,
+                                  const Instruction& inst);
+  void InspectDebugLocalVariable(std::ostringstream& ss, const Function& func,
+                                 const Instruction& inst);
+  void InspectDebugFunctionDefinition(std::ostringstream& ss,
+                                      const Instruction& function_call_inst);
+  void PrintShaderDebugInfoSource(std::ostringstream& ss,
+                                  const Instruction& debug_source,
+                                  const DebugSourceInfo& source_info);
 };
 
 }  // namespace val

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -505,6 +505,295 @@ void main() {
   EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
 }
 
+TEST_F(ValidateShaderDebugInfo, FunctionCall) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %24 = OpString "foo"
+         %27 = OpString "#version 450
+
+int foo(int z) {
+    return z * 3;
+}
+
+void main() {
+    uint x = 0;
+    int y = foo(x);
+}"
+         %33 = OpString "z"
+         %38 = OpString "main"
+         %54 = OpString "x"
+         %60 = OpString "y"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+     %int_3 = OpConstant %int 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_int = OpTypePointer Function %int
+     %uint_7 = OpConstant %uint 7
+         %18 = OpExtInst %void %1 DebugTypePointer %9 %uint_7 %uint_0
+         %19 = OpTypeFunction %int %_ptr_Function_int
+         %20 = OpExtInst %void %1 DebugTypeFunction %uint_3 %9 %9
+         %26 = OpExtInst %void %1 DebugSource %2 %27
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %28 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %26 %uint_2
+         %25 = OpExtInst %void %1 DebugFunction %24 %20 %26 %uint_3 %uint_0 %28 %24 %uint_3 %uint_3
+         %32 = OpExtInst %void %1 DebugLocalVariable %33 %9 %26 %uint_3 %uint_0 %25 %uint_4 %uint_1
+         %35 = OpExtInst %void %1 DebugExpression
+         %39 = OpExtInst %void %1 DebugFunction %38 %6 %26 %uint_7 %uint_0 %28 %38 %uint_3 %uint_7
+     %uint_5 = OpConstant %uint 5
+     %uint_8 = OpConstant %uint 8
+         %53 = OpExtInst %void %1 DebugLocalVariable %54 %9 %26 %uint_8 %uint_0 %39 %uint_4
+     %uint_9 = OpConstant %uint 9
+         %59 = OpExtInst %void %1 DebugLocalVariable %60 %9 %26 %uint_9 %uint_0 %39 %uint_4
+    %uint_10 = OpConstant %uint 10
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+          %x = OpVariable %_ptr_Function_uint Function
+          %y = OpVariable %_ptr_Function_uint Function
+      %param = OpVariable %_ptr_Function_uint Function
+         %50 = OpExtInst %void %1 DebugScope %39
+         %51 = OpExtInst %void %1 DebugLine %26 %uint_7 %uint_7 %uint_0 %uint_0
+         %49 = OpExtInst %void %1 DebugFunctionDefinition %39 %main
+         %57 = OpExtInst %void %1 DebugLine %26 %uint_8 %uint_8 %uint_0 %uint_0
+         %56 = OpExtInst %void %1 DebugDeclare %53 %x %35
+               OpStore %x %uint_0
+         %63 = OpExtInst %void %1 DebugLine %26 %uint_9 %uint_9 %uint_0 %uint_0
+         %62 = OpExtInst %void %1 DebugDeclare %59 %y %35
+         %65 = OpLoad %uint %x
+               OpStore %param %65
+         %66 = OpFunctionCall %int %foo_u1_ %param
+               OpStore %y %66
+               OpReturn
+               OpFunctionEnd
+    %foo_u1_ = OpFunction %int None %19
+          %z = OpFunctionParameter %_ptr_Function_int
+         %23 = OpLabel
+         %36 = OpExtInst %void %1 DebugScope %25
+         %37 = OpExtInst %void %1 DebugLine %26 %uint_3 %uint_3 %uint_0 %uint_0
+         %34 = OpExtInst %void %1 DebugDeclare %32 %z %35
+         %40 = OpExtInst %void %1 DebugFunctionDefinition %25 %foo_u1_
+         %42 = OpExtInst %void %1 DebugLine %26 %uint_4 %uint_4 %uint_0 %uint_0
+         %41 = OpLoad %int %z
+         %43 = OpIMul %int %41 %int_3
+               OpReturnValue %43
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:9:0
+  |
+9 |     int y = foo(x);
+  |
+  --> a.comp:3:0
+  |
+3 | int foo(int z) {
+  |)"));
+}
+
+// If we can only find the caller, not the callee
+TEST_F(ValidateShaderDebugInfo, FunctionCallNoCallee) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %24 = OpString "foo"
+         %27 = OpString "#version 450
+
+int foo(int z) {
+    return z * 3;
+}
+
+void main() {
+    uint x = 0;
+    int y = foo(x);
+}"
+         %33 = OpString "z"
+         %38 = OpString "main"
+         %54 = OpString "x"
+         %60 = OpString "y"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+     %int_3 = OpConstant %int 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_int = OpTypePointer Function %int
+     %uint_7 = OpConstant %uint 7
+         %18 = OpExtInst %void %1 DebugTypePointer %9 %uint_7 %uint_0
+         %19 = OpTypeFunction %int %_ptr_Function_int
+         %20 = OpExtInst %void %1 DebugTypeFunction %uint_3 %9 %9
+         %26 = OpExtInst %void %1 DebugSource %2 %27
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %28 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %26 %uint_2
+         %25 = OpExtInst %void %1 DebugFunction %24 %20 %26 %uint_3 %uint_0 %28 %24 %uint_3 %uint_3
+         %32 = OpExtInst %void %1 DebugLocalVariable %33 %9 %26 %uint_3 %uint_0 %25 %uint_4 %uint_1
+         %35 = OpExtInst %void %1 DebugExpression
+         %39 = OpExtInst %void %1 DebugFunction %38 %6 %26 %uint_7 %uint_0 %28 %38 %uint_3 %uint_7
+     %uint_5 = OpConstant %uint 5
+     %uint_8 = OpConstant %uint 8
+         %53 = OpExtInst %void %1 DebugLocalVariable %54 %9 %26 %uint_8 %uint_0 %39 %uint_4
+     %uint_9 = OpConstant %uint 9
+         %59 = OpExtInst %void %1 DebugLocalVariable %60 %9 %26 %uint_9 %uint_0 %39 %uint_4
+    %uint_10 = OpConstant %uint 10
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+          %x = OpVariable %_ptr_Function_uint Function
+          %y = OpVariable %_ptr_Function_uint Function
+      %param = OpVariable %_ptr_Function_uint Function
+         %50 = OpExtInst %void %1 DebugScope %39
+         %51 = OpExtInst %void %1 DebugLine %26 %uint_7 %uint_7 %uint_0 %uint_0
+         %49 = OpExtInst %void %1 DebugFunctionDefinition %39 %main
+         %57 = OpExtInst %void %1 DebugLine %26 %uint_8 %uint_8 %uint_0 %uint_0
+         %56 = OpExtInst %void %1 DebugDeclare %53 %x %35
+               OpStore %x %uint_0
+         %63 = OpExtInst %void %1 DebugLine %26 %uint_9 %uint_9 %uint_0 %uint_0
+         %62 = OpExtInst %void %1 DebugDeclare %59 %y %35
+         %65 = OpLoad %uint %x
+               OpStore %param %65
+         %66 = OpFunctionCall %int %foo_u1_ %param
+               OpStore %y %66
+               OpReturn
+               OpFunctionEnd
+    %foo_u1_ = OpFunction %int None %19
+          %z = OpFunctionParameter %_ptr_Function_int
+         %23 = OpLabel
+         %41 = OpLoad %int %z
+         %43 = OpIMul %int %41 %int_3
+               OpReturnValue %43
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> a.comp:9:0
+  |
+9 |     int y = foo(x);
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, FunctionCallAcrossFile) {
+  const std::string str = R"(
+
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+%file_name_0 = OpString "file_a.comp"
+%file_name_1 = OpString "file_b.comp"
+          %8 = OpString "uint"
+         %24 = OpString "foo"
+      %file_0 = OpString "
+int foo(int z) {
+    return z * 3;
+}
+"
+    %file_1 = OpString "#version 450
+void main() {
+    uint x = 0;
+    int y = foo(
+                 x
+               );
+}"
+         %33 = OpString "z"
+         %38 = OpString "main"
+         %54 = OpString "x"
+         %60 = OpString "y"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+    %uint_32 = OpConstant %uint 32
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
+     %uint_6 = OpConstant %uint 6
+     %uint_7 = OpConstant %uint 7
+     %int_3 = OpConstant %int 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_int = OpTypePointer Function %int
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+         %18 = OpExtInst %void %1 DebugTypePointer %9 %uint_7 %uint_0
+         %19 = OpTypeFunction %int %_ptr_Function_int
+         %20 = OpExtInst %void %1 DebugTypeFunction %uint_3 %9 %9
+  %source_0 = OpExtInst %void %1 DebugSource %file_name_0 %file_0
+  %source_1 = OpExtInst %void %1 DebugSource %file_name_1 %file_1
+         %28 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %source_0 %uint_2
+         %25 = OpExtInst %void %1 DebugFunction %24 %20 %source_0 %uint_2 %uint_0 %28 %24 %uint_3 %uint_3
+         %39 = OpExtInst %void %1 DebugFunction %38 %6 %source_1 %uint_2 %uint_0 %28 %38 %uint_3 %uint_7
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+          %x = OpVariable %_ptr_Function_uint Function
+          %y = OpVariable %_ptr_Function_uint Function
+      %param = OpVariable %_ptr_Function_uint Function
+         %51 = OpExtInst %void %1 DebugLine %source_1 %uint_2 %uint_2 %uint_0 %uint_0
+         %49 = OpExtInst %void %1 DebugFunctionDefinition %39 %main
+         %57 = OpExtInst %void %1 DebugLine %source_1 %uint_3 %uint_3 %uint_0 %uint_0
+               OpStore %x %uint_0
+         %63 = OpExtInst %void %1 DebugLine %source_1 %uint_4 %uint_6 %uint_0 %uint_0
+         %65 = OpLoad %uint %x
+               OpStore %param %65
+         %66 = OpFunctionCall %int %foo_u1_ %param
+               OpStore %y %66
+               OpReturn
+               OpFunctionEnd
+    %foo_u1_ = OpFunction %int None %19
+          %z = OpFunctionParameter %_ptr_Function_int
+         %23 = OpLabel
+         %37 = OpExtInst %void %1 DebugLine %source_0 %uint_2 %uint_2 %uint_0 %uint_0
+         %40 = OpExtInst %void %1 DebugFunctionDefinition %25 %foo_u1_
+         %42 = OpExtInst %void %1 DebugLine %source_0 %uint_3 %uint_3 %uint_0 %uint_0
+         %41 = OpLoad %int %z
+         %43 = OpIMul %int %41 %int_3
+               OpReturnValue %43
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(  --> file_b.comp:4:0
+  |
+4 |     int y = foo(
+5 |                  x
+6 |                );
+  |
+  --> file_a.comp:2:0
+  |
+2 | int foo(int z) {
+  |)"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
Next part of #6617 

- Creates a common util for function lines
- Have way to print two sections
- Add `OpFunctionCall`

```
error: 54: OpFunctionCall Argument <id> '41[%41]'s type does not match Function <id> '28[%_ptr_Function_int]'s parameter type.
  %47 = OpFunctionCall %int %48 %41

  --> file_b.comp:4:0
  |
4 |     int y = foo(
5 |                  x
6 |                );
  |
  --> file_a.comp:2:0
  |
2 | int foo(int z) {
  |
```