### PR TITLE
val: Detect additional unsupported arithmetic ops in invalid_type_pass

### DIFF
--- a/source/val/validate_invalid_type.cpp
+++ b/source/val/validate_invalid_type.cpp
@@ -24,6 +24,57 @@
 namespace spvtools {
 namespace val {
 
+namespace {
+
+bool IsBfloat16ScalarOrCompositeType(ValidationState_t& _, uint32_t type_id) {
+  const Instruction* inst = _.FindDef(type_id);
+  if (!inst) return false;
+
+  if (_.IsBfloat16Type(type_id)) return true;
+
+  switch (inst->opcode()) {
+    case spv::Op::OpTypeMatrix:
+    case spv::Op::OpTypeCooperativeMatrixNV:
+      return _.IsBfloat16ScalarType(_.GetComponentType(type_id));
+    default:
+      return false;
+  }
+}
+
+bool IsFP8ScalarOrCompositeType(ValidationState_t& _, uint32_t type_id) {
+  const Instruction* inst = _.FindDef(type_id);
+  if (!inst) return false;
+
+  if (_.IsFP8Type(type_id)) return true;
+
+  switch (inst->opcode()) {
+    case spv::Op::OpTypeMatrix:
+    case spv::Op::OpTypeCooperativeMatrixNV:
+      return _.IsFP8ScalarType(_.GetComponentType(type_id));
+    default:
+      return false;
+  }
+}
+
+spv_result_t CheckInvalidScalarOrCompositeType(ValidationState_t& _,
+                                               const Instruction* inst,
+                                               uint32_t type_id) {
+  const spv::Op opcode = inst->opcode();
+  if (IsBfloat16ScalarOrCompositeType(_, type_id)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
+  }
+  if (IsFP8ScalarOrCompositeType(_, type_id)) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << spvOpcodeString(opcode)
+           << " doesn't support FP8 E4M3/E5M2 types.";
+  }
+
+  return SPV_SUCCESS;
+}
+
+}  // namespace
+
 // Validates correctness of certain special type instructions.
 spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
   const spv::Op opcode = inst->opcode();
@@ -39,6 +90,13 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpFRem:
     case spv::Op::OpFMod:
     case spv::Op::OpFNegate:
+    case spv::Op::OpFmaKHR:
+    case spv::Op::OpVectorTimesScalar:
+    case spv::Op::OpMatrixTimesScalar:
+    case spv::Op::OpVectorTimesMatrix:
+    case spv::Op::OpMatrixTimesVector:
+    case spv::Op::OpMatrixTimesMatrix:
+    case spv::Op::OpOuterProduct:
     // Derivative Instructions
     case spv::Op::OpDPdx:
     case spv::Op::OpDPdy:
@@ -69,10 +127,30 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpGroupNonUniformFMul:
     case spv::Op::OpGroupNonUniformFMin: {
       const uint32_t result_type = inst->type_id();
-      if (_.IsBfloat16Type(result_type)) {
-        return _.diag(SPV_ERROR_INVALID_DATA, inst)
-               << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
+      if (spv_result_t result =
+              CheckInvalidScalarOrCompositeType(_, inst, result_type)) {
+        return result;
       }
+
+      break;
+    }
+
+    case spv::Op::OpCooperativeMatrixMulAddNV: {
+      if (spv_result_t result =
+              CheckInvalidScalarOrCompositeType(_, inst, inst->type_id())) {
+        return result;
+      }
+      for (uint32_t operand_index = 2; operand_index <= 4; ++operand_index) {
+        if (spv_result_t result = CheckInvalidScalarOrCompositeType(
+                _, inst, _.GetOperandTypeId(inst, operand_index))) {
+          return result;
+        }
+      }
+      break;
+    }
+
+    case spv::Op::OpDot: {
+      const uint32_t result_type = inst->type_id();
       if (_.IsFP8Type(result_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode)
@@ -143,29 +221,6 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
 
       break;
     }
-
-    case spv::Op::OpMatrixTimesMatrix: {
-      const uint32_t result_type = inst->type_id();
-      uint32_t res_num_rows = 0;
-      uint32_t res_num_cols = 0;
-      uint32_t res_col_type = 0;
-      uint32_t res_component_type = 0;
-      if (_.GetMatrixTypeInfo(result_type, &res_num_rows, &res_num_cols,
-                              &res_col_type, &res_component_type)) {
-        if (_.IsBfloat16Type(res_component_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << spvOpcodeString(opcode)
-                 << " doesn't support BFloat16 type.";
-        }
-        if (_.IsFP8Type(res_component_type)) {
-          return _.diag(SPV_ERROR_INVALID_DATA, inst)
-                 << spvOpcodeString(opcode)
-                 << " doesn't support FP8 E4M3/E5M2 types.";
-        }
-      }
-      break;
-    }
-
     default:
       break;
   }

--- a/test/val/val_invalid_type_test.cpp
+++ b/test/val/val_invalid_type_test.cpp
@@ -39,8 +39,10 @@ std::string GenerateBFloatCode(const std::string& main_body) {
 OpCapability Shader
 OpCapability BFloat16TypeKHR
 OpCapability AtomicFloat16AddEXT
+OpCapability FMAKHR
 OpCapability GroupNonUniformShuffle
 OpExtension "SPV_EXT_shader_atomic_float16_add"
+OpExtension "SPV_KHR_fma"
 OpExtension "SPV_KHR_bfloat16"
 %1 = OpExtInstImport "GLSL.std.450"
 OpMemoryModel Logical GLSL450
@@ -73,6 +75,43 @@ OpFunctionEnd)";
   return prefix + main_body + suffix;
 }
 
+std::string GenerateBFloatCoopMatCode(const std::string& main_body) {
+  const std::string prefix =
+      R"(
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpCapability BFloat16TypeKHR
+OpCapability BFloat16CooperativeMatrixKHR
+OpCapability CooperativeMatrixKHR
+OpExtension "SPV_KHR_bfloat16"
+OpExtension "SPV_KHR_cooperative_matrix"
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 32 1 1
+OpSource GLSL 450
+OpName %main "main"
+%void = OpTypeVoid
+%bfloat16 = OpTypeFloat 16 BFloat16KHR
+%func = OpTypeFunction %void
+%u32 = OpTypeInt 32 0
+%u32_8 = OpConstant %u32 8
+%subgroup = OpConstant %u32 3
+%useA = OpConstant %u32 0
+%bf16_1 = OpConstant %bfloat16 1
+%bf16matA = OpTypeCooperativeMatrixKHR %bfloat16 %subgroup %u32_8 %u32_8 %useA
+%bf16mat_A_1 = OpConstantComposite %bf16matA %bf16_1
+%main = OpFunction %void None %func
+%main_entry = OpLabel)";
+
+  const std::string suffix =
+      R"(
+OpReturn
+OpFunctionEnd)";
+
+  return prefix + main_body + suffix;
+}
+
 TEST_F(ValidateInvalidType, Bfloat16InvalidArithmeticInstruction) {
   const std::string body = R"(
 %v1 = OpVariable %_ptr_Function_bfloat16 Function
@@ -87,6 +126,45 @@ TEST_F(ValidateInvalidType, Bfloat16InvalidArithmeticInstruction) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("FMul doesn't support BFloat16 type."));
+}
+
+TEST_F(ValidateInvalidType, Bfloat16InvalidFmaInstruction) {
+  const std::string body = R"(
+%15 = OpFmaKHR %bfloat16 %bf16_1 %bf16_1 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatCode(body).c_str(), SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FmaKHR doesn't support BFloat16 type."));
+}
+
+TEST_F(ValidateInvalidType, Bfloat16InvalidVectorTimesScalarInstruction) {
+  const std::string body = R"(
+%v1 = OpVariable %_ptr_Function_v2bfloat16 Function
+%12 = OpLoad %v2bfloat16 %v1
+%15 = OpVectorTimesScalar %v2bfloat16 %12 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatCode(body).c_str(), SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("VectorTimesScalar doesn't support BFloat16 type."));
+}
+
+TEST_F(ValidateInvalidType, Bfloat16InvalidMatrixTimesScalarInstruction) {
+  const std::string body = R"(
+%15 = OpMatrixTimesScalar %bf16matA %bf16mat_A_1 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatCoopMatCode(body).c_str(),
+                      SPV_ENV_UNIVERSAL_1_6);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("MatrixTimesScalar doesn't support BFloat16 type."));
 }
 
 TEST_F(ValidateInvalidType, Bfloat16InvalidRelationalInstruction) {
@@ -207,6 +285,38 @@ TEST_F(ValidateInvalidType, FP8E5M2InvalidArithmeticInstruction) {
             ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("FMul doesn't support FP8 E4M3/E5M2 types."));
+}
+
+TEST_F(ValidateInvalidType, FP8E4M3InvalidDotInstruction) {
+  const std::string body = R"(
+%v1 = OpVariable %_ptr_Function_v2fp8e4m3 Function
+%v2 = OpVariable %_ptr_Function_v2fp8e4m3 Function
+%12 = OpLoad %v2fp8e4m3 %v1
+%14 = OpLoad %v2fp8e4m3 %v2
+%15 = OpDot %fp8e4m3 %12 %14
+)";
+
+  CompileSuccessfully(GenerateFP8Code(body).c_str(), SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Dot doesn't support FP8 E4M3/E5M2 types."));
+}
+
+TEST_F(ValidateInvalidType, FP8E5M2InvalidDotInstruction) {
+  const std::string body = R"(
+%v1 = OpVariable %_ptr_Function_v2fp8e5m2 Function
+%v2 = OpVariable %_ptr_Function_v2fp8e5m2 Function
+%12 = OpLoad %v2fp8e5m2 %v1
+%14 = OpLoad %v2fp8e5m2 %v2
+%15 = OpDot %fp8e5m2 %12 %14
+)";
+
+  CompileSuccessfully(GenerateFP8Code(body).c_str(), SPV_ENV_VULKAN_1_3);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Dot doesn't support FP8 E4M3/E5M2 types."));
 }
 
 TEST_F(ValidateInvalidType, FP8E4M3InvalidRelationalInstruction) {


### PR DESCRIPTION
@0cc4m reported OpMatrixTimesScalar with bf16 coopmat slipping through the cracks. I asked codex to fill any remaining gaps in the arithmetic instructions.