### PR TITLE
update validator for SPV_INTEL_rounded_divide_sqrt

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "source/diagnostic.h"
-#include "source/latest_version_glsl_std_450_header.h"
 #include "source/latest_version_opencl_std_header.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -22,6 +22,8 @@
 #include <vector>
 
 #include "source/diagnostic.h"
+#include "source/latest_version_glsl_std_450_header.h"
+#include "source/latest_version_opencl_std_header.h"
 #include "source/opcode.h"
 #include "source/spirv_constant.h"
 #include "source/spirv_target_env.h"
@@ -1823,11 +1825,23 @@ spv_result_t CheckFPRoundingModeForShaders(ValidationState_t& vstate,
 
 spv_result_t CheckFPRoundingModeForKernels(ValidationState_t& vstate,
                                            const Instruction& inst) {
-  // Validates conversion instruction to or from a floating-point type
   const auto opcode = inst.opcode();
-  if (opcode != spv::Op::OpConvertFToU && opcode != spv::Op::OpConvertFToS &&
-      opcode != spv::Op::OpConvertSToF && opcode != spv::Op::OpConvertUToF &&
-      opcode != spv::Op::OpFConvert) {
+  const bool isSqrtExtendedInstruction =
+      spvIsExtendedInstruction(inst.opcode()) &&
+      inst.ext_inst_type() == SPV_EXT_INST_TYPE_OPENCL_STD &&
+      inst.word(4) == OpenCLLIB::Sqrt;
+  if (opcode == spv::Op::OpFDiv || isSqrtExtendedInstruction) {
+    if (!vstate.HasCapability(spv::Capability::RoundedDivideSqrtINTEL)) {
+      return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
+             << "FPRoundingMode decoration can be applied to OpFDiv and "
+                "sqrt extended instructions only if the RoundedDivideSqrtINTEL "
+                "capability is enabled.";
+    }
+  } else if (opcode != spv::Op::OpConvertFToU &&
+             opcode != spv::Op::OpConvertFToS &&
+             opcode != spv::Op::OpConvertSToF &&
+             opcode != spv::Op::OpConvertUToF &&
+             opcode != spv::Op::OpFConvert) {
     return vstate.diag(SPV_ERROR_INVALID_ID, &inst)
            << "FPRoundingMode decoration can be applied only to a conversion "
               "instruction to or from a floating-point type.";

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -5369,6 +5369,112 @@ TEST_F(ValidateDecorations, KernelFPRoundingModeBadMode) {
                 "instruction to or from a floating-point type."));
 }
 
+TEST_F(ValidateDecorations, KernelFPRoundingModeDivideBad) {
+  std::string spirv = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+               OpDecorate %out_float FPRoundingMode RTE
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+   %functype = OpTypeFunction %void %float
+     %kernel = OpFunction %void None %functype
+   %in_float = OpFunctionParameter %float
+      %entry = OpLabel
+  %out_float = OpFDiv %float %in_float %in_float
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            ValidateAndRetrieveValidationState(SPV_ENV_UNIVERSAL_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FPRoundingMode decoration can be applied to OpFDiv "
+                        "and sqrt extended instructions only if the "
+                        "RoundedDivideSqrtINTEL capability is enabled."));
+}
+
+TEST_F(ValidateDecorations, KernelFPRoundingModeDivideGood) {
+  std::string spirv = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability RoundedDivideSqrtINTEL
+               OpExtension "SPV_INTEL_rounded_divide_sqrt"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+               OpDecorate %out_float FPRoundingMode RTE
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+   %functype = OpTypeFunction %void %float
+     %kernel = OpFunction %void None %functype
+   %in_float = OpFunctionParameter %float
+      %entry = OpLabel
+  %out_float = OpFDiv %float %in_float %in_float
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_0);
+  EXPECT_EQ(SPV_SUCCESS,
+            ValidateAndRetrieveValidationState(SPV_ENV_UNIVERSAL_1_0));
+}
+
+TEST_F(ValidateDecorations, KernelFPRoundingModeSqrtBad) {
+  std::string spirv = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+     %opencl = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+               OpDecorate %out_float FPRoundingMode RTE
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+   %functype = OpTypeFunction %void %float
+     %kernel = OpFunction %void None %functype
+   %in_float = OpFunctionParameter %float
+      %entry = OpLabel
+  %out_float = OpExtInst %float %opencl sqrt %in_float
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID,
+            ValidateAndRetrieveValidationState(SPV_ENV_UNIVERSAL_1_0));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FPRoundingMode decoration can be applied to OpFDiv "
+                        "and sqrt extended instructions only if the "
+                        "RoundedDivideSqrtINTEL capability is enabled."));
+}
+
+TEST_F(ValidateDecorations, KernelFPRoundingModeSqrtGood) {
+  std::string spirv = R"(
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability RoundedDivideSqrtINTEL
+               OpExtension "SPV_INTEL_rounded_divide_sqrt"
+     %opencl = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+               OpDecorate %out_float FPRoundingMode RTE
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+   %functype = OpTypeFunction %void %float
+     %kernel = OpFunction %void None %functype
+   %in_float = OpFunctionParameter %float
+      %entry = OpLabel
+  %out_float = OpExtInst %float %opencl sqrt %in_float
+               OpReturn
+               OpFunctionEnd
+  )";
+
+  CompileSuccessfully(spirv, SPV_ENV_UNIVERSAL_1_0);
+  EXPECT_EQ(SPV_SUCCESS,
+            ValidateAndRetrieveValidationState(SPV_ENV_UNIVERSAL_1_0));
+}
+
 TEST_F(ValidateDecorations, GroupDecorateTargetsDecorationGroup) {
   std::string spirv = R"(
 OpCapability Shader


### PR DESCRIPTION
The SPV_INTEL_rounded_divide_sqrt extension allows an FPRoundingMode decoration on divide and square root instructions.  This PR updates the validator so SPIR-V modules using this extension are not considered invalid.