### PR TITLE
[opt] Pass to convert to untyped pointers

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -105,6 +105,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/control_dependence.cpp \
 		source/opt/convert_to_sampled_image_pass.cpp \
 		source/opt/convert_to_half_pass.cpp \
+		source/opt/convert_to_untyped.cpp \
 		source/opt/copy_prop_arrays.cpp \
 		source/opt/dataflow.cpp \
 		source/opt/dead_branch_elim_pass.cpp \

--- a/Android.mk
+++ b/Android.mk
@@ -106,6 +106,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/control_dependence.cpp \
 		source/opt/convert_to_sampled_image_pass.cpp \
 		source/opt/convert_to_half_pass.cpp \
+		source/opt/convert_to_untyped.cpp \
 		source/opt/copy_prop_arrays.cpp \
 		source/opt/dataflow.cpp \
 		source/opt/dead_branch_elim_pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -448,6 +448,8 @@ static_library("spvtools_opt") {
     "source/opt/convert_to_half_pass.h",
     "source/opt/convert_to_sampled_image_pass.cpp",
     "source/opt/convert_to_sampled_image_pass.h",
+    "source/opt/convert_to_untyped.cpp",
+    "source/opt/convert_to_untyped.h",
     "source/opt/copy_prop_arrays.cpp",
     "source/opt/copy_prop_arrays.h",
     "source/opt/dataflow.cpp",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -459,6 +459,8 @@ static_library("spvtools_opt") {
     "source/opt/convert_to_half_pass.h",
     "source/opt/convert_to_sampled_image_pass.cpp",
     "source/opt/convert_to_sampled_image_pass.h",
+    "source/opt/convert_to_untyped.cpp",
+    "source/opt/convert_to_untyped.h",
     "source/opt/copy_prop_arrays.cpp",
     "source/opt/copy_prop_arrays.h",
     "source/opt/dataflow.cpp",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -722,6 +722,8 @@ Optimizer::PassToken CreateSSARewritePass();
 // redundancy elimination and DCE.
 Optimizer::PassToken CreateConvertRelaxedToHalfPass();
 
+Optimizer::PassToken CreateConvertToUntypedPass();
+
 // Create relax float ops pass.
 // This pass decorates all float32 result instructions with RelaxedPrecision
 // if not already so decorated.

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   constants.h
   control_dependence.h
   convert_to_sampled_image_pass.h
+  convert_to_untyped.h
   convert_to_half_pass.h
   copy_prop_arrays.h
   dataflow.h
@@ -156,6 +157,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   constants.cpp
   control_dependence.cpp
   convert_to_sampled_image_pass.cpp
+  convert_to_untyped.cpp
   convert_to_half_pass.cpp
   copy_prop_arrays.cpp
   dataflow.cpp

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -29,6 +29,8 @@ Pass::Status ConvertToUntyped::Process() {
     return Pass::Status::SuccessWithoutChange;
   }
 
+  CheckWorkgroup();
+
   AddUntypedEnable();
   ConvertPointers();
 
@@ -59,6 +61,58 @@ bool ConvertToUntyped::HasUnsupportedFeatures() {
       spv::Capability::CooperativeVectorNV,
       spv::Capability::CooperativeVectorTrainingNV};
   return caps.HasAnyOf(unsupported);
+}
+
+void ConvertToUntyped::CheckWorkgroup() {
+  if (!context()->get_feature_mgr()->GetCapabilities().contains(
+          spv::Capability::WorkgroupMemoryExplicitLayoutKHR)) {
+    return;
+  }
+
+  // The module could have a mix of explicit and non-explicit layout for
+  // workgroup memory (though in different entry points). This transform
+  // requires all explicit to work.
+  for (auto& inst : context()->types_values()) {
+    if (inst.opcode() == spv::Op::OpVariable) {
+      auto pointee_ty = context()
+                            ->get_type_mgr()
+                            ->GetType(inst.type_id())
+                            ->AsPointer()
+                            ->pointee_type();
+      if (!pointee_ty->AsStruct()) {
+        return;
+      }
+      bool has_block = false;
+      for (auto& dec : pointee_ty->decorations()) {
+        if (dec[0] == uint32_t(spv::Decoration::Block)) {
+          has_block = true;
+          break;
+        }
+      }
+      if (!has_block) {
+        return;
+      }
+    } else if (inst.opcode() == spv::Op::OpUntypedVariableKHR) {
+      auto data_ty =
+          context()->get_type_mgr()->GetType(inst.GetSingleWordInOperand(1));
+      if (!data_ty->AsStruct()) {
+        return;
+      }
+      bool has_block = false;
+      for (auto& dec : data_ty->decorations()) {
+        if (dec[0] == uint32_t(spv::Decoration::Block)) {
+          has_block = true;
+          break;
+        }
+      }
+      if (!has_block) {
+        return;
+      }
+    }
+  }
+
+  // All workgroup variables were block-decorated.
+  support_workgroup_ = true;
 }
 
 void ConvertToUntyped::AddUntypedEnable() {
@@ -125,6 +179,8 @@ bool ConvertToUntyped::SupportedStorageClass(spv::StorageClass sc) {
     case spv::StorageClass::Uniform:
     case spv::StorageClass::PushConstant:
       return true;
+    case spv::StorageClass::Workgroup:
+      return support_workgroup_;
     default:
       return false;
   }

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -305,7 +305,8 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
         type = type->AsArray()->element_type();
         break;
       case analysis::Type::kRuntimeArray:
-        type = type->AsRuntimeArray();
+        type = type->AsRuntimeArray()->element_type();
+        break;
       case analysis::Type::kMatrix:
         return std::make_pair(row_major, mat_stride);
       // No other types could hold a matrix

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -46,14 +46,6 @@ bool ConvertToUntyped::HasUnsupportedFeatures() {
     return true;
   }
 
-  // TODO: support the following capabilities
-  if (caps.contains(spv::Capability::VariablePointersStorageBuffer)) {
-    return true;
-  }
-  if (caps.contains(spv::Capability::WorkgroupMemoryExplicitLayoutKHR)) {
-    return true;
-  }
-
   // Unsupported
   CapabilitySet unsupported{
       spv::Capability::RawAccessChainsNV,
@@ -148,6 +140,8 @@ bool ConvertToUntyped::ShouldConvert(const Instruction* inst) {
       return SupportedStorageClass(inst->GetSingleWordInOperand(0));
     case spv::Op::OpAccessChain:
     case spv::Op::OpInBoundsAccessChain:
+    case spv::Op::OpPtrAccessChain:
+    case spv::Op::OpInBoundsPtrAccessChain:
     case spv::Op::OpVariable:
       return SupportedStorageClass(context()
                                        ->get_type_mgr()
@@ -194,7 +188,10 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
     switch (inst->opcode()) {
       case spv::Op::OpAccessChain:
       case spv::Op::OpInBoundsAccessChain:
-        for (uint32_t i = inst->NumInOperands() - 1; i > 0; i--) {
+      case spv::Op::OpUntypedAccessChainKHR: {
+        uint32_t base_idx =
+            inst->opcode() == spv::Op::OpUntypedAccessChainKHR ? 1 : 0;
+        for (uint32_t i = inst->NumInOperands() - 1; i > base_idx; i--) {
           if (auto* constant =
                   context()->get_constant_mgr()->FindDeclaredConstant(
                       inst->GetSingleWordInOperand(i))) {
@@ -209,14 +206,16 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
           }
         }
         inst = context()->get_def_use_mgr()->GetDef(
-            inst->GetSingleWordInOperand(0));
+            inst->GetSingleWordInOperand(base_idx));
         keep_going = true;
         break;
+      }
       case spv::Op::OpCopyObject:
         inst = context()->get_def_use_mgr()->GetDef(
             inst->GetSingleWordInOperand(0));
         break;
       case spv::Op::OpVariable:
+      case spv::Op::OpUntypedVariableKHR:
         break;
       default:
         // A variable pointer cannot point to a matrix or inside it so we can
@@ -227,11 +226,11 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
 
   bool row_major = false;
   uint32_t mat_stride = 0;
-  const auto* type = context()
-                         ->get_type_mgr()
-                         ->GetType(inst->type_id())
-                         ->AsPointer()
-                         ->pointee_type();
+  auto type = context()
+                  ->get_type_mgr()
+                  ->GetType(inst->type_id())
+                  ->AsPointer()
+                  ->pointee_type();
   for (uint32_t i = 0; i < indices.size(); i++) {
     switch (type->kind()) {
       case analysis::Type::kStruct: {
@@ -276,16 +275,11 @@ Instruction* ConvertToUntyped::ConvertPointer(Instruction* inst) {
       inst->result_id(), false);
   // De-duplicate undecorated pointers.
   if (!decs.empty() || !base_ptrs_.count(sc)) {
-    uint32_t id = NextId();
-    auto unique = MakeUnique<Instruction>(
-        context(), spv::Op::OpTypeUntypedPointerKHR, 0, id,
-        std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
-    replacement = &*unique;
-    context()->AddType(std::move(unique));
-    if (!decs.empty()) {
-      context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
-    } else {
-      base_ptrs_[sc] = replacement;
+    // Replace in situ
+    inst->SetOpcode(spv::Op::OpTypeUntypedPointerKHR);
+    inst->SetInOperands(std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
+    if (decs.empty()) {
+      base_ptrs_[sc] = inst;
     }
   } else {
     replacement = base_ptrs_[sc];
@@ -293,29 +287,37 @@ Instruction* ConvertToUntyped::ConvertPointer(Instruction* inst) {
   return replacement;
 }
 
-Instruction* ConvertToUntyped::ConvertVariable(Instruction* inst) {
+void ConvertToUntyped::ConvertVariable(Instruction* inst) {
   auto ptr_ty =
       context()->get_type_mgr()->GetType(inst->type_id())->AsPointer();
   auto data =
       context()->get_type_mgr()->GetTypeInstruction(ptr_ty->pointee_type());
-  uint32_t id = NextId();
-  // No initializers are permitted on any supported storage class.
-  auto unique = MakeUnique<Instruction>(
-      context(), spv::Op::OpUntypedVariableKHR, remapped_ids_[inst->type_id()],
-      id,
-      std::initializer_list<Operand>{
-          {SPV_OPERAND_TYPE_STORAGE_CLASS,
-           {static_cast<uint32_t>(ptr_ty->storage_class())}},
-          {SPV_OPERAND_TYPE_ID, {data}}});
-  auto replacement = &*unique;
-  // All supported storage classes are module scope variables.
-  context()->AddGlobalValue(std::move(unique));
-  context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
-  return replacement;
+  // Replace in situ.
+  inst->SetOpcode(spv::Op::OpUntypedVariableKHR);
+  inst->SetInOperands(std::initializer_list<Operand>{
+    {SPV_OPERAND_TYPE_STORAGE_CLASS, {uint32_t(ptr_ty->storage_class())}},
+    {SPV_OPERAND_TYPE_ID, {data}}});
 }
 
-Instruction* ConvertToUntyped::ConvertAccessChain(Instruction* inst) {
-  const bool inbounds = inst->opcode() == spv::Op::OpInBoundsAccessChain;
+void ConvertToUntyped::ConvertAccessChain(Instruction* inst) {
+  spv::Op converted_op = inst->opcode();
+  switch (converted_op) {
+    case spv::Op::OpAccessChain:
+      converted_op = spv::Op::OpUntypedAccessChainKHR;
+      break;
+    case spv::Op::OpInBoundsAccessChain:
+      converted_op = spv::Op::OpUntypedInBoundsAccessChainKHR;
+      break;
+    case spv::Op::OpPtrAccessChain:
+      converted_op = spv::Op::OpUntypedPtrAccessChainKHR;
+      break;
+    case spv::Op::OpInBoundsPtrAccessChain:
+      converted_op = spv::Op::OpUntypedInBoundsAccessChainKHR;
+      break;
+    default:
+      assert(false && "unhandled opcode");
+      break;
+  }
   auto base =
       context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
   auto ptr_ty =
@@ -329,18 +331,11 @@ Instruction* ConvertToUntyped::ConvertAccessChain(Instruction* inst) {
   for (uint32_t i = 0; i < inst->NumInOperands(); i++) {
     operands.push_back(inst->GetInOperand(i));
   }
-  uint32_t id = NextId();
-  auto unique = MakeUnique<Instruction>(
-      context(),
-      (inbounds ? spv::Op::OpUntypedInBoundsAccessChainKHR
-                : spv::Op::OpUntypedAccessChainKHR),
-      remapped_ids_[inst->type_id()], id, operands);
-  auto replacement = inst->InsertBefore(std::move(unique));
-  context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
-  return replacement;
+  inst->SetOpcode(converted_op);
+  inst->SetInOperands(std::move(operands));
 }
 
-Instruction* ConvertToUntyped::ConvertArrayLength(Instruction* inst) {
+void ConvertToUntyped::ConvertArrayLength(Instruction* inst) {
   auto structure =
       context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
   auto ptr_ty =
@@ -354,12 +349,8 @@ Instruction* ConvertToUntyped::ConvertArrayLength(Instruction* inst) {
   for (uint32_t i = 0; i < inst->NumInOperands(); i++) {
     operands.push_back(inst->GetInOperand(i));
   }
-  uint32_t id = NextId();
-  auto unique =
-      MakeUnique<Instruction>(context(), spv::Op::OpUntypedArrayLengthKHR,
-                              inst->type_id(), id, operands);
-  auto replacement = inst->InsertBefore(std::move(unique));
-  return replacement;
+  inst->SetOpcode(spv::Op::OpUntypedArrayLengthKHR);
+  inst->SetInOperands(std::move(operands));
 }
 
 std::vector<Operand> ConvertToUntyped::StoreOperands(
@@ -656,36 +647,35 @@ void ConvertToUntyped::Convert(Instruction* inst) {
   switch (inst->opcode()) {
     case spv::Op::OpTypePointer:
       replacement = ConvertPointer(inst);
-      to_delete_.push_back(inst);
+      if (replacement != nullptr) {
+        to_delete_.push_back(inst);
+        remapped_ids_[inst->result_id()] = replacement->result_id();
+      }
       break;
     case spv::Op::OpVariable:
-      replacement = ConvertVariable(inst);
-      to_delete_.push_back(inst);
+      ConvertVariable(inst);
       break;
     case spv::Op::OpAccessChain:
     case spv::Op::OpInBoundsAccessChain:
-      replacement = ConvertAccessChain(inst);
-      to_delete_.push_back(inst);
+    case spv::Op::OpPtrAccessChain:
+    case spv::Op::OpInBoundsPtrAccessChain:
+      ConvertAccessChain(inst);
       break;
     case spv::Op::OpArrayLength:
-      replacement = ConvertArrayLength(inst);
-      to_delete_.push_back(inst);
+      ConvertArrayLength(inst);
       break;
     case spv::Op::OpCopyMemory:
       ConvertCopyMemory(inst);
       to_delete_.push_back(inst);
-      return;
+      break;
     case spv::Op::OpCooperativeMatrixLoadKHR:
     case spv::Op::OpCooperativeMatrixStoreKHR:
-      // Note: no deletion here.
       UpdateCooperativeMatrixLoadStore(inst);
-      return;
+      break;
     default:
       assert(false && "unhandled opcode");
       break;
   }
-
-  remapped_ids_[inst->result_id()] = replacement->result_id();
 }
 
 void ConvertToUntyped::ConvertPointers() {

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -156,12 +156,9 @@ void ConvertToUntyped::AddUntypedEnable() {
         continue;
       }
       const analysis::Pointer ptr_type{nullptr, sc};
-      auto registered = context()->get_type_mgr()->GetRegisteredType(&ptr_type);
-      if (registered) {
-        auto id = context()->get_type_mgr()->GetId(registered);
-        if (id != 0) {
-          base_ptrs_[uint32_t(sc)] = context()->get_def_use_mgr()->GetDef(id);
-        }
+      auto id = context()->get_type_mgr()->GetId(&ptr_type);
+      if (id != 0) {
+        base_ptrs_[uint32_t(sc)] = context()->get_def_use_mgr()->GetDef(id);
       }
     }
   }
@@ -178,6 +175,7 @@ bool ConvertToUntyped::SupportedStorageClass(spv::StorageClass sc) {
     case spv::StorageClass::StorageBuffer:
     case spv::StorageClass::Uniform:
     case spv::StorageClass::PushConstant:
+    case spv::StorageClass::PhysicalStorageBuffer:
       return true;
     case spv::StorageClass::Workgroup:
       return support_workgroup_;
@@ -274,9 +272,7 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
       case spv::Op::OpUntypedVariableKHR:
         break;
       default:
-        // A variable pointer cannot point to a matrix or inside it so we can
-        // stop searching at this point.
-        return std::make_pair(false, 0);
+        break;
     }
   }
 

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -1,0 +1,724 @@
+// Copyright (c) 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "convert_to_untyped.h"
+
+#include <deque>
+#include <iostream>
+#include <limits>
+#include <unordered_set>
+
+#include "source/operand.h"
+
+namespace spvtools {
+namespace opt {
+
+Pass::Status ConvertToUntyped::Process() {
+  if (HasUnsupportedFeatures()) {
+    return Pass::Status::SuccessWithoutChange;
+  }
+
+  AddUntypedEnable();
+  ConvertPointers();
+
+  uint32_t max_id = std::max(context()->max_id_bound(), max_id_);
+  context()->set_max_id_bound(max_id);
+  get_module()->SetIdBound(max_id);
+
+  return Pass::Status::SuccessWithChange;
+}
+
+bool ConvertToUntyped::HasUnsupportedFeatures() {
+  // Only support converting shaders.
+  const auto& caps = context()->get_feature_mgr()->GetCapabilities();
+  if (!caps.contains(spv::Capability::Shader)) {
+    return true;
+  }
+
+  // TODO: support the following capabilities
+  if (caps.contains(spv::Capability::VariablePointersStorageBuffer)) {
+    return true;
+  }
+  if (caps.contains(spv::Capability::WorkgroupMemoryExplicitLayoutKHR)) {
+    return true;
+  }
+
+  // Unsupported
+  CapabilitySet unsupported{
+      spv::Capability::RawAccessChainsNV,
+      spv::Capability::PredicatedIOINTEL,
+      spv::Capability::GraphARM,
+      spv::Capability::CooperativeMatrixReductionsNV,
+      spv::Capability::CooperativeMatrixConversionsNV,
+      spv::Capability::CooperativeMatrixPerElementOperationsNV,
+      spv::Capability::CooperativeMatrixTensorAddressingNV,
+      spv::Capability::CooperativeMatrixBlockLoadsNV,
+      spv::Capability::CooperativeVectorNV,
+      spv::Capability::CooperativeVectorTrainingNV};
+  return caps.HasAnyOf(unsupported);
+}
+
+void ConvertToUntyped::AddUntypedEnable() {
+  bool needs_ext = true;
+  for (auto& ei : get_module()->extensions()) {
+    const std::string name = ei.GetInOperand(0).AsString();
+    if (name == "SPV_KHR_untyped_pointers") {
+      needs_ext = false;
+      break;
+    }
+  }
+  if (needs_ext) {
+    std::vector<uint32_t> words =
+        spvtools::utils::MakeVector("SPV_KHR_untyped_pointers");
+    context()->AddExtension(
+        MakeUnique<Instruction>(context(), spv::Op::OpExtension, 0, 0,
+                                std::initializer_list<Operand>{
+                                    {SPV_OPERAND_TYPE_LITERAL_STRING, words}}));
+  }
+
+  if (!context()->get_feature_mgr()->HasCapability(
+          spv::Capability::UntypedPointersKHR)) {
+    context()->AddCapability(MakeUnique<Instruction>(
+        context(), spv::Op::OpCapability, 0, 0,
+        std::initializer_list<Operand>{
+            {SPV_OPERAND_TYPE_CAPABILITY,
+             {uint32_t(spv::Capability::UntypedPointersKHR)}}}));
+  } else {
+    // Untyped pointers capability is already declared, pre-populate base_ptrs_.
+    // All possibly supported storage classes are listed for extensibility
+    // purposes.
+    std::vector<spv::StorageClass> storage_classes{
+        spv::StorageClass::StorageBuffer,
+        spv::StorageClass::Uniform,
+        spv::StorageClass::Workgroup,
+        spv::StorageClass::PushConstant,
+        spv::StorageClass::PhysicalStorageBuffer,
+        spv::StorageClass::UniformConstant};
+    for (auto sc : storage_classes) {
+      if (!SupportedStorageClass(sc)) {
+        continue;
+      }
+      const analysis::Pointer ptr_type{nullptr, sc};
+      auto registered = context()->get_type_mgr()->GetRegisteredType(&ptr_type);
+      if (registered) {
+        auto id = context()->get_type_mgr()->GetId(registered);
+        if (id != 0) {
+          base_ptrs_[uint32_t(sc)] = context()->get_def_use_mgr()->GetDef(id);
+        }
+      }
+    }
+  }
+}
+
+uint32_t ConvertToUntyped::NextId() {
+  uint32_t id = context()->TakeNextUniqueId();
+  max_id_ = std::max(id, max_id_);
+  return id;
+}
+
+bool ConvertToUntyped::SupportedStorageClass(spv::StorageClass sc) {
+  switch (sc) {
+    case spv::StorageClass::StorageBuffer:
+    case spv::StorageClass::Uniform:
+    case spv::StorageClass::PushConstant:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool ConvertToUntyped::SupportedStorageClass(uint32_t sc) {
+  return SupportedStorageClass(static_cast<spv::StorageClass>(sc));
+}
+
+bool ConvertToUntyped::ShouldConvert(const Instruction* inst) {
+  switch (inst->opcode()) {
+    case spv::Op::OpTypePointer:
+      return SupportedStorageClass(inst->GetSingleWordInOperand(0));
+    case spv::Op::OpAccessChain:
+    case spv::Op::OpInBoundsAccessChain:
+    case spv::Op::OpVariable:
+      return SupportedStorageClass(context()
+                                       ->get_type_mgr()
+                                       ->GetType(inst->type_id())
+                                       ->AsPointer()
+                                       ->storage_class());
+    case spv::Op::OpCopyMemory: {
+      const auto* dst =
+          context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+      const auto* dst_ptr =
+          context()->get_type_mgr()->GetType(dst->type_id())->AsPointer();
+      const auto* src =
+          context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(1));
+      const auto* src_ptr =
+          context()->get_type_mgr()->GetType(src->type_id())->AsPointer();
+      return SupportedStorageClass(dst_ptr->storage_class()) ||
+             SupportedStorageClass(src_ptr->storage_class());
+    }
+    case spv::Op::OpArrayLength: {
+      const auto* obj =
+          context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+      const auto* ptr =
+          context()->get_type_mgr()->GetType(obj->type_id())->AsPointer();
+      return SupportedStorageClass(ptr->storage_class());
+    }
+    case spv::Op::OpCooperativeMatrixLoadKHR:
+    case spv::Op::OpCooperativeMatrixStoreKHR: {
+      const auto* ptr =
+          context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+      const auto* ptr_ty =
+          context()->get_type_mgr()->GetType(ptr->type_id())->AsPointer();
+      return SupportedStorageClass(ptr_ty->storage_class());
+    }
+    default:
+      return false;
+  }
+}
+
+std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
+  std::deque<uint32_t> indices;
+  bool keep_going = true;
+  while (keep_going) {
+    keep_going = false;
+    switch (inst->opcode()) {
+      case spv::Op::OpAccessChain:
+      case spv::Op::OpInBoundsAccessChain:
+        for (uint32_t i = inst->NumInOperands() - 1; i > 0; i--) {
+          if (auto* constant =
+                  context()->get_constant_mgr()->FindDeclaredConstant(
+                      inst->GetSingleWordInOperand(i))) {
+            uint64_t ext = constant->GetZeroExtendedValue();
+            if (ext > std::numeric_limits<uint32_t>::max()) {
+              return std::make_pair(false, 0);
+            }
+            indices.push_front(static_cast<uint32_t>(ext));
+          } else {
+            // Assume we aren't at the start to accumulate a stride.
+            indices.push_front(1);
+          }
+        }
+        inst = context()->get_def_use_mgr()->GetDef(
+            inst->GetSingleWordInOperand(0));
+        keep_going = true;
+        break;
+      case spv::Op::OpCopyObject:
+        inst = context()->get_def_use_mgr()->GetDef(
+            inst->GetSingleWordInOperand(0));
+        break;
+      case spv::Op::OpVariable:
+        break;
+      default:
+        // A variable pointer cannot point to a matrix or inside it so we can
+        // stop searching at this point.
+        return std::make_pair(false, 0);
+    }
+  }
+
+  bool row_major = false;
+  uint32_t mat_stride = 0;
+  const auto* type = context()
+                         ->get_type_mgr()
+                         ->GetType(inst->type_id())
+                         ->AsPointer()
+                         ->pointee_type();
+  for (uint32_t i = 0; i < indices.size(); i++) {
+    switch (type->kind()) {
+      case analysis::Type::kStruct: {
+        auto where = type->AsStruct()->element_decorations().find(indices[i]);
+        if (where != type->AsStruct()->element_decorations().end()) {
+          const auto& decs = where->second;
+          for (auto dec : decs) {
+            if (dec[0] == uint32_t(spv::Decoration::MatrixStride)) {
+              mat_stride = dec[1];
+            }
+            if (dec[0] == uint32_t(spv::Decoration::RowMajor)) {
+              row_major = true;
+            }
+          }
+        }
+        type = type->AsStruct()->element_types()[indices[i]];
+        break;
+      }
+      case analysis::Type::kArray:
+        type = type->AsArray()->element_type();
+        break;
+      case analysis::Type::kRuntimeArray:
+        type = type->AsRuntimeArray();
+      case analysis::Type::kMatrix:
+        return std::make_pair(row_major, mat_stride);
+      // No other types could hold a matrix
+      default:
+        return std::make_pair(false, 0);
+    }
+  }
+
+  if (type->AsMatrix()) {
+    return std::make_pair(row_major, mat_stride);
+  }
+  return std::make_pair(false, 0);
+}
+
+Instruction* ConvertToUntyped::ConvertPointer(Instruction* inst) {
+  Instruction* replacement = nullptr;
+  auto sc = inst->GetSingleWordInOperand(0);
+  auto decs = context()->get_decoration_mgr()->GetDecorationsFor(
+      inst->result_id(), false);
+  // De-duplicate undecorated pointers.
+  if (!decs.empty() || !base_ptrs_.count(sc)) {
+    uint32_t id = NextId();
+    auto unique = MakeUnique<Instruction>(
+        context(), spv::Op::OpTypeUntypedPointerKHR, 0, id,
+        std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
+    replacement = &*unique;
+    context()->AddType(std::move(unique));
+    if (!decs.empty()) {
+      context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
+    } else {
+      base_ptrs_[sc] = replacement;
+    }
+  } else {
+    replacement = base_ptrs_[sc];
+  }
+  return replacement;
+}
+
+Instruction* ConvertToUntyped::ConvertVariable(Instruction* inst) {
+  auto ptr_ty =
+      context()->get_type_mgr()->GetType(inst->type_id())->AsPointer();
+  auto data =
+      context()->get_type_mgr()->GetTypeInstruction(ptr_ty->pointee_type());
+  uint32_t id = NextId();
+  // No initializers are permitted on any supported storage class.
+  auto unique = MakeUnique<Instruction>(
+      context(), spv::Op::OpUntypedVariableKHR, remapped_ids_[inst->type_id()],
+      id,
+      std::initializer_list<Operand>{
+          {SPV_OPERAND_TYPE_STORAGE_CLASS,
+           {static_cast<uint32_t>(ptr_ty->storage_class())}},
+          {SPV_OPERAND_TYPE_ID, {data}}});
+  auto replacement = &*unique;
+  // All supported storage classes are module scope variables.
+  context()->AddGlobalValue(std::move(unique));
+  context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
+  return replacement;
+}
+
+Instruction* ConvertToUntyped::ConvertAccessChain(Instruction* inst) {
+  const bool inbounds = inst->opcode() == spv::Op::OpInBoundsAccessChain;
+  auto base =
+      context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+  auto ptr_ty =
+      context()->get_type_mgr()->GetType(base->type_id())->AsPointer();
+  auto data =
+      context()->get_type_mgr()->GetTypeInstruction(ptr_ty->pointee_type());
+  // Add the base type, but then reuse all the other operands.
+  std::vector<Operand> operands;
+  operands.reserve(inst->NumInOperands() + 1);
+  operands.push_back({SPV_OPERAND_TYPE_ID, {data}});
+  for (uint32_t i = 0; i < inst->NumInOperands(); i++) {
+    operands.push_back(inst->GetInOperand(i));
+  }
+  uint32_t id = NextId();
+  auto unique = MakeUnique<Instruction>(
+      context(),
+      (inbounds ? spv::Op::OpUntypedInBoundsAccessChainKHR
+                : spv::Op::OpUntypedAccessChainKHR),
+      remapped_ids_[inst->type_id()], id, operands);
+  auto replacement = inst->InsertBefore(std::move(unique));
+  context()->get_decoration_mgr()->CloneDecorations(inst->result_id(), id);
+  return replacement;
+}
+
+Instruction* ConvertToUntyped::ConvertArrayLength(Instruction* inst) {
+  auto structure =
+      context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+  auto ptr_ty =
+      context()->get_type_mgr()->GetType(structure->type_id())->AsPointer();
+  auto data =
+      context()->get_type_mgr()->GetTypeInstruction(ptr_ty->pointee_type());
+  // Add the structure type, but then reuse all the other operands.
+  std::vector<Operand> operands;
+  operands.reserve(inst->NumInOperands() + 1);
+  operands.push_back({SPV_OPERAND_TYPE_ID, {data}});
+  for (uint32_t i = 0; i < inst->NumInOperands(); i++) {
+    operands.push_back(inst->GetInOperand(i));
+  }
+  uint32_t id = NextId();
+  auto unique =
+      MakeUnique<Instruction>(context(), spv::Op::OpUntypedArrayLengthKHR,
+                              inst->type_id(), id, operands);
+  auto replacement = inst->InsertBefore(std::move(unique));
+  return replacement;
+}
+
+std::vector<Operand> ConvertToUntyped::StoreOperands(
+    const std::vector<Operand>& operands, uint32_t align) {
+  // Add placeholders for the pointer and object.
+  std::vector<Operand> st_operands{{SPV_OPERAND_TYPE_ID, {0}},
+                                   {SPV_OPERAND_TYPE_ID, {0}}};
+  if (operands.empty() && align != 0) {
+    // Add alignment
+    st_operands.push_back({SPV_OPERAND_TYPE_MEMORY_ACCESS,
+                           {uint32_t(spv::MemoryAccessMask::Aligned)}});
+    st_operands.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {align}});
+  } else if (!operands.empty()) {
+    // Add/Remove alignment
+    // Copy MakePointerAvailable scope
+    // Drop MakePointerVisible (and ignore scope)
+    uint32_t idx = 0;
+    st_operands.push_back(operands[idx++]);
+    if ((operands[0].words[0] & uint32_t(spv::MemoryAccessMask::Aligned)) !=
+        0) {
+      idx++;
+      if (align == 0) {
+        st_operands[2].words[0] ^= uint32_t(spv::MemoryAccessMask::Aligned);
+      }
+    }
+    if (align != 0) {
+      st_operands[2].words[0] |= uint32_t(spv::MemoryAccessMask::Aligned);
+      st_operands.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {align}});
+    }
+
+    if ((operands[0].words[0] &
+         uint32_t(spv::MemoryAccessMask::MakePointerAvailable)) != 0) {
+      st_operands.push_back(operands[idx]);
+    }
+
+    st_operands[2].words[0] &=
+        ~uint32_t(spv::MemoryAccessMask::MakePointerVisible);
+  }
+
+  return st_operands;
+}
+
+std::vector<Operand> ConvertToUntyped::LoadOperands(
+    const std::vector<Operand>& operands, uint32_t align) {
+  // Add placeholder operand for pointer
+  std::vector<Operand> ld_operands{{SPV_OPERAND_TYPE_ID, {0}}};
+  if (operands.empty() && align != 0) {
+    // Add alignment
+    ld_operands.push_back({SPV_OPERAND_TYPE_MEMORY_ACCESS,
+                           {uint32_t(spv::MemoryAccessMask::Aligned)}});
+    ld_operands.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {align}});
+  } else if (!operands.empty()) {
+    // Add/Remove alignment
+    // Drop MakePointerAvailable (and ignore scope)
+    // Copy MakePointerVisible and scope
+    uint32_t idx = 0;
+    ld_operands.push_back(operands[idx++]);
+    if ((operands[0].words[0] & uint32_t(spv::MemoryAccessMask::Aligned)) !=
+        0) {
+      idx++;
+      if (align == 0) {
+        ld_operands[1].words[0] ^= uint32_t(spv::MemoryAccessMask::Aligned);
+      }
+    }
+    if (align != 0) {
+      ld_operands[1].words[0] |= uint32_t(spv::MemoryAccessMask::Aligned);
+      ld_operands.push_back({SPV_OPERAND_TYPE_LITERAL_INTEGER, {align}});
+    }
+
+    if ((operands[0].words[0] &
+         uint32_t(spv::MemoryAccessMask::MakePointerAvailable)) != 0) {
+      idx++;
+      ld_operands[1].words[0] ^=
+          uint32_t(spv::MemoryAccessMask::MakePointerAvailable);
+    }
+
+    if ((operands[0].words[0] &
+         uint32_t(spv::MemoryAccessMask::MakePointerVisible)) != 0) {
+      ld_operands.push_back(operands[idx]);
+    }
+  }
+
+  return ld_operands;
+}
+
+void ConvertToUntyped::ConvertCopyMemory(Instruction* inst) {
+  auto dst =
+      context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+  auto dst_type =
+      context()->get_type_mgr()->GetType(dst->type_id())->AsPointer();
+  auto dst_sc = dst_type->storage_class();
+  auto dst_untyped = SupportedStorageClass(dst_sc);
+  auto src =
+      context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(1));
+  auto src_type =
+      context()->get_type_mgr()->GetType(src->type_id())->AsPointer();
+  auto src_sc = src_type->storage_class();
+  auto src_untyped = SupportedStorageClass(src_sc);
+
+  // Get the memory access operands for src and dst.
+  std::vector<Operand> dst_operands;
+  std::vector<Operand> src_operands;
+  if (inst->NumInOperands() > 2) {
+    uint32_t i = 2;
+    for (; i < inst->NumInOperands(); i++) {
+      auto& op = inst->GetInOperand(i);
+      if (i > 2 && op.type == SPV_OPERAND_TYPE_MEMORY_ACCESS) {
+        break;
+      }
+      dst_operands.push_back(op);
+    }
+    if (inst->NumInOperands() > i) {
+      // The are separate src and dst memory access operands.
+      for (; i < inst->NumInOperands(); i++) {
+        src_operands.push_back(inst->GetInOperand(i));
+      }
+    } else {
+      // Shared memory access operands.
+      src_operands = dst_operands;
+    }
+  }
+
+  auto [dst_row_major, dst_mat_stride] = MatrixStride(dst);
+  auto [src_row_major, src_mat_stride] = MatrixStride(src);
+
+  // src and dst pointee types must match.
+  auto pointee_type = dst_type->pointee_type();
+
+  // Matrices (and their columns) are a special case.
+  // The layout information is not on the matrix itself so we could be copying
+  // matrices with completely different layouts. Just break them down into
+  // component loads and stores.
+  if ((dst_mat_stride != 0 || src_mat_stride != 0) &&
+      !pointee_type->AsFloat()) {
+    uint32_t num_cols = 1;
+    uint32_t num_rows = 1;
+    const analysis::Type* ele_type = nullptr;
+    if (auto mat_type = pointee_type->AsMatrix()) {
+      num_cols = mat_type->element_count();
+      auto vec_type = mat_type->element_type()->AsVector();
+      num_rows = vec_type->element_count();
+      ele_type = vec_type->element_type();
+    } else if (auto vec_type = pointee_type->AsVector()) {
+      num_rows = vec_type->element_count();
+      ele_type = vec_type->element_type();
+    }
+
+    uint32_t align = ele_type->AsFloat()->width() / 8;
+
+    // Setup operands for the loads and stores.
+    auto ld_operands = LoadOperands(src_operands, align);
+    auto st_operands = StoreOperands(dst_operands, align);
+
+    // Setup the access operands.
+    spv::Op src_access_op =
+        src_untyped ? spv::Op::OpUntypedAccessChainKHR : spv::Op::OpAccessChain;
+    spv::Op dst_access_op =
+        dst_untyped ? spv::Op::OpUntypedAccessChainKHR : spv::Op::OpAccessChain;
+    uint32_t base_type_id = context()->get_type_mgr()->GetId(pointee_type);
+    uint32_t ele_type_id = context()->get_type_mgr()->GetId(ele_type);
+
+    std::vector<Operand> src_access_operands;
+    if (src_untyped) {
+      src_access_operands.push_back({SPV_OPERAND_TYPE_ID, {base_type_id}});
+    }
+    src_access_operands.push_back({SPV_OPERAND_TYPE_ID, {src->result_id()}});
+    src_access_operands.push_back({SPV_OPERAND_TYPE_ID, {0}});
+
+    std::vector<Operand> dst_access_operands;
+    if (dst_untyped) {
+      dst_access_operands.push_back({SPV_OPERAND_TYPE_ID, {base_type_id}});
+    }
+    dst_access_operands.push_back({SPV_OPERAND_TYPE_ID, {dst->result_id()}});
+    dst_access_operands.push_back({SPV_OPERAND_TYPE_ID, {0}});
+
+    if (num_cols > 1) {
+      src_access_operands.push_back({SPV_OPERAND_TYPE_ID, {0}});
+      dst_access_operands.push_back({SPV_OPERAND_TYPE_ID, {0}});
+    }
+
+    // Finally, unroll the copy as individual loads and stores.
+    const uint32_t src_access_idx = src_untyped ? 2 : 1;
+    const uint32_t dst_access_idx = dst_untyped ? 2 : 1;
+    for (uint32_t c = 0; c < num_cols; c++) {
+      for (uint32_t r = 0; r < num_rows; r++) {
+        // Update the access operands
+        if (num_cols == 1) {
+          uint32_t row_id = context()->get_constant_mgr()->GetUIntConstId(r);
+          src_access_operands[src_access_idx].words[0] = row_id;
+          dst_access_operands[dst_access_idx].words[0] = row_id;
+        } else {
+          uint32_t col_id = context()->get_constant_mgr()->GetUIntConstId(c);
+          uint32_t row_id = context()->get_constant_mgr()->GetUIntConstId(r);
+          src_access_operands[src_access_idx].words[0] = col_id;
+          src_access_operands[src_access_idx + 1].words[0] = row_id;
+          dst_access_operands[dst_access_idx].words[0] = col_id;
+          dst_access_operands[dst_access_idx + 1].words[0] = row_id;
+        }
+
+        uint32_t src_access_id = NextId();
+        inst->InsertBefore(MakeUnique<Instruction>(
+            context(), src_access_op, base_ptrs_[uint32_t(src_sc)]->result_id(),
+            src_access_id, src_access_operands));
+
+        uint32_t src_ld = NextId();
+        // Update load operand ids
+        ld_operands[0].words[0] = src_access_id;
+        inst->InsertBefore(MakeUnique<Instruction>(
+            context(), spv::Op::OpLoad, ele_type_id, src_ld, ld_operands));
+
+        uint32_t dst_access_id = NextId();
+        inst->InsertBefore(MakeUnique<Instruction>(
+            context(), dst_access_op, base_ptrs_[uint32_t(dst_sc)]->result_id(),
+            dst_access_id, dst_access_operands));
+
+        // Update store operand ids
+        st_operands[0].words[0] = dst_access_id;
+        st_operands[1].words[0] = src_ld;
+        inst->InsertBefore(MakeUnique<Instruction>(context(), spv::Op::OpStore,
+                                                   0, 0, st_operands));
+      }
+    }
+
+    return;
+  }
+
+  // For other cases just load from src and store to dst.
+  // Don't bother with OpCopyMemorySized, too many shenanigans are necessary for
+  // that.
+  //
+  // We don't need to set an align.
+  auto ld_operands = LoadOperands(src_operands, 0);
+  auto st_operands = StoreOperands(dst_operands, 0);
+
+  ld_operands[0].words[0] = src->result_id();
+  auto ld = inst->InsertBefore(MakeUnique<Instruction>(
+      context(), spv::Op::OpLoad,
+      context()->get_type_mgr()->GetId(pointee_type), NextId(), ld_operands));
+
+  st_operands[0].words[0] = dst->result_id();
+  st_operands[1].words[0] = ld->result_id();
+  inst->InsertBefore(
+      MakeUnique<Instruction>(context(), spv::Op::OpStore, 0, 0, st_operands));
+}
+
+void ConvertToUntyped::UpdateCooperativeMatrixLoadStore(Instruction* inst) {
+  uint32_t stride_idx =
+      inst->opcode() == spv::Op::OpCooperativeMatrixLoadKHR ? 2 : 3;
+  // With typed pointers the stride is counted in elements, but with untyped
+  // pointers the stride is interpreted in bytes. So if there is no stride
+  // specified, nothing needs done.
+  if (inst->NumInOperands() <= stride_idx) {
+    return;
+  }
+
+  auto ptr =
+      context()->get_def_use_mgr()->GetDef(inst->GetSingleWordInOperand(0));
+  auto ptr_ty = context()->get_type_mgr()->GetType(ptr->type_id())->AsPointer();
+
+  // The pointer must point to a scalar or vector of numeric type so there is a
+  // very limited number of permutations to consider.
+  //
+  // Also the memory is in contiguous locations, so just use the size (e.g.
+  // don't worry about 3-element vectors).
+  auto type = ptr_ty->pointee_type();
+  uint32_t size = 1;
+  if (auto vec_ty = type->AsVector()) {
+    size *= vec_ty->element_count();
+    type = vec_ty->element_type();
+  } else if (auto long_vec_ty = type->AsCooperativeVectorNV()) {
+    size *= long_vec_ty->components();
+    type = long_vec_ty->component_type();
+  }
+
+  if (auto int_type = type->AsInteger()) {
+    size *= int_type->width() / 8;
+  } else if (auto float_type = type->AsFloat()) {
+    size *= float_type->width() / 8;
+  }
+
+  auto mul = inst->InsertBefore(MakeUnique<Instruction>(
+      context(), spv::Op::OpIMul, context()->get_type_mgr()->GetUIntTypeId(),
+      NextId(),
+      std::initializer_list<Operand>{
+          {SPV_OPERAND_TYPE_ID, {inst->GetSingleWordInOperand(stride_idx)}},
+          {SPV_OPERAND_TYPE_ID,
+           {context()->get_constant_mgr()->GetUIntConstId(size)}}}));
+
+  inst->SetInOperand(stride_idx, {mul->result_id()});
+}
+
+void ConvertToUntyped::Convert(Instruction* inst) {
+  Instruction* replacement = nullptr;
+  switch (inst->opcode()) {
+    case spv::Op::OpTypePointer:
+      replacement = ConvertPointer(inst);
+      to_delete_.push_back(inst);
+      break;
+    case spv::Op::OpVariable:
+      replacement = ConvertVariable(inst);
+      to_delete_.push_back(inst);
+      break;
+    case spv::Op::OpAccessChain:
+    case spv::Op::OpInBoundsAccessChain:
+      replacement = ConvertAccessChain(inst);
+      to_delete_.push_back(inst);
+      break;
+    case spv::Op::OpArrayLength:
+      replacement = ConvertArrayLength(inst);
+      to_delete_.push_back(inst);
+      break;
+    case spv::Op::OpCopyMemory:
+      ConvertCopyMemory(inst);
+      to_delete_.push_back(inst);
+      return;
+    case spv::Op::OpCooperativeMatrixLoadKHR:
+    case spv::Op::OpCooperativeMatrixStoreKHR:
+      // Note: no deletion here.
+      UpdateCooperativeMatrixLoadStore(inst);
+      return;
+    default:
+      assert(false && "unhandled opcode");
+      break;
+  }
+
+  remapped_ids_[inst->result_id()] = replacement->result_id();
+}
+
+void ConvertToUntyped::ConvertPointers() {
+  // Convert instructions that change opcode with untyped pointers.
+  std::vector<Instruction*> to_convert;
+  get_module()->ForEachInst([this, &to_convert](Instruction* inst) {
+    if (ShouldConvert(inst)) {
+      to_convert.push_back(inst);
+    }
+  });
+
+  for (auto* inst : to_convert) {
+    Convert(inst);
+  }
+
+  // Update operands of instructions
+  get_module()->ForEachInst([this](Instruction* inst) {
+    for (uint32_t i = 0; i < inst->NumOperands(); i++) {
+      auto& op = inst->GetOperand(i);
+      if (spvIsIdType(op.type) && op.type != SPV_OPERAND_TYPE_RESULT_ID) {
+        auto where = remapped_ids_.find(op.words[0]);
+        if (where != remapped_ids_.end()) {
+          op.words[0] = where->second;
+        }
+      }
+    }
+  });
+
+  // Delete dead instructions
+  for (auto* inst : to_delete_) {
+    context()->KillInst(inst);
+  }
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -15,7 +15,6 @@
 #include "convert_to_untyped.h"
 
 #include <deque>
-#include <iostream>
 #include <limits>
 #include <unordered_set>
 
@@ -330,7 +329,8 @@ Instruction* ConvertToUntyped::ConvertPointer(Instruction* inst) {
   if (!decs.empty() || !base_ptrs_.count(sc)) {
     // Replace in situ
     inst->SetOpcode(spv::Op::OpTypeUntypedPointerKHR);
-    inst->SetInOperands(std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
+    inst->SetInOperands(
+        std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
     if (decs.empty()) {
       base_ptrs_[sc] = inst;
     }
@@ -348,8 +348,8 @@ void ConvertToUntyped::ConvertVariable(Instruction* inst) {
   // Replace in situ.
   inst->SetOpcode(spv::Op::OpUntypedVariableKHR);
   inst->SetInOperands(std::initializer_list<Operand>{
-    {SPV_OPERAND_TYPE_STORAGE_CLASS, {uint32_t(ptr_ty->storage_class())}},
-    {SPV_OPERAND_TYPE_ID, {data}}});
+      {SPV_OPERAND_TYPE_STORAGE_CLASS, {uint32_t(ptr_ty->storage_class())}},
+      {SPV_OPERAND_TYPE_ID, {data}}});
 }
 
 void ConvertToUntyped::ConvertAccessChain(Instruction* inst) {

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -30,14 +30,18 @@ Pass::Status ConvertToUntyped::Process() {
 
   CheckWorkgroup();
 
-  AddUntypedEnable();
-  ConvertPointers();
+  bool changed = ConvertPointers();
+  if (changed) {
+    AddUntypedPointerCapability();
+  }
 
-  uint32_t max_id = std::max(context()->max_id_bound(), max_id_);
-  context()->set_max_id_bound(max_id);
-  get_module()->SetIdBound(max_id);
-
-  return Pass::Status::SuccessWithChange;
+  if (context()->id_overflow()) {
+    return Pass::Status::Failure;
+  }
+  if (changed) {
+    return Pass::Status::SuccessWithChange;
+  }
+  return Pass::Status::SuccessWithoutChange;
 }
 
 bool ConvertToUntyped::HasUnsupportedFeatures() {
@@ -114,7 +118,7 @@ void ConvertToUntyped::CheckWorkgroup() {
   support_workgroup_ = true;
 }
 
-void ConvertToUntyped::AddUntypedEnable() {
+void ConvertToUntyped::AddUntypedPointerCapability() {
   bool needs_ext = true;
   for (auto& ei : get_module()->extensions()) {
     const std::string name = ei.GetInOperand(0).AsString();
@@ -139,33 +143,11 @@ void ConvertToUntyped::AddUntypedEnable() {
         std::initializer_list<Operand>{
             {SPV_OPERAND_TYPE_CAPABILITY,
              {uint32_t(spv::Capability::UntypedPointersKHR)}}}));
-  } else {
-    // Untyped pointers capability is already declared, pre-populate base_ptrs_.
-    // All possibly supported storage classes are listed for extensibility
-    // purposes.
-    std::vector<spv::StorageClass> storage_classes{
-        spv::StorageClass::StorageBuffer,
-        spv::StorageClass::Uniform,
-        spv::StorageClass::Workgroup,
-        spv::StorageClass::PushConstant,
-        spv::StorageClass::PhysicalStorageBuffer,
-        spv::StorageClass::UniformConstant};
-    for (auto sc : storage_classes) {
-      if (!SupportedStorageClass(sc)) {
-        continue;
-      }
-      const analysis::Pointer ptr_type{nullptr, sc};
-      auto id = context()->get_type_mgr()->GetId(&ptr_type);
-      if (id != 0) {
-        base_ptrs_[uint32_t(sc)] = context()->get_def_use_mgr()->GetDef(id);
-      }
-    }
   }
 }
 
 uint32_t ConvertToUntyped::NextId() {
-  uint32_t id = context()->TakeNextUniqueId();
-  max_id_ = std::max(id, max_id_);
+  uint32_t id = context()->TakeNextId();
   return id;
 }
 
@@ -320,14 +302,14 @@ std::pair<bool, uint32_t> ConvertToUntyped::MatrixStride(Instruction* inst) {
   return std::make_pair(false, 0);
 }
 
-Instruction* ConvertToUntyped::ConvertPointer(Instruction* inst) {
+Instruction* ConvertToUntyped::ConvertPointerType(Instruction* inst) {
   Instruction* replacement = nullptr;
   auto sc = inst->GetSingleWordInOperand(0);
   auto decs = context()->get_decoration_mgr()->GetDecorationsFor(
       inst->result_id(), false);
   // De-duplicate undecorated pointers.
   if (!decs.empty() || !base_ptrs_.count(sc)) {
-    // Replace in situ
+    // Rewrite inst in place. This maintains dominance ordering.
     inst->SetOpcode(spv::Op::OpTypeUntypedPointerKHR);
     inst->SetInOperands(
         std::initializer_list<Operand>{{SPV_OPERAND_TYPE_STORAGE_CLASS, {sc}}});
@@ -345,7 +327,7 @@ void ConvertToUntyped::ConvertVariable(Instruction* inst) {
       context()->get_type_mgr()->GetType(inst->type_id())->AsPointer();
   auto data =
       context()->get_type_mgr()->GetTypeInstruction(ptr_ty->pointee_type());
-  // Replace in situ.
+  // Rewrite inst in place. This maintains dominance ordering.
   inst->SetOpcode(spv::Op::OpUntypedVariableKHR);
   inst->SetInOperands(std::initializer_list<Operand>{
       {SPV_OPERAND_TYPE_STORAGE_CLASS, {uint32_t(ptr_ty->storage_class())}},
@@ -699,7 +681,7 @@ void ConvertToUntyped::Convert(Instruction* inst) {
   Instruction* replacement = nullptr;
   switch (inst->opcode()) {
     case spv::Op::OpTypePointer:
-      replacement = ConvertPointer(inst);
+      replacement = ConvertPointerType(inst);
       if (replacement != nullptr) {
         to_delete_.push_back(inst);
         remapped_ids_[inst->result_id()] = replacement->result_id();
@@ -731,7 +713,31 @@ void ConvertToUntyped::Convert(Instruction* inst) {
   }
 }
 
-void ConvertToUntyped::ConvertPointers() {
+bool ConvertToUntyped::ConvertPointers() {
+  if (context()->get_feature_mgr()->HasCapability(
+          spv::Capability::UntypedPointersKHR)) {
+    // Untyped pointers capability is already declared, pre-populate base_ptrs_.
+    // All possibly supported storage classes are listed for extensibility
+    // purposes.
+    std::vector<spv::StorageClass> storage_classes{
+        spv::StorageClass::StorageBuffer,
+        spv::StorageClass::Uniform,
+        spv::StorageClass::Workgroup,
+        spv::StorageClass::PushConstant,
+        spv::StorageClass::PhysicalStorageBuffer,
+        spv::StorageClass::UniformConstant};
+    for (auto sc : storage_classes) {
+      if (!SupportedStorageClass(sc)) {
+        continue;
+      }
+      const analysis::Pointer ptr_type{nullptr, sc};
+      auto id = context()->get_type_mgr()->GetId(&ptr_type);
+      if (id != 0) {
+        base_ptrs_[uint32_t(sc)] = context()->get_def_use_mgr()->GetDef(id);
+      }
+    }
+  }
+
   // Convert instructions that change opcode with untyped pointers.
   std::vector<Instruction*> to_convert;
   get_module()->ForEachInst([this, &to_convert](Instruction* inst) {
@@ -740,27 +746,33 @@ void ConvertToUntyped::ConvertPointers() {
     }
   });
 
-  for (auto* inst : to_convert) {
-    Convert(inst);
-  }
+  if (!to_convert.empty()) {
+    for (auto* inst : to_convert) {
+      Convert(inst);
+    }
 
-  // Update operands of instructions
-  get_module()->ForEachInst([this](Instruction* inst) {
-    for (uint32_t i = 0; i < inst->NumOperands(); i++) {
-      auto& op = inst->GetOperand(i);
-      if (spvIsIdType(op.type) && op.type != SPV_OPERAND_TYPE_RESULT_ID) {
-        auto where = remapped_ids_.find(op.words[0]);
-        if (where != remapped_ids_.end()) {
-          op.words[0] = where->second;
+    // Update operands of instructions
+    get_module()->ForEachInst([this](Instruction* inst) {
+      for (uint32_t i = 0; i < inst->NumOperands(); i++) {
+        auto& op = inst->GetOperand(i);
+        if (spvIsIdType(op.type) && op.type != SPV_OPERAND_TYPE_RESULT_ID) {
+          auto where = remapped_ids_.find(op.words[0]);
+          if (where != remapped_ids_.end()) {
+            op.words[0] = where->second;
+          }
         }
       }
-    }
-  });
+    });
 
-  // Delete dead instructions
-  for (auto* inst : to_delete_) {
-    context()->KillInst(inst);
+    // Delete dead instructions
+    for (auto* inst : to_delete_) {
+      context()->KillInst(inst);
+    }
+
+    return true;
   }
+
+  return false;
 }
 
 }  // namespace opt

--- a/source/opt/convert_to_untyped.cpp
+++ b/source/opt/convert_to_untyped.cpp
@@ -746,33 +746,33 @@ bool ConvertToUntyped::ConvertPointers() {
     }
   });
 
-  if (!to_convert.empty()) {
-    for (auto* inst : to_convert) {
-      Convert(inst);
-    }
-
-    // Update operands of instructions
-    get_module()->ForEachInst([this](Instruction* inst) {
-      for (uint32_t i = 0; i < inst->NumOperands(); i++) {
-        auto& op = inst->GetOperand(i);
-        if (spvIsIdType(op.type) && op.type != SPV_OPERAND_TYPE_RESULT_ID) {
-          auto where = remapped_ids_.find(op.words[0]);
-          if (where != remapped_ids_.end()) {
-            op.words[0] = where->second;
-          }
-        }
-      }
-    });
-
-    // Delete dead instructions
-    for (auto* inst : to_delete_) {
-      context()->KillInst(inst);
-    }
-
-    return true;
+  if (to_convert.empty()) {
+    return false;
   }
 
-  return false;
+  for (auto* inst : to_convert) {
+    Convert(inst);
+  }
+
+  // Update operands of instructions
+  get_module()->ForEachInst([this](Instruction* inst) {
+    for (uint32_t i = 0; i < inst->NumOperands(); i++) {
+      auto& op = inst->GetOperand(i);
+      if (spvIsIdType(op.type) && op.type != SPV_OPERAND_TYPE_RESULT_ID) {
+        auto where = remapped_ids_.find(op.words[0]);
+        if (where != remapped_ids_.end()) {
+          op.words[0] = where->second;
+        }
+      }
+    }
+  });
+
+  // Delete dead instructions
+  for (auto* inst : to_delete_) {
+    context()->KillInst(inst);
+  }
+
+  return true;
 }
 
 }  // namespace opt

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -50,6 +50,9 @@ class ConvertToUntyped : public Pass {
   // Returns true if the module has unsupported features.
   bool HasUnsupportedFeatures();
 
+  // Determines whether workgroup storage class can be converted.
+  void CheckWorkgroup();
+
   // Converts or updates inst.
   void Convert(Instruction* inst);
 
@@ -96,6 +99,7 @@ class ConvertToUntyped : public Pass {
   std::vector<Instruction*> to_delete_{};
 
   uint32_t max_id_ = 0;
+  bool support_workgroup_ = false;
 };
 
 }  // namespace opt

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -33,6 +33,11 @@ class ConvertToUntyped : public Pass {
   void AddUntypedEnable();
 
   // Updates the module by converting instructions and replacing uses.
+  //
+  // The TypeManager is not updated as the mutations occur and all instructions
+  // continue to use old ids (mapped to correctly typed pointers) until after
+  // conversions. Then all operands are updated (and unneeded instructions
+  // removed).
   void ConvertPointers();
 
   // Returns true if sc is supports untyped pointers.
@@ -53,13 +58,13 @@ class ConvertToUntyped : public Pass {
   Instruction* ConvertPointer(Instruction* inst);
 
   // Converts OpVariable to OpUntypedVariableKHR
-  Instruction* ConvertVariable(Instruction* inst);
+  void ConvertVariable(Instruction* inst);
 
-  // Converts Op[InBounds]AccessChain to OpUntyped[InBounds]AccessChainKHR.
-  Instruction* ConvertAccessChain(Instruction* inst);
+  // Converts access chains to equivalent untyped version.
+  void ConvertAccessChain(Instruction* inst);
 
   // Converts OpArrayLength to OpUntypedArrayLengthKHR.
-  Instruction* ConvertArrayLength(Instruction* inst);
+  void ConvertArrayLength(Instruction* inst);
 
   // Converts OpCopyMemory.
   // If the copy is a matrix or the column of a matrix, it is converted to loads

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_CONVERT_TO_UNTYPED_H_
+#define LIBSPIRV_OPT_CONVERT_TO_UNTYPED_H_
+
+#include "pass.h"
+
+#include <unordered_map>
+#include <utility>
+
+namespace spvtools {
+namespace opt {
+
+class ConvertToUntyped : public Pass {
+ public:
+  const char* name() const override { return "convert-to-untyped"; }
+  Status Process() override;
+
+ private:
+  // Adds the untyped pointer extension and capability if they are not present.
+  void AddUntypedEnable();
+
+  // Updates the module by converting instructions and replacing uses.
+  void ConvertPointers();
+
+  // Returns true if sc is supports untyped pointers.
+  bool SupportedStorageClass(spv::StorageClass sc);
+  bool SupportedStorageClass(uint32_t sc);
+
+  // Returns true if inst needs conversion.
+  bool ShouldConvert(const Instruction* inst);
+
+  // Returns true if the module has unsupported features.
+  bool HasUnsupportedFeatures();
+
+  // Converts or updates inst.
+  void Convert(Instruction* inst);
+
+  // Converts OpTypePointer to OpTypeUntypedPointerKHR
+  // All undecorated pointers in each storage class are de-duplicated.
+  Instruction* ConvertPointer(Instruction* inst);
+
+  // Converts OpVariable to OpUntypedVariableKHR
+  Instruction* ConvertVariable(Instruction* inst);
+
+  // Converts Op[InBounds]AccessChain to OpUntyped[InBounds]AccessChainKHR.
+  Instruction* ConvertAccessChain(Instruction* inst);
+
+  // Converts OpArrayLength to OpUntypedArrayLengthKHR.
+  Instruction* ConvertArrayLength(Instruction* inst);
+
+  // Converts OpCopyMemory.
+  // If the copy is a matrix or the column of a matrix, it is converted to loads
+  // and stores element-wise.
+  // Otherwise, converts the copy to a load and store.
+  void ConvertCopyMemory(Instruction* inst);
+
+  // Updates cooperative matrix load/store strides to be in bytes.
+  void UpdateCooperativeMatrixLoadStore(Instruction* inst);
+
+  uint32_t NextId();
+
+  // Returns (row_major, matrix_stride) for the inst.
+  std::pair<bool, uint32_t> MatrixStride(Instruction* inst);
+
+  // Memory access operand conversion (from OpCopyMemory)
+  // Converts operands into appropriate memory access operands for OpStore.
+  std::vector<Operand> StoreOperands(const std::vector<Operand>& operands,
+                                     uint32_t align);
+  // Converts operands into appropriate memory access operands for OpLoad.
+  std::vector<Operand> LoadOperands(const std::vector<Operand>& operands,
+                                    uint32_t align);
+
+  // Tracks the de-duplicated pointers per storage class.
+  std::unordered_map<uint32_t, Instruction*> base_ptrs_{};
+  // Tracks result id to its replacement result id
+  std::unordered_map<uint32_t, uint32_t> remapped_ids_{};
+  // Converted instructions that need deleted.
+  std::vector<Instruction*> to_delete_{};
+
+  uint32_t max_id_ = 0;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+#endif  // LIBSPIRV_OPT_CONVERT_TO_UNTYPED_H_

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -15,10 +15,10 @@
 #ifndef LIBSPIRV_OPT_CONVERT_TO_UNTYPED_H_
 #define LIBSPIRV_OPT_CONVERT_TO_UNTYPED_H_
 
-#include "pass.h"
-
 #include <unordered_map>
 #include <utility>
+
+#include "pass.h"
 
 namespace spvtools {
 namespace opt {

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -38,7 +38,7 @@ class ConvertToUntyped : public Pass {
   // continue to use old ids (mapped to correctly typed pointers) until after
   // conversions. Then all operands are updated (and unneeded instructions
   // removed).
-  // 
+  //
   // Returns true if conversions were made.
   bool ConvertPointers();
 

--- a/source/opt/convert_to_untyped.h
+++ b/source/opt/convert_to_untyped.h
@@ -30,7 +30,7 @@ class ConvertToUntyped : public Pass {
 
  private:
   // Adds the untyped pointer extension and capability if they are not present.
-  void AddUntypedEnable();
+  void AddUntypedPointerCapability();
 
   // Updates the module by converting instructions and replacing uses.
   //
@@ -38,7 +38,9 @@ class ConvertToUntyped : public Pass {
   // continue to use old ids (mapped to correctly typed pointers) until after
   // conversions. Then all operands are updated (and unneeded instructions
   // removed).
-  void ConvertPointers();
+  // 
+  // Returns true if conversions were made.
+  bool ConvertPointers();
 
   // Returns true if sc is supports untyped pointers.
   bool SupportedStorageClass(spv::StorageClass sc);
@@ -58,7 +60,7 @@ class ConvertToUntyped : public Pass {
 
   // Converts OpTypePointer to OpTypeUntypedPointerKHR
   // All undecorated pointers in each storage class are de-duplicated.
-  Instruction* ConvertPointer(Instruction* inst);
+  Instruction* ConvertPointerType(Instruction* inst);
 
   // Converts OpVariable to OpUntypedVariableKHR
   void ConvertVariable(Instruction* inst);
@@ -98,7 +100,6 @@ class ConvertToUntyped : public Pass {
   // Converted instructions that need deleted.
   std::vector<Instruction*> to_delete_{};
 
-  uint32_t max_id_ = 0;
   bool support_workgroup_ = false;
 };
 

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -465,6 +465,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag,
     RegisterPass(CreateReplaceInvalidOpcodePass());
   } else if (pass_name == "convert-relaxed-to-half") {
     RegisterPass(CreateConvertRelaxedToHalfPass());
+  } else if (pass_name == "convert-to-untyped") {
+    RegisterPass(CreateConvertToUntypedPass());
   } else if (pass_name == "relax-float-ops") {
     RegisterPass(CreateRelaxFloatOpsPass());
   } else if (pass_name == "simplify-instructions") {
@@ -1052,6 +1054,11 @@ Optimizer::PassToken CreateUpgradeMemoryModelPass() {
 Optimizer::PassToken CreateConvertRelaxedToHalfPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ConvertToHalfPass>());
+}
+
+Optimizer::PassToken CreateConvertToUntypedPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::ConvertToUntyped>());
 }
 
 Optimizer::PassToken CreateRelaxFloatOpsPass() {

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -465,6 +465,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag,
     RegisterPass(CreateReplaceInvalidOpcodePass());
   } else if (pass_name == "convert-relaxed-to-half") {
     RegisterPass(CreateConvertRelaxedToHalfPass());
+  } else if (pass_name == "convert-to-untyped") {
+    RegisterPass(CreateConvertToUntypedPass());
   } else if (pass_name == "relax-float-ops") {
     RegisterPass(CreateRelaxFloatOpsPass());
   } else if (pass_name == "simplify-instructions") {
@@ -1053,6 +1055,11 @@ Optimizer::PassToken CreateUpgradeMemoryModelPass() {
 Optimizer::PassToken CreateConvertRelaxedToHalfPass() {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ConvertToHalfPass>());
+}
+
+Optimizer::PassToken CreateConvertToUntypedPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::ConvertToUntyped>());
 }
 
 Optimizer::PassToken CreateRelaxFloatOpsPass() {

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -29,6 +29,7 @@
 #include "source/opt/compact_ids_pass.h"
 #include "source/opt/convert_to_half_pass.h"
 #include "source/opt/convert_to_sampled_image_pass.h"
+#include "source/opt/convert_to_untyped.h"
 #include "source/opt/copy_prop_arrays.h"
 #include "source/opt/dead_branch_elim_pass.h"
 #include "source/opt/dead_insert_elim_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -34,6 +34,7 @@ add_spvtools_unittest(TARGET opt
        control_dependence.cpp
        convert_relaxed_to_half_test.cpp
        convert_to_sampled_image_test.cpp
+       convert_to_untyped_test.cpp
        copy_prop_array_test.cpp
        dataflow.cpp
        dead_branch_elim_test.cpp

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -46,9 +46,12 @@ TEST_F(ConvertToUntypedTest, SupportedStorageClasses_NoWorkgroup) {
 ; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
 ; CHECK-DAG: OpTypeUntypedPointerKHR Uniform
 ; CHECK-DAG: OpTypeUntypedPointerKHR PushConstant
+; CHECK-DAG: OpTypeUntypedPointerKHR PhysicalStorageBuffer
 ; CHECK-NOT: OpTypeUntypedPointerKHR Workgroup
 OpCapability Shader
-OpMemoryModel Logical GLSL450
+OpCapability PhysicalStorageBufferAddresses
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
 OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 %void = OpTypeVoid
@@ -57,6 +60,7 @@ OpExecutionMode %main LocalSize 1 1 1
 %ptr_ssbo_int = OpTypePointer StorageBuffer %int
 %ptr_ubo_int = OpTypePointer Uniform %int
 %ptr_pc_int = OpTypePointer PushConstant %int
+%ptr_pssbo_int = OpTypePointer PhysicalStorageBuffer %int
 %ptr_wg_int = OpTypePointer Workgroup %int
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
@@ -72,11 +76,14 @@ TEST_F(ConvertToUntypedTest, SupportedStorageClasses_Workgroup) {
 ; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
 ; CHECK-DAG: OpTypeUntypedPointerKHR Uniform
 ; CHECK-DAG: OpTypeUntypedPointerKHR PushConstant
+; CHECK-DAG: OpTypeUntypedPointerKHR PhysicalStorageBuffer
 ; CHECK-DAG: OpTypeUntypedPointerKHR Workgroup
 OpCapability Shader
 OpCapability WorkgroupMemoryExplicitLayoutKHR
+OpCapability PhysicalStorageBufferAddresses
 OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
-OpMemoryModel Logical GLSL450
+OpExtension "SPV_KHR_physical_storage_buffer"
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
 OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 %void = OpTypeVoid
@@ -85,6 +92,7 @@ OpExecutionMode %main LocalSize 1 1 1
 %ptr_ssbo_int = OpTypePointer StorageBuffer %int
 %ptr_ubo_int = OpTypePointer Uniform %int
 %ptr_pc_int = OpTypePointer PushConstant %int
+%ptr_pssbo_int = OpTypePointer PhysicalStorageBuffer %int
 %ptr_wg_int = OpTypePointer Workgroup %int
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
@@ -139,6 +147,63 @@ OpDecorate %ptr_uint ArrayStride 4
 %uint = OpTypeInt 32 0
 %ptr_int = OpTypePointer StorageBuffer %int
 %ptr_uint = OpTypePointer StorageBuffer %uint
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, Pointer_PreExsitingBase) {
+  const std::string text = R"(
+; CHECK-NOT: OpTypePointer
+; CHECK: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-NOT: OpTypeUntypedPointerKHR
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%ptr_int = OpTypePointer StorageBuffer %int
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, Pointer_PreExsitingBase_Unusable) {
+  const std::string text = R"(
+; CHECK: OpDecorate [[ptr:%\w+]] ArrayStride 4
+; CHECK-NOT: OpTypePointer
+; CHECK: [[ptr]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-NOT: OpTypeUntypedPointerKHR
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %ptr ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%int = OpTypeInt 32 1
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%ptr_int = OpTypePointer StorageBuffer %int
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
 OpReturn
@@ -1098,6 +1163,46 @@ OpReturn
 OpFunctionEnd
 )";
 
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, PhysicalStorageBuffer) {
+  const std::string text = R"(
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR PhysicalStorageBuffer
+; CHECK: [[conv:%\w+]] = OpConvertUToPtr [[ptr]]
+; CHECK: OpConvertPtrToU {{%\w+}} [[conv]]
+; CHECK: OpBitcast [[ptr]]
+OpCapability Shader
+OpCapability Int64
+OpCapability PhysicalStorageBufferAddresses
+OpMemoryModel PhysicalStorageBuffer64 GLSL450
+OpEntryPoint GLCompute %main "main" %pc
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint2 = OpTypeVector %uint 2
+%uint2_0 = OpConstantComposite %uint2 %uint_0 %uint_0
+%ulong = OpTypeInt 64 0
+%block = OpTypeStruct %ulong
+%ptr_block = OpTypePointer PushConstant %block
+%ptr_ulong = OpTypePointer PushConstant %ulong
+%ptr_pssbo_uint = OpTypePointer PhysicalStorageBuffer %uint
+%pc = OpVariable %ptr_block PushConstant
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpAccessChain %ptr_ulong %pc %uint_0
+%ld = OpLoad %ulong %gep
+%convert = OpConvertUToPtr %ptr_pssbo_uint %ld
+%reconvert = OpConvertPtrToU %ulong %convert
+%bitcast = OpBitcast %ptr_pssbo_uint %uint2_0
+OpReturn
+OpFunctionEnd
+)";
 
   SetTargetEnv(SPV_ENV_VULKAN_1_3);
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -224,6 +224,47 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
+TEST_F(ConvertToUntypedTest, PtrAccessChain) {
+  const std::string text = R"(
+; CHECK: OpDecorate {{%\w+}} ArrayStride 4
+; CHECK: OpDecorate [[stride_ptr:%\w+]] ArrayStride 4
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK: [[uint_0:%\w+]] = OpConstant [[uint]] 0
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: [[stride_ptr]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: [[access:%\w+]] = OpUntypedAccessChainKHR [[stride_ptr]]
+; CHECK: OpUntypedPtrAccessChainKHR [[stride_ptr]] [[uint]] [[access]] [[uint_0]]
+OpCapability Shader
+OpCapability VariablePointersStorageBuffer
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %rta ArrayStride 4
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %ptr_uint ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%rta = OpTypeRuntimeArray %uint
+%block = OpTypeStruct %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%var = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%access = OpAccessChain %ptr_uint %var %uint_0 %uint_0
+%ptr_access = OpPtrAccessChain %ptr_uint %access %uint_0
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
 TEST_F(ConvertToUntypedTest, ArrayLength) {
   const std::string text = R"(
 ; CHECK: [[uint:%\w+]] = OpTypeInt
@@ -316,6 +357,62 @@ OpDecorate %out Binding 1
 %entry = OpLabel
 %in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
 %out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorElement) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[ld:%\w+]] = OpLoad [[float]] [[in_access]]
+; CHECK: OpStore [[out_access]] [[ld]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%ptr_float = OpTypePointer StorageBuffer %float
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_float %in %uint_0 %uint_2 %uint_0
+%out_access = OpAccessChain %ptr_float %out %uint_0 %uint_2 %uint_0
 OpCopyMemory %out_access %in_access
 OpReturn
 OpFunctionEnd
@@ -840,6 +937,80 @@ OpMemberDecorate %heap_ty 0 Offset 0
 %buffer = OpBufferPointerEXT %ptr_uint %gep
 %ld = OpLoad %uint %buffer
 OpReturn
+OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, VariablePointers_StorageBuffer) {
+  const std::string text = R"(
+; CHECK: OpDecorate {{%\w+}} ArrayStride 4
+; CHECK: OpDecorate [[stride_ptr:%\w+]] ArrayStride 4
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK: [[uint_0:%\w+]] = OpConstant [[uint]] 0
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: [[stride_ptr]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: [[null:%\w+]] = OpConstantNull [[stride_ptr]]
+; CHECK: [[var:%\w+]] = OpUntypedVariableKHR
+; CHECK: [[fn_ty:%\w+]] = OpTypeFunction [[stride_ptr]] [[stride_ptr]]
+; CHECK: [[fn_ptr:%\w+]] = OpTypePointer Function [[ptr]]
+; CHECK: [[fn_var:%\w+]] = OpVariable [[fn_ptr]] Function [[var]]
+; CHECK: [[ld:%\w+]] = OpLoad [[ptr]] [[fn_var]]
+; CHECK: [[access:%\w+]] = OpUntypedAccessChainKHR [[stride_ptr]] {{%\w+}} [[ld]] [[uint_0]] [[uint_0]]
+; CHECK: [[ptr_access:%\w+]] = OpUntypedPtrAccessChainKHR [[stride_ptr]] [[uint]] [[access]] [[uint_0]]
+; CHECK: OpFunctionCall [[stride_ptr]] [[fn:%\w+]] [[ptr_access]]
+; CHECK: [[fn]] = OpFunction [[stride_ptr]] None [[fn_ty]]
+; CHECK: [[param:%\w+]] = OpFunctionParameter [[stride_ptr]]
+; CHECK: [[sel:%\w+]] = OpSelect [[stride_ptr]] {{%\w+}} [[null]] [[param]]
+; CHECK: [[phi:%\w+]] = OpPhi [[stride_ptr]] [[sel]] {{%\w+}} [[null]] {{%\w+}}
+; CHECK: OpReturnValue [[phi]]
+OpCapability Shader
+OpCapability VariablePointersStorageBuffer
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main" %var
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %block Block
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %rta ArrayStride 4
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %ptr_uint ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%bool = OpTypeBool
+%cond = OpConstantFalse %bool
+%rta = OpTypeRuntimeArray %uint
+%block = OpTypeStruct %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%null = OpConstantNull %ptr_uint
+%var = OpVariable %ptr_block StorageBuffer
+%fn_ty = OpTypeFunction %ptr_uint %ptr_uint
+%ptr_func = OpTypePointer Function %ptr_block
+%main = OpFunction %void None %void_fn
+%main_entry = OpLabel
+%fn_var = OpVariable %ptr_func Function %var
+%ld_ptr = OpLoad %ptr_block %fn_var
+%access = OpAccessChain %ptr_uint %ld_ptr %uint_0 %uint_0
+%ptr_access = OpPtrAccessChain %ptr_uint %access %uint_0
+%call = OpFunctionCall %ptr_uint %fn %ptr_access
+OpReturn
+OpFunctionEnd
+%fn = OpFunction %ptr_uint None %fn_ty
+%param = OpFunctionParameter %ptr_uint
+%fn_entry = OpLabel
+%sel = OpSelect %ptr_uint %cond %null %param
+OpSelectionMerge %merge None
+OpBranchConditional %cond %merge %else
+%else = OpLabel
+OpBranch %merge
+%merge = OpLabel
+%phi = OpPhi %ptr_uint %sel %fn_entry %null %else
+OpReturnValue %phi
 OpFunctionEnd
 )";
 

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -41,11 +41,12 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
-TEST_F(ConvertToUntypedTest, SupportedStorageClasses) {
+TEST_F(ConvertToUntypedTest, SupportedStorageClasses_NoWorkgroup) {
   const std::string text = R"(
 ; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
 ; CHECK-DAG: OpTypeUntypedPointerKHR Uniform
 ; CHECK-DAG: OpTypeUntypedPointerKHR PushConstant
+; CHECK-NOT: OpTypeUntypedPointerKHR Workgroup
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
@@ -56,12 +57,42 @@ OpExecutionMode %main LocalSize 1 1 1
 %ptr_ssbo_int = OpTypePointer StorageBuffer %int
 %ptr_ubo_int = OpTypePointer Uniform %int
 %ptr_pc_int = OpTypePointer PushConstant %int
+%ptr_wg_int = OpTypePointer Workgroup %int
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
 OpReturn
 OpFunctionEnd
 )";
 
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, SupportedStorageClasses_Workgroup) {
+  const std::string text = R"(
+; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: OpTypeUntypedPointerKHR Uniform
+; CHECK-DAG: OpTypeUntypedPointerKHR PushConstant
+; CHECK-DAG: OpTypeUntypedPointerKHR Workgroup
+OpCapability Shader
+OpCapability WorkgroupMemoryExplicitLayoutKHR
+OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%ptr_ssbo_int = OpTypePointer StorageBuffer %int
+%ptr_ubo_int = OpTypePointer Uniform %int
+%ptr_pc_int = OpTypePointer PushConstant %int
+%ptr_wg_int = OpTypePointer Workgroup %int
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_UNIVERSAL_1_4);
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
@@ -1013,6 +1044,60 @@ OpBranch %merge
 OpReturnValue %phi
 OpFunctionEnd
 )";
+
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, WorkgroupMemoryExplicitLayout) {
+  const std::string text = R"(
+; CHECK: OpDecorate [[block1:%\w+]] Block
+; CHECK: OpDecorate [[block2:%\w+]] Block
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK: [[uint_0:%\w+]] = OpConstant [[uint]] 0
+; CHECK: [[float:%\w+]] = OpTypeFloat 32
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR Workgroup
+; CHECK: [[v1:%\w+]] = OpUntypedVariableKHR [[ptr]] Workgroup [[block1]]
+; CHECK: [[v2:%\w+]] = OpUntypedVariableKHR [[ptr]] Workgroup [[block2]]
+; CHECK: [[access1:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block1]] [[v1]] [[uint_0]]
+; CHECK: OpLoad [[uint]] [[access1]]
+; CHECK: [[access2:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block2]] [[v2]] [[uint_0]]
+; CHECK: OpLoad [[float]] [[access2]]
+OpCapability Shader
+OpCapability WorkgroupMemoryExplicitLayoutKHR
+OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main" %v1 %v2
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %block1 Block
+OpMemberDecorate %block1 0 Offset 0
+OpDecorate %block2 Block
+OpMemberDecorate %block2 0 Offset 0
+OpDecorate %v1 Aliased
+OpDecorate %v2 Aliased
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%float = OpTypeFloat 32
+%block1 = OpTypeStruct %uint
+%block2 = OpTypeStruct %float
+%ptr_block1 = OpTypePointer Workgroup %block1
+%ptr_block2 = OpTypePointer Workgroup %block2
+%ptr_uint = OpTypePointer Workgroup %uint
+%ptr_float = OpTypePointer Workgroup %float
+%v1 = OpVariable %ptr_block1 Workgroup
+%v2 = OpVariable %ptr_block2 Workgroup
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%access1 = OpAccessChain %ptr_uint %v1 %uint_0
+%ld1 = OpLoad %uint %access1
+%access2 = OpAccessChain %ptr_float %v2 %uint_0
+%ld2 = OpLoad %float %access2
+OpReturn
+OpFunctionEnd
+)";
+
 
   SetTargetEnv(SPV_ENV_VULKAN_1_3);
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -1,0 +1,850 @@
+// Copyright (c) 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "assembly_builder.h"
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using ConvertToUntypedTest = opt::PassTest<::testing::Test>;
+
+TEST_F(ConvertToUntypedTest, AddCapability) {
+  const std::string text = R"(
+; CHECK: OpCapability UntypedPointersKHR
+; CHECK: OpExtension "SPV_KHR_untyped_pointers"
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, SupportedStorageClasses) {
+  const std::string text = R"(
+; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: OpTypeUntypedPointerKHR Uniform
+; CHECK-DAG: OpTypeUntypedPointerKHR PushConstant
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%ptr_ssbo_int = OpTypePointer StorageBuffer %int
+%ptr_ubo_int = OpTypePointer Uniform %int
+%ptr_pc_int = OpTypePointer PushConstant %int
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, Pointer_Deduplicate) {
+  const std::string text = R"(
+; CHECK-NOT: OpTypePointer
+; CHECK: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-NOT: OpTypeUntypedPointerKHR
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%uint = OpTypeInt 32 0
+%ptr_int = OpTypePointer StorageBuffer %int
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, Pointer_DistinguishDecorations) {
+  const std::string text = R"(
+; CHECK: OpDecorate [[ptr_uint:%\w+]] ArrayStride 4
+; CHECK: [[int:%\w+]] = OpTypeInt 32 1
+; CHECK: [[uint:%\w+]] = OpTypeInt 32 0
+; CHECK-NOT: OpTypePointer
+; CHECK-DAG: OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[ptr_uint]] = OpTypeUntypedPointerKHR StorageBuffer
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %ptr_uint ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%uint = OpTypeInt 32 0
+%ptr_int = OpTypePointer StorageBuffer %int
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, Variable_Descriptor) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[var:%\w+]] DescriptorSet 0
+; CHECK-DAG: OpDecorate [[var]] Binding 0
+; CHECK: [[block:%\w+]] = OpTypeStruct
+; CHECK-NOT: OpVariable
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR Uniform
+; CHECK: [[var]] = OpUntypedVariableKHR [[ptr]] Uniform [[block]]
+; CHECK: OpCopyObject [[ptr]] [[var]]
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %block Block
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%block = OpTypeStruct %uint
+%ptr_block = OpTypePointer Uniform %block
+%var = OpVariable %ptr_block Uniform
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%copy = OpCopyObject %ptr_block %var
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, AccessChain) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[var:%\w+]] DescriptorSet 0
+; CHECK-DAG: OpDecorate [[var]] Binding 0
+; CHECK: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK: [[block:%\w+]] = OpTypeStruct
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR Uniform
+; CHECK: [[var]] = OpUntypedVariableKHR [[ptr]] Uniform [[block]]
+; CHECK: OpLabel
+; CHECK: OpUntypedAccessChainKHR [[ptr]] [[block]] [[var]] [[zero]]
+; CHECK-NOT: OpAccessChain
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %block Block
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%block = OpTypeStruct %uint
+%ptr_block = OpTypePointer Uniform %block
+%ptr_uint = OpTypePointer Uniform %uint
+%var = OpVariable %ptr_block Uniform
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpAccessChain %ptr_uint %var %uint_0
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, AccessChain_InBounds) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[var:%\w+]] DescriptorSet 0
+; CHECK-DAG: OpDecorate [[var]] Binding 0
+; CHECK: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK: [[block:%\w+]] = OpTypeStruct
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR Uniform
+; CHECK: [[var]] = OpUntypedVariableKHR [[ptr]] Uniform [[block]]
+; CHECK: OpLabel
+; CHECK: OpUntypedInBoundsAccessChainKHR [[ptr]] [[block]] [[var]] [[zero]]
+; CHECK-NOT: OpInBoundsAccessChain
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %block Block
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%block = OpTypeStruct %uint
+%ptr_block = OpTypePointer Uniform %block
+%ptr_uint = OpTypePointer Uniform %uint
+%var = OpVariable %ptr_block Uniform
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpInBoundsAccessChain %ptr_uint %var %uint_0
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, ArrayLength) {
+  const std::string text = R"(
+; CHECK: [[uint:%\w+]] = OpTypeInt
+; CHECK: [[block:%\w+]] = OpTypeStruct
+; CHECK: [[var:%\w+]] = OpUntypedVariableKHR
+; CHECK: OpLabel
+; CHECK: OpUntypedArrayLengthKHR [[uint]] [[block]] [[var]] 0
+; CHECK-NOT: OpArrayLength
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpDecorate %block Block
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+OpDecorate %rta ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%rta = OpTypeRuntimeArray %uint
+%block = OpTypeStruct %rta
+%ptr_block = OpTypePointer StorageBuffer %block
+%var = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%len = OpArrayLength %uint %var 0
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[two]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[two]]
+; CHECK: OpStore [[out_gep]] [[in_ld]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
+%out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SharedMemoryOperand) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access:Aligned\|MakePointerVisible\|NonPrivatePointer]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access:Aligned\|MakePointerAvailable\|NonPrivatePointer]] 4 [[five]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[five]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[two]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[two]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[five]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
+%out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access Aligned|MakePointerAvailable|MakePointerVisible|NonPrivatePointer 16 %uint_5 %uint_5
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SharedMemoryOperand_AddAligned) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access:Aligned\|MakePointerVisible\|NonPrivatePointer]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access:Aligned\|MakePointerAvailable\|NonPrivatePointer]] 4 [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[two]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[five]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[two]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[two]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
+%out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access MakePointerAvailable|MakePointerVisible|NonPrivatePointer %uint_2 %uint_5
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SeparatedMemoryOperands) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access:Aligned\|MakePointerVisible\|NonPrivatePointer]] 4 [[two]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access:Aligned\|MakePointerAvailable\|NonPrivatePointer]] 4 [[five]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[two]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[five]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[two]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4 [[two]]
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[two]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4 [[five]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
+%out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access Aligned|MakePointerAvailable|NonPrivatePointer 16 %uint_5 Aligned|MakePointerVisible|NonPrivatePointer 16 %uint_2
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SeparatedMemoryOperands_AddAligned) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 3
+; CHECK-DAG: [[block:%\w+]] = OpTypeStruct
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[in]] [[zero]] [[two]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[block]] [[out]] [[zero]] [[two]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access:Aligned\|Nontemporal]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access:Volatile\|Aligned]] 4
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[in_access]] [[two]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[vec]] [[out_access]] [[two]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block 0 Offset 0
+OpMemberDecorate %block 0 RowMajor
+OpMemberDecorate %block 0 MatrixStride 12
+OpDecorate %block Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%vec3 = OpTypeVector %float 3
+%mat3x3 = OpTypeMatrix %vec3 3
+%block = OpTypeStruct %mat3x3
+%ptr_block = OpTypePointer StorageBuffer %block
+%ptr_vec = OpTypePointer StorageBuffer %vec3
+%in = OpVariable %ptr_block StorageBuffer
+%out = OpVariable %ptr_block StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_vec %in %uint_0 %uint_2
+%out_access = OpAccessChain %ptr_vec %out %uint_0 %uint_2
+OpCopyMemory %out_access %in_access Volatile Nontemporal
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_Matrix_NoOperands) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[vec:%\w+]] = OpTypeVector [[float]] 2
+; CHECK-DAG: [[mat:%\w+]] = OpTypeMatrix [[vec]] 2
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] {{%\w+}} [[in]] [[zero]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] {{%\w+}} [[out]] [[zero]]
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[in_access]] [[zero]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access:Aligned]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[out_access]] [[zero]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access:Aligned]] 4
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[in_access]] [[zero]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[out_access]] [[zero]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[in_access]] [[one]] [[zero]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[out_access]] [[one]] [[zero]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4
+; CHECK: [[in_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[in_access]] [[one]] [[one]]
+; CHECK: [[in_ld:%\w+]] = OpLoad [[float]] [[in_gep]] [[ld_access]] 4
+; CHECK: [[out_gep:%\w+]] = OpUntypedAccessChainKHR [[ptr]] [[mat]] [[out_access]] [[one]] [[one]]
+; CHECK: OpStore [[out_gep]] [[in_ld]] [[st_access]] 4
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block1 0 Offset 0
+OpMemberDecorate %block1 0 ColMajor
+OpMemberDecorate %block1 0 MatrixStride 8
+OpDecorate %block1 Block
+OpMemberDecorate %block2 0 Offset 0
+OpMemberDecorate %block2 0 RowMajor
+OpMemberDecorate %block2 0 MatrixStride 24
+OpDecorate %block2 Block
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%vec2 = OpTypeVector %float 2
+%mat2x2 = OpTypeMatrix %vec2 2
+%block1 = OpTypeStruct %mat2x2
+%block2 = OpTypeStruct %mat2x2
+%ptr_block1 = OpTypePointer StorageBuffer %block1
+%ptr_block2 = OpTypePointer StorageBuffer %block2
+%ptr_mat2x2 = OpTypePointer StorageBuffer %mat2x2
+%in = OpVariable %ptr_block1 StorageBuffer
+%out = OpVariable %ptr_block2 StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_mat2x2 %in %uint_0
+%out_access = OpAccessChain %ptr_mat2x2 %out %uint_0
+OpCopyMemory %out_access %in_access
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CopyMemory_Array) {
+  const std::string text = R"(
+; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
+; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
+; CHECK-DAG: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK-DAG: [[in]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[out]] = OpUntypedVariableKHR [[ptr]]
+; CHECK-DAG: [[zero:%\w+]] = OpConstant {{%\w+}} 0
+; CHECK-DAG: [[one:%\w+]] = OpConstant {{%\w+}} 1
+; CHECK-DAG: [[two:%\w+]] = OpConstant {{%\w+}} 2
+; CHECK-DAG: [[five:%\w+]] = OpConstant {{%\w+}} 5
+; CHECK-DAG: [[float:%\w+]] = OpTypeFloat 32
+; CHECK-DAG: [[array:%\w+]] = OpTypeArray [[float]] [[five]]
+; CHECK: OpLabel
+; CHECK: [[in_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] {{%\w+}} [[in]] [[zero]]
+; CHECK: [[out_access:%\w+]] = OpUntypedAccessChainKHR [[ptr]] {{%\w+}} [[out]] [[zero]]
+; CHECK: [[ld:%\w+]] = OpLoad [[array]] [[in_access]]
+; CHECK: OpStore [[out_access]] [[ld]]
+; CHECK-NOT: OpCopyMemory
+OpCapability Shader
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpMemberDecorate %block1 0 Offset 0
+OpDecorate %block1 Block
+OpMemberDecorate %block2 0 Offset 0
+OpDecorate %block2 Block
+OpDecorate %array ArrayStride 4
+OpDecorate %in DescriptorSet 0
+OpDecorate %in Binding 0
+OpDecorate %out DescriptorSet 0
+OpDecorate %out Binding 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_5 = OpConstant %uint 5
+%float = OpTypeFloat 32
+%array = OpTypeArray %float %uint_5
+%block1 = OpTypeStruct %array
+%block2 = OpTypeStruct %array
+%ptr_block1 = OpTypePointer StorageBuffer %block1
+%ptr_block2 = OpTypePointer StorageBuffer %block2
+%ptr_array = OpTypePointer StorageBuffer %array
+%in = OpVariable %ptr_block1 StorageBuffer
+%out = OpVariable %ptr_block2 StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%in_access = OpAccessChain %ptr_array %in %uint_0
+%out_access = OpAccessChain %ptr_array %out %uint_0
+OpCopyMemory %out_access %in_access
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, CooperativeMatrixLoadStore) {
+  const std::string text = R"(
+; CHECK-DAG: [[uint_4:%\w+]] = OpConstant {{%\w+}} 4
+; CHECK-DAG: [[uint_8:%\w+]] = OpConstant {{%\w+}} 8
+; CHECK: [[in_stride:%\w+]] = OpFunctionParameter
+; CHECK: [[out_stride:%\w+]] = OpFunctionParameter
+; CHECK: [[mul:%\w+]] = OpIMul {{%\w+}} [[in_stride]] [[uint_4]]
+; CHECK: OpCooperativeMatrixLoadKHR {{%\w+}} {{%\w+}} {{%\w+}} [[mul]]
+; CHECK: [[mul:%\w+]] = OpIMul {{%\w+}} [[out_stride]] [[uint_8]]
+; CHECK: OpCooperativeMatrixStoreKHR {{%\w+}} {{%\w+}} {{%\w+}} [[mul]]
+OpCapability Shader
+OpCapability Float16
+OpCapability VulkanMemoryModel
+OpCapability CooperativeMatrixKHR
+OpExtension "SPV_KHR_cooperative_matrix"
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %rta_float ArrayStride 4
+OpDecorate %rta_vec2 ArrayStride 8
+OpDecorate %in_block Block
+OpMemberDecorate %in_block 0 Offset 0
+OpDecorate %out_block Block
+OpMemberDecorate %out_block 0 Offset 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_3 = OpConstant %uint 3
+%uint_16 = OpConstant %uint 16
+%half = OpTypeFloat 16
+%float = OpTypeFloat 32
+%vec2 = OpTypeVector %float 2
+%rta_float = OpTypeRuntimeArray %float
+%rta_vec2 = OpTypeRuntimeArray %vec2
+%in_block = OpTypeStruct %rta_float
+%out_block = OpTypeStruct %rta_vec2
+%ptr_in_block = OpTypePointer StorageBuffer %in_block
+%ptr_out_block = OpTypePointer StorageBuffer %out_block
+%ptr_float = OpTypePointer StorageBuffer %float
+%ptr_vec2 = OpTypePointer StorageBuffer %vec2
+%in_var = OpVariable %ptr_in_block StorageBuffer
+%out_var = OpVariable %ptr_out_block StorageBuffer
+%coop_mat_a = OpTypeCooperativeMatrixKHR %half %uint_3 %uint_16 %uint_16 %uint_0
+%fn_ty = OpTypeFunction %void %uint %uint
+%fn = OpFunction %void None %fn_ty
+%in_stride = OpFunctionParameter %uint
+%out_stride = OpFunctionParameter %uint
+%entry = OpLabel
+%in_gep = OpAccessChain %ptr_float %in_var %uint_0 %uint_0
+%ld = OpCooperativeMatrixLoadKHR %coop_mat_a %in_gep %uint_0 %in_stride
+%out_gep = OpAccessChain %ptr_vec2 %out_var %uint_0 %uint_0
+OpCooperativeMatrixStoreKHR %out_gep %ld %uint_0 %out_stride
+OpReturn
+OpFunctionEnd
+%main = OpFunction %void None %void_fn
+%lab = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+TEST_F(ConvertToUntypedTest, UpdateBufferPointer) {
+  const std::string text = R"(
+; CHECK: [[ptr:%\w+]] = OpTypeUntypedPointerKHR StorageBuffer
+; CHECK: OpBufferPointerEXT [[ptr]]
+OpCapability Shader
+OpCapability DescriptorHeapEXT
+OpExtension "SPV_EXT_descriptor_heap"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main" %heap
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %heap BuiltIn ResourceHeapEXT
+OpDecorate %heap_ty Block
+OpMemberDecorate %heap_ty 0 Offset 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%heap_ptr = OpTypeUntypedPointerKHR UniformConstant
+%buffer_ty = OpTypeBufferEXT StorageBuffer
+%heap_ty = OpTypeStruct %buffer_ty
+%ptr_uint = OpTypePointer StorageBuffer %uint
+%heap = OpUntypedVariableKHR %heap_ptr UniformConstant
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+%gep = OpUntypedAccessChainKHR %heap_ptr %heap_ty %heap %uint_0
+%buffer = OpBufferPointerEXT %ptr_uint %gep
+%ld = OpLoad %uint %buffer
+OpReturn
+OpFunctionEnd
+)";
+
+  SetTargetEnv(SPV_ENV_VULKAN_1_3);
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
+}  // namespace

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -587,7 +587,8 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
-TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SharedMemoryOperand_AddAligned) {
+TEST_F(ConvertToUntypedTest,
+       CopyMemory_RowMajorColumn_SharedMemoryOperand_AddAligned) {
   const std::string text = R"(
 ; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
 ; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
@@ -657,7 +658,8 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
-TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SeparatedMemoryOperands) {
+TEST_F(ConvertToUntypedTest,
+       CopyMemory_RowMajorColumn_SeparatedMemoryOperands) {
   const std::string text = R"(
 ; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
 ; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1
@@ -727,7 +729,8 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
 }
 
-TEST_F(ConvertToUntypedTest, CopyMemory_RowMajorColumn_SeparatedMemoryOperands_AddAligned) {
+TEST_F(ConvertToUntypedTest,
+       CopyMemory_RowMajorColumn_SeparatedMemoryOperands_AddAligned) {
   const std::string text = R"(
 ; CHECK-DAG: OpDecorate [[in:%\w+]] Binding 0
 ; CHECK-DAG: OpDecorate [[out:%\w+]] Binding 1

--- a/test/opt/convert_to_untyped_test.cpp
+++ b/test/opt/convert_to_untyped_test.cpp
@@ -22,6 +22,25 @@ using namespace spvtools;
 
 using ConvertToUntypedTest = opt::PassTest<::testing::Test>;
 
+TEST_F(ConvertToUntypedTest, DoNotCapability) {
+  const std::string text = R"(
+; CHECK-NOT: OpCapability UntypedPointersKHR
+; CHECK-NOT: OpExtension "SPV_KHR_untyped_pointers"
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::ConvertToUntyped>(text, true);
+}
+
 TEST_F(ConvertToUntypedTest, AddCapability) {
   const std::string text = R"(
 ; CHECK: OpCapability UntypedPointersKHR
@@ -32,6 +51,8 @@ OpEntryPoint GLCompute %main "main"
 OpExecutionMode %main LocalSize 1 1 1
 %void = OpTypeVoid
 %void_fn = OpTypeFunction %void
+%uint = OpTypeInt 32 0
+%ptr = OpTypePointer StorageBuffer %uint
 %main = OpFunction %void None %void_fn
 %entry = OpLabel
 OpReturn


### PR DESCRIPTION
Converts typed pointers instructions to their untyped versions:
* OpTypePointer -> OpTypeUntypedPointerKHR
* OpVariable -> OpUntypedVariableKHR
* OpAccessChain -> OpUntypedAccessChainKHR
* OpInBoundsAccessChain -> OpUntypedInBoundsAccessChainKHR
* OpPtrAccessChain -> OpUntypedPtrAccessChainKHR
* OpInBoundsPtrAccessChain -> OpUntypedInBoundsPtrAccessChainKHR
* OpCopyMemory
  * this is decomposed into loads and stores
* Updates stride in cooperative matrix load/store

Supported storage classes:
* StorageBuffer
* Uniform
* PushConstant
* PhysicalStorageBuffer
* Workgroup (if workgroup memory explicit layout is enabled)

Future work:
* Add an option to convert to workgroup memory explicit layout
* Support UniformConstant for OpUntypedImageTexelPointerEXT