### PR TITLE
Allow OpPoisonKHR definition on the top of the module

### DIFF
--- a/source/val/validate_misc.cpp
+++ b/source/val/validate_misc.cpp
@@ -133,6 +133,7 @@ spv_result_t ValidateAbort(ValidationState_t& _, const Instruction* inst) {
 spv_result_t MiscPass(ValidationState_t& _, const Instruction* inst) {
   switch (inst->opcode()) {
     case spv::Op::OpUndef:
+    case spv::Op::OpPoisonKHR:
       if (auto error = ValidateUndef(_, inst)) return error;
       break;
     default:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -107,6 +107,7 @@ ModuleLayoutSection InstructionLayoutSection(
       return kLayoutFunctionDefinitions;
     case spv::Op::OpLine:
     case spv::Op::OpNoLine:
+    case spv::Op::OpPoisonKHR:
     case spv::Op::OpUndef:
       if (current_section == kLayoutTypes) return kLayoutTypes;
       return kLayoutFunctionDefinitions;


### PR DESCRIPTION
Currently it's not allowed by the spec, but it's arguably a specification bug.