### PR TITLE
Fix missing optimization in CodeSinkingPass

### DIFF
--- a/source/opt/code_sink.cpp
+++ b/source/opt/code_sink.cpp
@@ -246,6 +246,7 @@ bool CodeSinkingPass::HasUniformMemorySync() {
     }
   });
   has_uniform_sync_ = has_sync;
+  checked_for_uniform_sync_ = true;
   return has_sync;
 }
 


### PR DESCRIPTION
Set `checked_for_uniform_sync_` after the first scan for uniform memory sync instructions in `HasUniformMemorySync`. Since this function is called for most instructions, this change makes the optimization pass O(N) instead of O(N^2). This drastically reduces how long it takes in complex binaries and fulfills what I assume was the original intent of `checked_for_uniform_sync_`.