### PR TITLE
Treat version and operand_kinds as optional in generate_language_headers

### DIFF
--- a/utils/generate_language_headers.py
+++ b/utils/generate_language_headers.py
@@ -170,11 +170,20 @@ def main():
     with open(args.extinst_grammar) as json_file:
         grammar_json = json.loads(json_file.read())
         grammar_name = os.path.splitext(os.path.basename(args.extinst_output_path))[0]
+        if 'version' in grammar_json:
+          version = grammar_json['version']
+        else:
+          version = 0
+        if 'operand_kinds' in grammar_json:
+          operand_kinds = grammar_json['operand_kinds']
+        else:
+          operand_kinds = []
+
         grammar = ExtInstGrammar(name = grammar_name,
                                  copyright = grammar_json['copyright'],
                                  instructions = grammar_json['instructions'],
-                                 operand_kinds = grammar_json['operand_kinds'],
-                                 version = grammar_json['version'],
+                                 operand_kinds = operand_kinds,
+                                 version = version,
                                  revision = grammar_json['revision'])
         make_path_to_file(args.extinst_output_path)
         with open(args.extinst_output_path, 'w') as f:


### PR DESCRIPTION
Grammars such as NonSemantic.Graph.DebugInfo omit operand_kinds and version. Match SPIRV-Headers optional-field handling so GN header generation succeeds.

This should fix the CI error I'm seeing here: https://github.com/KhronosGroup/glslang/pull/4275
```
python3 ../../External/spirv-tools/utils/generate_language_headers.py --extinst-grammar ../../External/spirv-tools/external/spirv-headers/include/spirv/unified1/extinst.nonsemantic.graph.debuginfo.grammar.json --extinst-output-path gen/External/spirv-tools/NonSemanticGraphDebugInfo.h
Traceback (most recent call last):
  File "/tmpfs/src/github/glslang/out/Default-hlsl-false/../../External/spirv-tools/utils/generate_language_headers.py", line 185, in 
    main()
  File "/tmpfs/src/github/glslang/out/Default-hlsl-false/../../External/spirv-tools/utils/generate_language_headers.py", line 176, in main
    operand_kinds = grammar_json['operand_kinds'],
                    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'operand_kinds'
```

This change was mostly debugged/written using Cursor.