### PR TITLE
spirv-val: Fix OpBufferPointerEXT Explicit Layout

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -2446,20 +2446,13 @@ spv_result_t CheckInvalidVulkanExplicitLayout(ValidationState_t& vstate) {
       case spv::Op::OpBufferPointerEXT: {
         const auto ptr_id = inst.GetOperandAs<uint32_t>(1);
         const auto ptr_type = vstate.FindDef(vstate.FindDef(ptr_id)->type_id());
-        // Check the type of the data operand for an invalid layout.
         sc = ptr_type->GetOperandAs<spv::StorageClass>(1);
-        if (!AllowsLayout(vstate, sc) &&
-            UsesExplicitLayout(vstate, type_id, cache) !=
-                spv::Decoration::Max) {
+        // OpBufferPointerEXT needs to be in explicit layout, which it is,
+        // because it must be Uniform/StorageBuffer
+        if (sc != spv::StorageClass::StorageBuffer &&
+            sc != spv::StorageClass::Uniform) {
           return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
-                 << vstate.VkErrorID(11346)
-                 << "The result type operand of OpBufferPointerEXT must have "
-                 << "a Type operand that is explicitly laid out : "
-                 << vstate.getIdName(type_id);
-        } else if (sc != spv::StorageClass::StorageBuffer &&
-                   sc != spv::StorageClass::Uniform) {
-          return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
-                 << "OpBufferPointerEXT's Result Type must be a pointer type "
+                 << "OpBufferPointerEXT Result Type must be a pointer type "
                  << "with a Storage Class of Uniform or StorageBuffer.";
         }
         break;

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -3397,8 +3397,6 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
         return VUID_WRAP(VUID-StandaloneSpirv-Result-11337);
     case 11339:
         return VUID_WRAP(VUID-StandaloneSpirv-Result-11339);
-    case 11346:
-        return VUID_WRAP(VUID-StandaloneSpirv-Result-11346);
     case 11347:
         return VUID_WRAP(VUID-StandaloneSpirv-OpUntypedVariableKHR-11347);
     case 11416:

--- a/test/val/val_extension_spv_ext_descriptor_heap.cpp
+++ b/test/val/val_extension_spv_ext_descriptor_heap.cpp
@@ -1140,7 +1140,7 @@ TEST_F(ValidateSpvEXTDescriptorHeap, BufferPointerEXTStorageClass) {
   const std::string diag = getDiagnosticString();
   EXPECT_THAT(
       diag,
-      HasSubstr("OpBufferPointerEXT's Result Type must be a pointer "
+      HasSubstr("OpBufferPointerEXT Result Type must be a pointer "
                 "type with a Storage Class of Uniform or StorageBuffer."));
 }
 
@@ -1195,10 +1195,9 @@ TEST_F(ValidateSpvEXTDescriptorHeap, BufferPointerEXTLayout) {
   CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
   EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
   const std::string diag = getDiagnosticString();
-  EXPECT_THAT(diag, AnyVUID("VUID-StandaloneSpirv-Result-11346"));
-  EXPECT_THAT(
-      diag, HasSubstr("The result type operand of OpBufferPointerEXT "
-                      "must have a Type operand that is explicitly laid out"));
+  EXPECT_THAT(diag,
+              HasSubstr("OpBufferPointerEXT Result Type must be a pointer type "
+                        "with a Storage Class of Uniform or StorageBuffer."));
 }
 
 TEST_F(ValidateSpvEXTDescriptorHeap, BufferPointerEXTDecorate) {


### PR DESCRIPTION
Taken out of https://github.com/KhronosGroup/SPIRV-Tools/pull/6701/files as we just approved https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8305

