### PR TITLE
spirv-val: Add OpDecorate to ShaderDebugInfo messages

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -110,21 +110,23 @@ bool IsNotMemberDecoration(spv::Decoration dec) {
 spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
                                       const Instruction* inst,
                                       const Instruction* target) {
-  auto fail = [&_, dec, inst, target](uint32_t vuid) -> DiagnosticStream {
-    DiagnosticStream ds = std::move(
-        _.diag(SPV_ERROR_INVALID_ID, inst)
-        << _.VkErrorID(vuid) << _.SpvDecorationString(dec)
-        << " decoration on target <id> " << _.getIdName(target->id()) << " ");
-    return ds;
+  auto fail = [&_, dec, target]() -> std::string {
+    std::ostringstream ss;
+    ss << _.SpvDecorationString(dec) << " decoration on target <id> "
+       << _.getIdName(target->id()) << " ";
+    return ss.str();
   };
+
   switch (dec) {
     case spv::Decoration::SpecId:
       if (target->opcode() != spv::Op::OpSpecConstantTrue &&
           target->opcode() != spv::Op::OpSpecConstantFalse &&
           target->opcode() != spv::Op::OpSpecConstant &&
           target->opcode() != spv::Op::OpSpecConstantDataKHR) {
-        return fail(0) << "must be OpSpecConstantTrue, OpSpecConstantFalse, "
-                          "OpSpecConstant, or OpSpecConstantDataKHR";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail()
+               << "must be OpSpecConstantTrue, OpSpecConstantFalse, "
+                  "OpSpecConstant, or OpSpecConstantDataKHR";
       }
       break;
     case spv::Decoration::Block:
@@ -133,7 +135,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
     case spv::Decoration::GLSLPacked:
     case spv::Decoration::CPacked:
       if (target->opcode() != spv::Op::OpTypeStruct) {
-        return fail(0) << "must be a structure type";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be a structure type";
       }
       break;
     case spv::Decoration::ArrayStride:
@@ -141,7 +144,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
           target->opcode() != spv::Op::OpTypeRuntimeArray &&
           target->opcode() != spv::Op::OpTypePointer &&
           target->opcode() != spv::Op::OpTypeUntypedPointerKHR) {
-        return fail(0) << "must be an array or pointer type";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be an array or pointer type";
       }
       break;
     case spv::Decoration::BuiltIn:
@@ -155,11 +159,13 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
       if (_.HasCapability(spv::Capability::Shader) &&
           inst->GetOperandAs<spv::BuiltIn>(2) == spv::BuiltIn::WorkgroupSize) {
         if (!spvOpcodeIsConstant(target->opcode())) {
-          return fail(0) << "must be a constant for WorkgroupSize";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << fail() << "must be a constant for WorkgroupSize";
         }
       } else if (target->opcode() != spv::Op::OpVariable &&
                  target->opcode() != spv::Op::OpUntypedVariableKHR) {
-        return fail(0) << "must be a variable";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be a variable";
       }
       break;
     case spv::Decoration::NoPerspective:
@@ -185,10 +191,12 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
           target->opcode() != spv::Op::OpFunctionParameter &&
           target->opcode() != spv::Op::OpRawAccessChainNV &&
           target->opcode() != spv::Op::OpBufferPointerEXT) {
-        return fail(0) << "must be a memory object declaration";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be a memory object declaration";
       }
       if (!_.IsPointerType(target->type_id())) {
-        return fail(0) << "must be a pointer type";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be a pointer type";
       }
       break;
     case spv::Decoration::Invariant:
@@ -200,7 +208,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
     case spv::Decoration::InputAttachmentIndex:
       if (target->opcode() != spv::Op::OpVariable &&
           target->opcode() != spv::Op::OpUntypedVariableKHR) {
-        return fail(0) << "must be a variable";
+        return _.diag(SPV_ERROR_INVALID_ID, inst)
+               << fail() << "must be a variable";
       }
       break;
     default:
@@ -237,7 +246,8 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
       case spv::Decoration::Index:
         // Langauge from SPIR-V definition of Index
         if (sc != spv::StorageClass::Output) {
-          return fail(0) << "must be in the Output storage class";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << fail() << "must be in the Output storage class";
         }
         break;
       case spv::Decoration::Binding:
@@ -246,13 +256,17 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
             sc != spv::StorageClass::Uniform &&
             sc != spv::StorageClass::UniformConstant &&
             sc != spv::StorageClass::TileAttachmentQCOM) {
-          return fail(6491) << "must be in the StorageBuffer, Uniform, or "
-                               "UniformConstant storage class";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << _.VkErrorID(6491) << fail()
+                 << "must be in the StorageBuffer, Uniform, or "
+                    "UniformConstant storage class";
         }
         break;
       case spv::Decoration::InputAttachmentIndex:
         if (sc != spv::StorageClass::UniformConstant) {
-          return fail(6678) << "must be in the UniformConstant storage class";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << _.VkErrorID(6678) << fail()
+                 << "must be in the UniformConstant storage class";
         }
         break;
       case spv::Decoration::Flat:
