### PR TITLE
build: Fix Build.gn with Graph.DebugInfo

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -52,6 +52,7 @@ action("spvtools_core_tables") {
   f8=rebase_path("${grammar_dir}/extinst.spv-amd-shader-ballot.grammar.json", root_build_dir)
   f9=rebase_path("${grammar_dir}/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json", root_build_dir)
   f10=rebase_path("${grammar_dir}/extinst.spv-amd-shader-trinary-minmax.grammar.json", root_build_dir)
+  f11=rebase_path("${grammar_dir}/extinst.nonsemantic.graph.debuginfo.grammar.json", root_build_dir)
 
   sources = [
     "utils/Table/__init__.py",
@@ -64,6 +65,7 @@ action("spvtools_core_tables") {
     "${grammar_dir}/extinst.nonsemantic.clspvreflection.grammar.json",
     "${grammar_dir}/extinst.nonsemantic.shader.debuginfo.100.grammar.json",
     "${grammar_dir}/extinst.nonsemantic.vkspreflection.grammar.json",
+    "${grammar_dir}/extinst.nonsemantic.graph.debuginfo.grammar.json",
     "${grammar_dir}/extinst.opencl.debuginfo.100.grammar.json",
     "${grammar_dir}/extinst.opencl.std.100.grammar.json",
     "${grammar_dir}/extinst.spv-amd-gcn-shader.grammar.json",
@@ -90,6 +92,7 @@ action("spvtools_core_tables") {
     "--extinst=,${f8}",
     "--extinst=,${f9}",
     "--extinst=,${f10}",
+    "--extinst=,${f11}",
     "--core-tables-body-output",
     rebase_path(core_tables_body_file, root_build_dir),
     "--core-tables-header-output",
@@ -160,6 +163,10 @@ spvtools_language_header("vkdebuginfo") {
   name = "NonSemanticShaderDebugInfo"
   grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json"
 }
+spvtools_language_header("graphdebuginfo") {
+  name = "NonSemanticGraphDebugInfo"
+  grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.nonsemantic.graph.debuginfo.grammar.json"
+}
 
 config("spvtools_public_config") {
   include_dirs = [ "include" ]
@@ -219,6 +226,7 @@ group("spvtools_language_headers") {
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
     ":spvtools_language_header_vkdebuginfo",
+    ":spvtools_language_header_graphdebuginfo",
   ]
 }
 
@@ -229,6 +237,7 @@ static_library("spvtools") {
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
     ":spvtools_language_header_vkdebuginfo",
+    ":spvtools_language_header_graphdebuginfo",
   ]
 
   sources = [
@@ -388,6 +397,7 @@ static_library("spvtools_val") {
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_debuginfo",
     ":spvtools_language_header_vkdebuginfo",
+    ":spvtools_language_header_graphdebuginfo",
   ]
   public_deps = [ ":spvtools_headers" ]
 
@@ -656,6 +666,7 @@ static_library("spvtools_opt") {
     ":spvtools_headers",
     ":spvtools_language_header_cldebuginfo100",
     ":spvtools_language_header_vkdebuginfo",
+    ":spvtools_language_header_graphdebuginfo",
   ]
 
   if (build_with_chromium) {
@@ -1259,6 +1270,7 @@ if (build_with_chromium && spvtools_build_executables) {
       ":spvtools_language_header_cldebuginfo100",
       ":spvtools_language_header_debuginfo",
       ":spvtools_language_header_vkdebuginfo",
+      ":spvtools_language_header_graphdebuginfo",
       ":spvtools_tools_io",
       ":spvtools_val",
       "//testing/gmock",


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Tools/pull/6666#issuecomment-4453463445 is breaking the `build.gn` for VVL... I just grabbed the commit before, so VVL is good

I tried to copy-and-paste a fix, zero idea how to actually test it, but seems like it should work for someone who knows GN better