### PR TITLE
enum_set: Bucket operator==() link errors with Visual Studio 15 2017

### DIFF
--- a/source/enum_set.h
+++ b/source/enum_set.h
@@ -73,8 +73,8 @@ class EnumSet {
     // 1st enum this bucket can represent.
     T start;
 
-    friend bool operator==(const Bucket& lhs, const Bucket& rhs) {
-      return lhs.start == rhs.start && lhs.data == rhs.data;
+    bool operator==(const Bucket& other) const {
+      return start == other.start && data == other.data;
     }
   };
 


### PR DESCRIPTION
With Visual Studio 2017, I'm getting these link errors:
```
SPIRV-Tools-opt.lib(feature_manager.obj) : error LNK2019: unresolved external symbol "bool __cdecl operator==(struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &,struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &)" (??8@YA_NAEBUBucket@?$EnumSet@W4Extension@spvtools@@@spvtools@@0@Z) referenced in function "public: bool __cdecl std::equal_to<void>::operator()<struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &,struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &>(struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &,struct spvtools::EnumSet<enum spvtools::Extension>::Bucket const &)const " (??$?RAEBUBucket@?$EnumSet@W4Extension@spvtools@@@spvtools@@AEBU012@@?$equal_to@X@std@@QEBA_NAEBUBucket@?$EnumSet@W4Extension@spvtools@@@spvtools@@0@Z)
SPIRV-Tools-opt.lib(feature_manager.obj) : error LNK2019: unresolved external symbol "bool __cdecl operator==(struct spvtools::EnumSet<enum spv::Capability>::Bucket const &,struct spvtools::EnumSet<enum spv::Capability>::Bucket const &)" (??8@YA_NAEBUBucket@?$EnumSet@W4Capability@spv@@@spvtools@@0@Z) referenced in function "public: bool __cdecl std::equal_to<void>::operator()<struct spvtools::EnumSet<enum spv::Capability>::Bucket const &,struct spvtools::EnumSet<enum spv::Capability>::Bucket const &>(struct spvtools::EnumSet<enum spv::Capability>::Bucket const &,struct spvtools::EnumSet<enum spv::Capability>::Bucket const &)const " (??$?RAEBUBucket@?$EnumSet@W4Capability@spv@@@spvtools@@AEBU012@@?$equal_to@X@std@@QEBA_NAEBUBucket@?$EnumSet@W4Capability@spv@@@spvtools@@0@Z)
```
It looks like a compiler issue because these errors are not raised using more recent versions of Visual Studio.
Nonetheless, changing the operator==() from a friend function to a member method fixes the issue, which is what this patch does.