@@ -260,12 +274,16 @@ spv_result_t ValidateDecorationTarget(ValidationState_t& _, spv::Decoration dec,
       case spv::Decoration::Centroid:
       case spv::Decoration::Sample:
         if (sc != spv::StorageClass::Input && sc != spv::StorageClass::Output) {
-          return fail(4670) << "storage class must be Input or Output";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << _.VkErrorID(4670) << fail()
+                 << "storage class must be Input or Output";
         }
         break;
       case spv::Decoration::PerVertexKHR:
         if (sc != spv::StorageClass::Input) {
-          return fail(6777) << "storage class must be Input";
+          return _.diag(SPV_ERROR_INVALID_ID, inst)
+                 << _.VkErrorID(6777) << fail()
+                 << "storage class must be Input";
         }
         break;
       default:

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -2210,6 +2210,10 @@ std::string ValidationState_t::InspectShaderDebugInfo(const Instruction& inst) {
              opcode == spv::Op::OpExecutionModeId ||
              opcode == spv::Op::OpEntryPoint) {
     InspectEntryPoint(ss, inst);
+  } else if (opcode == spv::Op::OpDecorate || opcode == spv::Op::OpDecorateId ||
+             opcode == spv::Op::OpMemberDecorate ||
+             opcode == spv::Op::OpMemberDecorateIdEXT) {
+    InspectDecorate(ss, inst);
   }
 
   return ss.str();
@@ -2452,6 +2456,68 @@ void ValidationState_t::InspectEntryPoint(std::ostringstream& ss,
   if (function_inst) {
     InspectDebugFunctionDefinition(ss, *function_inst);
   }
+}
+
+void ValidationState_t::InspectDecorate(std::ostringstream& ss,
+                                        const Instruction& decorate_inst) {
+  const Instruction* target_inst =
+      FindDef(decorate_inst.GetOperandAs<uint32_t>(0));
+  if (!target_inst) {
+    return;
+  }
+
+  spv::Op target_opcode = target_inst->opcode();
+  if (target_opcode == spv::Op::OpVariable) {
+    return InspectDebugGlobalVariable(ss, *target_inst);
+  } else if (target_opcode == spv::Op::OpUntypedVariableKHR) {
+    return;  // TODO - add tests and support
+  }
+
+  // If here, likely an OpType* so if we can detect only a single global
+  // variable is using that type, just attempt to print it out
+  const uint32_t set_id = ShaderDebugInfoSet();
+  const Instruction* debug_gloabl_var_inst = nullptr;
+  for (const auto& inst : ordered_instructions()) {
+    if (inst.opcode() == spv::Op::OpFunction) {
+      break;
+    }
+
+    if (inst.opcode() != spv::Op::OpExtInst ||
+        inst.GetOperandAs<uint32_t>(2) != set_id ||
+        inst.GetOperandAs<uint32_t>(3) !=
+            NonSemanticShaderDebugInfoDebugGlobalVariable) {
+      continue;
+    }
+
+    const Instruction* var_inst = FindDef(inst.GetOperandAs<uint32_t>(11));
+    if (!var_inst || var_inst->opcode() != spv::Op::OpVariable) {
+      continue;
+    }
+
+    const Instruction* pointer_type = FindDef(var_inst->type_id());
+    if (!pointer_type || pointer_type->opcode() != spv::Op::OpTypePointer) {
+      continue;
+    }
+
+    const uint32_t pointee_type_id = pointer_type->GetOperandAs<uint32_t>(2);
+    if (pointee_type_id == target_inst->id()) {
+      if (debug_gloabl_var_inst) {
+        return;  // Multiple variables using this type
+      }
+      debug_gloabl_var_inst = &inst;
+    }
+  }
+  if (!debug_gloabl_var_inst) return;
+
+  const Instruction* debug_source =
+      FindDef(debug_gloabl_var_inst->GetOperandAs<uint32_t>(6));
+  if (!debug_source || debug_source->GetOperandAs<uint32_t>(3) !=
+                           NonSemanticShaderDebugInfoDebugSource) {
+    return;
+  }
+
+  auto source_info = GetDebugSourceInfo(*debug_gloabl_var_inst);
+  PrintShaderDebugInfoSource(ss, *debug_source, source_info);
 }
 
 void ValidationState_t::InspectDebugFunctionDefinition(

--- a/source/val/validation_state.h
+++ b/source/val/validation_state.h
@@ -1220,6 +1220,8 @@ class ValidationState_t {
                                         const Function& func,
                                         const Instruction& inst);
   void InspectEntryPoint(std::ostringstream& ss, const Instruction& inst);
+  void InspectDecorate(std::ostringstream& ss,
+                       const Instruction& decorate_inst);
   void InspectDebugFunctionDefinition(std::ostringstream& ss,
                                       const Instruction& function_inst);
   void PrintShaderDebugInfoSource(std::ostringstream& ss,

--- a/test/val/val_shader_debug_info_test.cpp
+++ b/test/val/val_shader_debug_info_test.cpp
@@ -1136,11 +1136,6 @@ void main() {
 
 TEST_F(ValidateShaderDebugInfo, FunctionParameter) {
   const std::string str = R"(
-; SPIR-V
-; Version: 1.5
-; Generator: Khronos Glslang Reference Front End; 11
-; Bound: 75
-; Schema: 0
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -1239,6 +1234,251 @@ void main() {
   |
 3 | uint foo(uint a) {
   |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, DecorationOnVariable) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %x
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+layout(set = 0, binding = 0) buffer ssbo {
+    uint a;
+} x;
+
+void main() {
+    x.a = 0;
+}"
+         %27 = OpString "a"
+         %30 = OpString "ssbo"
+         %36 = OpString "x"
+         %42 = OpString "int"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %x Binding 0
+               OpDecorate %x DescriptorSet 0
+               OpDecorate %x ArrayStride 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_7 = OpConstant %uint 7
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %21 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_7 %uint_0 %21 %16 %uint_3 %uint_7
+       %ssbo = OpTypeStruct %uint
+    %uint_10 = OpConstant %uint 10
+         %26 = OpExtInst %void %1 DebugTypeMember %27 %9 %18 %uint_4 %uint_10 %uint_0 %uint_0 %uint_3
+         %29 = OpExtInst %void %1 DebugTypeComposite %30 %uint_1 %18 %uint_3 %uint_0 %21 %30 %uint_0 %uint_3 %26
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+    %uint_12 = OpConstant %uint 12
+         %33 = OpExtInst %void %1 DebugTypePointer %29 %uint_12 %uint_0
+          %x = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+     %uint_8 = OpConstant %uint 8
+         %35 = OpExtInst %void %1 DebugGlobalVariable %36 %29 %18 %uint_3 %uint_0 %21 %36 %x %uint_8
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %47 = OpAccessChain %_ptr_StorageBuffer_uint %x %int_0
+               OpStore %47 %uint_0
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(--> a.comp:3:0
+  |
+3 | layout(set = 0, binding = 0) buffer ssbo {
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, DecorationOnTypeUsedOnce) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %x
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+layout(set = 0, binding = 0) buffer ssbo {
+    uint a;
+} x;
+
+void main() {
+    x.a = 0;
+}"
+         %27 = OpString "a"
+         %30 = OpString "ssbo"
+         %36 = OpString "x"
+         %42 = OpString "int"
+               OpDecorate %ssbo Block
+               OpDecorate %ssbo ArrayStride 16
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %x Binding 0
+               OpDecorate %x DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_7 = OpConstant %uint 7
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %21 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_7 %uint_0 %21 %16 %uint_3 %uint_7
+       %ssbo = OpTypeStruct %uint
+    %uint_10 = OpConstant %uint 10
+         %26 = OpExtInst %void %1 DebugTypeMember %27 %9 %18 %uint_4 %uint_10 %uint_0 %uint_0 %uint_3
+         %29 = OpExtInst %void %1 DebugTypeComposite %30 %uint_1 %18 %uint_3 %uint_0 %21 %30 %uint_0 %uint_3 %26
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+    %uint_12 = OpConstant %uint 12
+         %33 = OpExtInst %void %1 DebugTypePointer %29 %uint_12 %uint_0
+          %x = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+     %uint_8 = OpConstant %uint 8
+         %35 = OpExtInst %void %1 DebugGlobalVariable %36 %29 %18 %uint_3 %uint_0 %21 %36 %x %uint_8
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %47 = OpAccessChain %_ptr_StorageBuffer_uint %x %int_0
+               OpStore %47 %uint_0
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), HasSubstr(R"(--> a.comp:3:0
+  |
+3 | layout(set = 0, binding = 0) buffer ssbo {
+  |)"));
+}
+
+TEST_F(ValidateShaderDebugInfo, DecorationOnTypeUsedMultiple) {
+  const std::string str = R"(
+                OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %x %y
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+
+layout(set = 0, binding = 0) buffer ssbo {
+    uint a;
+} x;
+
+layout(set = 0, binding = 1) buffer ssbo2 {
+    uint b;
+} y;
+
+void main() {
+    x.a = 0;
+    y.b = 0;
+}"
+         %27 = OpString "a"
+         %30 = OpString "ssbo"
+         %36 = OpString "x"
+         %40 = OpString "b"
+         %42 = OpString "ssbo2"
+         %48 = OpString "y"
+         %53 = OpString "int"
+               OpDecorate %ssbo Block
+               OpDecorate %ssbo ArrayStride 16
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %x Binding 0
+               OpDecorate %x DescriptorSet 0
+               OpDecorate %y Binding 1
+               OpDecorate %y DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+    %uint_11 = OpConstant %uint 11
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %21 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_11 %uint_0 %21 %16 %uint_3 %uint_11
+       %ssbo = OpTypeStruct %uint
+    %uint_10 = OpConstant %uint 10
+         %26 = OpExtInst %void %1 DebugTypeMember %27 %9 %18 %uint_4 %uint_10 %uint_0 %uint_0 %uint_3
+         %29 = OpExtInst %void %1 DebugTypeComposite %30 %uint_1 %18 %uint_3 %uint_0 %21 %30 %uint_0 %uint_3 %26
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+    %uint_12 = OpConstant %uint 12
+         %33 = OpExtInst %void %1 DebugTypePointer %29 %uint_12 %uint_0
+          %x = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+     %uint_8 = OpConstant %uint 8
+         %35 = OpExtInst %void %1 DebugGlobalVariable %36 %29 %18 %uint_3 %uint_0 %21 %36 %x %uint_8
+         %39 = OpExtInst %void %1 DebugTypeMember %40 %9 %18 %uint_8 %uint_10 %uint_0 %uint_0 %uint_3
+     %uint_7 = OpConstant %uint 7
+         %41 = OpExtInst %void %1 DebugTypeComposite %42 %uint_1 %18 %uint_7 %uint_0 %21 %42 %uint_0 %uint_3 %39
+         %45 = OpExtInst %void %1 DebugTypePointer %41 %uint_12 %uint_0
+          %y = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+         %47 = OpExtInst %void %1 DebugGlobalVariable %48 %41 %18 %uint_7 %uint_0 %21 %48 %y %uint_8
+        %int = OpTypeInt 32 1
+         %54 = OpExtInst %void %1 DebugTypeBasic %53 %uint_32 %uint_4 %uint_0
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+         %57 = OpExtInst %void %1 DebugTypePointer %9 %uint_12 %uint_0
+    %uint_13 = OpConstant %uint 13
+    %uint_14 = OpConstant %uint 14
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %50 = OpExtInst %void %1 DebugScope %17
+         %51 = OpExtInst %void %1 DebugLine %18 %uint_11 %uint_11 %uint_0 %uint_0
+         %49 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+         %59 = OpExtInst %void %1 DebugLine %18 %uint_12 %uint_12 %uint_0 %uint_0
+         %58 = OpAccessChain %_ptr_StorageBuffer_uint %x %int_0
+               OpStore %58 %uint_0
+         %61 = OpExtInst %void %1 DebugLine %18 %uint_13 %uint_13 %uint_0 %uint_0
+         %60 = OpAccessChain %_ptr_StorageBuffer_uint %y %int_0
+               OpStore %60 %uint_0
+         %63 = OpExtInst %void %1 DebugLine %18 %uint_14 %uint_14 %uint_0 %uint_0
+               OpReturn
+               OpFunctionEnd
+
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(), Not(HasSubstr("a.comp")));
 }
 
 }  // namespace


### PR DESCRIPTION
Adds support for `OpDecorate` and `OpMemberDecorate` to try and report the shader debug info

For cases where you have `OpDecorate %struct_type` I try and find if there is only a single variable tied to that type (not sure how much generators are actually trying to "share" complex types like structs) so if possible, can still provide an error like

```
error: 16: ArrayStride decoration on target <id> '12[%_struct_12]' must be an array or pointer type
  OpDecorate %_struct_12 ArrayStride 16

  --> a.comp:3:0
  |
3 | layout(set = 0, binding = 0) buffer ssbo {
  |
```