### PR TITLE
spirv-val: Add ShaderDebugInfo EntryPoint

### DIFF
--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2301,11 +2301,15 @@ void ValidationState_t::InspectDebugLine(std::ostringstream& ss,
     }
 
     if (prev->opcode() == spv::Op::OpExtInst &&
-        prev->GetOperandAs<uint32_t>(2) == set_id &&
-        prev->GetOperandAs<uint32_t>(3) ==
-            NonSemanticShaderDebugInfoDebugLine) {
-      debug_line_inst = prev;
-      break;
+        prev->GetOperandAs<uint32_t>(2) == set_id) {
+      const uint32_t ext_inst = prev->GetOperandAs<uint32_t>(3);
+      if (ext_inst == NonSemanticShaderDebugInfoDebugLine) {
+        debug_line_inst = prev;
+        break;
+      } else if (ext_inst == NonSemanticShaderDebugInfoDebugNoLine) {
+        // If we see a DebugNoLine first, this section has no valid line
+        break;
+      }
     }
   }
 

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2188,19 +2188,24 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
 
   std::ostringstream ss;
   const Function* func = inst.function();
+  const spv::Op opcode = inst.opcode();
   if (func != nullptr) {
-    if (inst.opcode() == spv::Op::OpVariable) {
+    if (opcode == spv::Op::OpVariable) {
       InspectDebugLocalVariable(ss, *func, inst);
-    } else if (inst.opcode() == spv::Op::OpFunctionCall) {
-      InspectDebugFunctionDefinition(ss, inst);
+    } else if (opcode == spv::Op::OpFunctionCall) {
+      InspectFunctionCall(ss, inst);
     } else {
       // Currently a fall back for anything in a function
       InspectDebugLine(ss, inst);
     }
-  } else if (inst.opcode() == spv::Op::OpVariable) {
+  } else if (opcode == spv::Op::OpVariable) {
     // Know are global because not in any function
     // TODO - test with OpUntypedVariable as well
     InspectDebugGlobalVariable(ss, inst);
+  } else if (opcode == spv::Op::OpExecutionMode ||
+             opcode == spv::Op::OpExecutionModeId ||
+             opcode == spv::Op::OpEntryPoint) {
+    InspectEntryPoint(ss, inst);
   }
 
   return ss.str();
@@ -2404,22 +2409,43 @@ void ValidationState_t::InspectDebugLocalVariable(
   PrintShaderDebugInfoSource(ss, *debug_source, source_info);
 }
 
-void ValidationState_t::InspectDebugFunctionDefinition(
+void ValidationState_t::InspectFunctionCall(
     std::ostringstream& ss, const Instruction& function_call_inst) {
   // First print the caller, then print the callee if also found
   InspectDebugLine(ss, function_call_inst);
 
-  const uint32_t set_id = ShaderDebugInfoSet();
-  const Instruction* debug_func_def = nullptr;
-
   const uint32_t callee_function_id =
       function_call_inst.GetOperandAs<uint32_t>(2);
   const Instruction* function_inst = FindDef(callee_function_id);
-  if (!function_inst) return;
+  if (function_inst) {
+    InspectDebugFunctionDefinition(ss, *function_inst);
+  }
+}
+
+void ValidationState_t::InspectEntryPoint(std::ostringstream& ss,
+                                          const Instruction& inst) {
+  const Instruction* function_inst = nullptr;
+  if (inst.opcode() == spv::Op::OpExecutionMode ||
+      inst.opcode() == spv::Op::OpExecutionModeId) {
+    function_inst = FindDef(inst.GetOperandAs<uint32_t>(0));
+  } else if (inst.opcode() == spv::Op::OpEntryPoint) {
+    function_inst = FindDef(inst.GetOperandAs<uint32_t>(1));
+  }
+
+  if (function_inst) {
+    InspectDebugFunctionDefinition(ss, *function_inst);
+  }
+}
+
+void ValidationState_t::InspectDebugFunctionDefinition(
+    std::ostringstream& ss, const Instruction& function_inst) {
+  assert(function_inst.opcode() == spv::Op::OpFunction);
+  const uint32_t set_id = ShaderDebugInfoSet();
+  const Instruction* debug_func_def = nullptr;
 
   // Loop through the Function block as the DebugFunctionDefinition needs to be
   // inside it
-  size_t first_inst_id = (function_inst - &ordered_instructions()[0]) + 1;
+  size_t first_inst_id = (&function_inst - &ordered_instructions()[0]) + 1;
   for (size_t i = first_inst_id + 1; i < ordered_instructions().size(); ++i) {
     const Instruction& current_inst = ordered_instructions()[i];
     if (current_inst.opcode() == spv::Op::OpFunctionEnd) {
@@ -2430,7 +2456,7 @@ void ValidationState_t::InspectDebugFunctionDefinition(
         current_inst.GetOperandAs<uint32_t>(2) == set_id &&
         current_inst.GetOperandAs<uint32_t>(3) ==
             NonSemanticShaderDebugInfoDebugFunctionDefinition &&
-        current_inst.GetOperandAs<uint32_t>(5) == callee_function_id) {
+        current_inst.GetOperandAs<uint32_t>(5) == function_inst.id()) {
       debug_func_def = &current_inst;
       break;
     }

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1214,8 +1214,11 @@ class ValidationState_t {
                                   const Instruction& inst);
   void InspectDebugLocalVariable(std::ostringstream& ss, const Function& func,
                                  const Instruction& inst);
+  void InspectFunctionCall(std::ostringstream& ss,
+                           const Instruction& function_call_inst);
+  void InspectEntryPoint(std::ostringstream& ss, const Instruction& inst);
   void InspectDebugFunctionDefinition(std::ostringstream& ss,
-                                      const Instruction& function_call_inst);
+                                      const Instruction& function_inst);
   void PrintShaderDebugInfoSource(std::ostringstream& ss,
                                   const Instruction& debug_source,
                                   const DebugSourceInfo& source_info);

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -848,6 +848,98 @@ void main() {
   |)"));
 }
 
+TEST_F(ValidateShaderDebugInfo, ExecutionMode) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 0 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+void main() {
+}"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_3 %uint_0 %20 %16 %uint_3 %uint_3
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %25 = OpExtInst %void %1 DebugScope %17
+         %26 = OpExtInst %void %1 DebugLine %18 %uint_3 %uint_3 %uint_0 %uint_0
+         %24 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(--> a.comp:3:0
+  |
+3 | void main() {
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, EntryPoint) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+void main() {
+}"
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %20 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_3 %uint_0 %20 %16 %uint_3 %uint_3
+       %main = OpFunction %uint None %5
+         %15 = OpLabel
+         %25 = OpExtInst %void %1 DebugScope %17
+         %26 = OpExtInst %void %1 DebugLine %18 %uint_3 %uint_3 %uint_0 %uint_0
+         %24 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+               OpReturnValue %uint_1
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(--> a.comp:3:0
+  |
+3 | void main() {
+  |)"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -83,6 +83,60 @@ void main() {
   |)"));
 }
 
+TEST_F(ValidateShaderDebugInfo, DebugNoLine) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+         %19 = OpString "#version 450
+layout(set = 0, binding = 1, std430) buffer SSBO {
+    vec4 data;
+};
+
+void main() {
+    data = vec4(0.0);
+}"
+               OpDecorate %SSBO Block
+               OpMemberDecorate %SSBO 0 Offset 0
+               OpDecorate %_ Binding 1
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_0 = OpConstant %uint 0
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %SSBO = OpTypeStruct %v4float
+%_ptr_StorageBuffer_SSBO = OpTypePointer StorageBuffer %SSBO
+    %uint_12 = OpConstant %uint 12
+          %_ = OpVariable %_ptr_StorageBuffer_SSBO StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_0 = OpConstant %float 0
+         %50 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+     %uint_7 = OpConstant %uint 7
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %54 = OpExtInst %void %1 DebugLine %18 %uint_7 %uint_7 %uint_0 %uint_0
+         %55 = OpExtInst %void %1 DebugNoLine
+         %53 = OpAccessChain %_ptr_StorageBuffer_v4float %_ %int_0 %int_0 %int_0
+         %56 = OpExtInst %void %1 DebugLine %18 %uint_7 %uint_7 %uint_0 %uint_0
+               OpStore %53 %50
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_1);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_1));
+  EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
+}
+
 TEST_F(ValidateShaderDebugInfo, DebugLineMultieLine) {
   const std::string str = R"(
                OpCapability Shader


### PR DESCRIPTION
Part of #6617 

- Add proper `DebugNoLine` support
- For things that point to the Entry point functions, print the functions out

```
error: 6: Local Size execution mode must not have a product of zero (X = 0, Y = 1, Z = 1).
  OpExecutionMode %2 LocalSize 0 1 1

  --> a.comp:3:0
  |
3 | void main() {
  |

error: 5: [VUID-StandaloneSpirv-None-04633] OpEntryPoint Entry Point <id> '2[%2]'s function return type is not void.
  OpEntryPoint GLCompute %2 "main"

  --> a.comp:3:0
  |
3 | void main() {
  |
```