### PR TITLE
spirv-opt: fix handling of non-semantic instructions that succeed graphs

### DIFF
--- a/source/opt/graph.cpp
+++ b/source/opt/graph.cpp
@@ -37,6 +37,12 @@ Graph* Graph::Clone(IRContext* ctx) const {
 
   clone->SetGraphEnd(std::unique_ptr<Instruction>(EndInst()->Clone(ctx)));
 
+  clone->non_semantic_.reserve(non_semantic_.size());
+  for (const auto& i : non_semantic_) {
+    clone->AddNonSemanticInstruction(
+        std::unique_ptr<Instruction>(i->Clone(ctx)));
+  }
+
   return clone;
 }
 
@@ -44,7 +50,6 @@ void Graph::ForEachInst(const std::function<void(Instruction*)>& f,
                         bool run_on_debug_line_insts,
                         bool run_on_non_semantic_insts) {
   (void)run_on_debug_line_insts;
-  (void)run_on_non_semantic_insts;
 
   f(def_inst_.get());
 
@@ -61,13 +66,18 @@ void Graph::ForEachInst(const std::function<void(Instruction*)>& f,
   }
 
   f(end_inst_.get());
+
+  if (run_on_non_semantic_insts) {
+    for (auto& inst : non_semantic_) {
+      f(inst.get());
+    }
+  }
 }
 
 void Graph::ForEachInst(const std::function<void(const Instruction*)>& f,
                         bool run_on_debug_line_insts,
                         bool run_on_non_semantic_insts) const {
   (void)run_on_debug_line_insts;
-  (void)run_on_non_semantic_insts;
 
   f(def_inst_.get());
 
@@ -84,6 +94,12 @@ void Graph::ForEachInst(const std::function<void(const Instruction*)>& f,
   }
 
   f(end_inst_.get());
+
+  if (run_on_non_semantic_insts) {
+    for (auto& inst : non_semantic_) {
+      f(inst.get());
+    }
+  }
 }
 
 }  // namespace opt

--- a/source/opt/graph.h
+++ b/source/opt/graph.h
@@ -45,6 +45,10 @@ struct Graph {
   // Appends an output to this graph.
   inline void AddOutput(std::unique_ptr<Instruction> inst);
 
+  // Add a non-semantic instruction that succeeds this graph in the module.
+  // These instructions are maintained in the order they are added.
+  inline void AddNonSemanticInstruction(std::unique_ptr<Instruction> inst);
+
   // Saves the given graph end instruction.
   void SetGraphEnd(std::unique_ptr<Instruction> end_inst);
 
@@ -78,7 +82,7 @@ struct Graph {
 
   // Runs the given function |f| on instructions in this graph, in order,
   // and optionally on debug line instructions that might precede them and
-  // non-semantic instructions that succceed the function.
+  // non-semantic instructions that succeed the graph.
   void ForEachInst(const std::function<void(Instruction*)>& f,
                    bool run_on_debug_line_insts = false,
                    bool run_on_non_semantic_insts = false);
@@ -97,6 +101,8 @@ struct Graph {
   std::vector<std::unique_ptr<Instruction>> outputs_;
   // The OpGraphEnd instruction.
   std::unique_ptr<Instruction> end_inst_;
+  // Non-semantic instructions that succeed this graph.
+  std::vector<std::unique_ptr<Instruction>> non_semantic_;
 };
 
 inline Graph::Graph(std::unique_ptr<Instruction> def_inst)
@@ -112,6 +118,11 @@ inline void Graph::AddInstruction(std::unique_ptr<Instruction> inst) {
 
 inline void Graph::AddOutput(std::unique_ptr<Instruction> inst) {
   outputs_.emplace_back(std::move(inst));
+}
+
+inline void Graph::AddNonSemanticInstruction(
+    std::unique_ptr<Instruction> inst) {
+  non_semantic_.emplace_back(std::move(inst));
 }
 
 inline void Graph::SetGraphEnd(std::unique_ptr<Instruction> end_inst) {

--- a/source/opt/ir_loader.cpp
+++ b/source/opt/ir_loader.cpp
@@ -195,7 +195,7 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
     graph_ = nullptr;
   } else if (opcode == spv::Op::OpGraphConstantARM) {
     module_->AddGlobalValue(std::move(spv_inst));
-  } else if (graph_ != nullptr) {
+  } else if (graph_ != nullptr) {  // Inside graph definition
     if (opcode == spv::Op::OpGraphInputARM) {
       graph_->AddInput(std::move(spv_inst));
     } else if (opcode == spv::Op::OpGraphSetOutputARM) {
@@ -212,169 +212,175 @@ bool IrLoader::AddInstruction(const spv_parsed_instruction_t* inst) {
           return false;
       }
     }
-  } else {
-    if (function_ == nullptr) {  // Outside function definition
-      SPIRV_ASSERT(consumer_, block_ == nullptr);
-      if (opcode == spv::Op::OpCapability ||
-          opcode == spv::Op::OpConditionalCapabilityINTEL) {
-        module_->AddCapability(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpExtension ||
-                 opcode == spv::Op::OpConditionalExtensionINTEL) {
-        module_->AddExtension(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpExtInstImport) {
-        module_->AddExtInstImport(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpMemoryModel) {
-        module_->SetMemoryModel(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpSamplerImageAddressingModeNV) {
-        module_->SetSampledImageAddressMode(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpEntryPoint) {
-        module_->AddEntryPoint(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpGraphEntryPointARM) {
-        module_->AddGraphEntryPoint(std::move(spv_inst));
-      } else if (opcode == spv::Op::OpExecutionMode ||
-                 opcode == spv::Op::OpExecutionModeId) {
-        module_->AddExecutionMode(std::move(spv_inst));
-      } else if (IsDebug1Inst(opcode)) {
-        module_->AddDebug1Inst(std::move(spv_inst));
-      } else if (IsDebug2Inst(opcode)) {
-        module_->AddDebug2Inst(std::move(spv_inst));
-      } else if (IsDebug3Inst(opcode)) {
-        module_->AddDebug3Inst(std::move(spv_inst));
-      } else if (IsAnnotationInst(opcode)) {
-        module_->AddAnnotationInst(std::move(spv_inst));
-      } else if (IsTypeInst(opcode)) {
-        module_->AddType(std::move(spv_inst));
-      } else if (IsConstantInst(opcode) || opcode == spv::Op::OpVariable ||
-                 opcode == spv::Op::OpUntypedVariableKHR ||
-                 opcode == spv::Op::OpUndef) {
-        module_->AddGlobalValue(std::move(spv_inst));
-      } else if (spvIsExtendedInstruction(opcode) &&
-                 spvExtInstIsDebugInfo(inst->ext_inst_type)) {
-        module_->AddExtInstDebugInfo(std::move(spv_inst));
-      } else if (spvIsExtendedInstruction(opcode) &&
-                 spvExtInstIsNonSemantic(inst->ext_inst_type)) {
-        // If there are no functions, add the non-semantic instructions to the
-        // global values. Otherwise append it to the list of the last function.
-        auto func_begin = module_->begin();
-        auto func_end = module_->end();
-        if (func_begin == func_end) {
-          module_->AddGlobalValue(std::move(spv_inst));
-        } else {
-          (--func_end)->AddNonSemanticInstruction(std::move(spv_inst));
-        }
-      } else {
-        Errorf(consumer_, src, loc,
-               "Unhandled inst type (opcode: %d) found outside function "
-               "definition.",
-               opcode);
-        return false;
-      }
-    } else {
-      if (opcode == spv::Op::OpLoopMerge || opcode == spv::Op::OpSelectionMerge)
-        last_dbg_scope_ = DebugScope(kNoDebugScope, kNoInlinedAt);
-      if (last_dbg_scope_.GetLexicalScope() != kNoDebugScope)
-        spv_inst->SetDebugScope(last_dbg_scope_);
-      if (spvIsExtendedInstruction(opcode) &&
-          spvExtInstIsDebugInfo(inst->ext_inst_type)) {
-        const uint32_t ext_inst_index = inst->words[kExtInstSetIndex];
-        if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
-          const OpenCLDebugInfo100Instructions ext_inst_key =
-              OpenCLDebugInfo100Instructions(ext_inst_index);
-          switch (ext_inst_key) {
-            case OpenCLDebugInfo100DebugDeclare: {
-              if (block_ == nullptr)  // Inside function but outside blocks
-                function_->AddDebugInstructionInHeader(std::move(spv_inst));
-              else
-                block_->AddInstruction(std::move(spv_inst));
-              break;
-            }
-            case OpenCLDebugInfo100DebugValue: {
-              if (block_ == nullptr)  // Inside function but outside blocks
-                function_->AddDebugInstructionInHeader(std::move(spv_inst));
-              else
-                block_->AddInstruction(std::move(spv_inst));
-              break;
-            }
-            default: {
-              Errorf(consumer_, src, loc,
-                     "Debug info extension instruction other than DebugScope, "
-                     "DebugNoScope, DebugFunctionDefinition, DebugDeclare, and "
-                     "DebugValue found inside function",
-                     opcode);
-              return false;
-            }
+  } else if (function_ != nullptr) {  // Inside function definition
+    if (opcode == spv::Op::OpLoopMerge || opcode == spv::Op::OpSelectionMerge)
+      last_dbg_scope_ = DebugScope(kNoDebugScope, kNoInlinedAt);
+    if (last_dbg_scope_.GetLexicalScope() != kNoDebugScope)
+      spv_inst->SetDebugScope(last_dbg_scope_);
+    if (spvIsExtendedInstruction(opcode) &&
+        spvExtInstIsDebugInfo(inst->ext_inst_type)) {
+      const uint32_t ext_inst_index = inst->words[kExtInstSetIndex];
+      if (inst->ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_DEBUGINFO_100) {
+        const OpenCLDebugInfo100Instructions ext_inst_key =
+            OpenCLDebugInfo100Instructions(ext_inst_index);
+        switch (ext_inst_key) {
+          case OpenCLDebugInfo100DebugDeclare: {
+            if (block_ == nullptr)  // Inside function but outside blocks
+              function_->AddDebugInstructionInHeader(std::move(spv_inst));
+            else
+              block_->AddInstruction(std::move(spv_inst));
+            break;
           }
-        } else if (inst->ext_inst_type ==
-                   SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
-          const NonSemanticShaderDebugInfoInstructions ext_inst_key =
-              NonSemanticShaderDebugInfoInstructions(ext_inst_index);
-          switch (ext_inst_key) {
-            case NonSemanticShaderDebugInfoDebugDeclare:
-            case NonSemanticShaderDebugInfoDebugValue:
-            case NonSemanticShaderDebugInfoDebugScope:
-            case NonSemanticShaderDebugInfoDebugNoScope:
-            case NonSemanticShaderDebugInfoDebugFunctionDefinition: {
-              if (block_ == nullptr) {  // Inside function but outside blocks
-                Errorf(consumer_, src, loc,
-                       "Debug info extension instruction found inside function "
-                       "but outside block",
-                       opcode);
-              } else {
-                block_->AddInstruction(std::move(spv_inst));
-              }
-              break;
-            }
-            default: {
-              Errorf(consumer_, src, loc,
-                     "Debug info extension instruction other than DebugScope, "
-                     "DebugNoScope, DebugDeclare, and DebugValue found inside "
-                     "function",
-                     opcode);
-              return false;
-            }
+          case OpenCLDebugInfo100DebugValue: {
+            if (block_ == nullptr)  // Inside function but outside blocks
+              function_->AddDebugInstructionInHeader(std::move(spv_inst));
+            else
+              block_->AddInstruction(std::move(spv_inst));
+            break;
           }
-        } else {
-          const DebugInfoInstructions ext_inst_key =
-              DebugInfoInstructions(ext_inst_index);
-          switch (ext_inst_key) {
-            case DebugInfoDebugDeclare: {
-              if (block_ == nullptr)  // Inside function but outside blocks
-                function_->AddDebugInstructionInHeader(std::move(spv_inst));
-              else
-                block_->AddInstruction(std::move(spv_inst));
-              break;
-            }
-            case DebugInfoDebugValue: {
-              if (block_ == nullptr)  // Inside function but outside blocks
-                function_->AddDebugInstructionInHeader(std::move(spv_inst));
-              else
-                block_->AddInstruction(std::move(spv_inst));
-              break;
-            }
-            default: {
-              Errorf(consumer_, src, loc,
-                     "Debug info extension instruction other than DebugScope, "
-                     "DebugNoScope, DebugDeclare, and DebugValue found inside "
-                     "function",
-                     opcode);
-              return false;
-            }
-          }
-        }
-      } else {
-        if (block_ == nullptr) {  // Inside function but outside blocks
-          if (opcode != spv::Op::OpFunctionParameter) {
+          default: {
             Errorf(consumer_, src, loc,
-                   "Non-OpFunctionParameter (opcode: %d) found inside "
-                   "function but outside basic block",
+                   "Debug info extension instruction other than DebugScope, "
+                   "DebugNoScope, DebugFunctionDefinition, DebugDeclare, and "
+                   "DebugValue found inside function",
                    opcode);
             return false;
           }
-          function_->AddParameter(std::move(spv_inst));
-        } else {
-          block_->AddInstruction(std::move(spv_inst));
+        }
+      } else if (inst->ext_inst_type ==
+                 SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100) {
+        const NonSemanticShaderDebugInfoInstructions ext_inst_key =
+            NonSemanticShaderDebugInfoInstructions(ext_inst_index);
+        switch (ext_inst_key) {
+          case NonSemanticShaderDebugInfoDebugDeclare:
+          case NonSemanticShaderDebugInfoDebugValue:
+          case NonSemanticShaderDebugInfoDebugScope:
+          case NonSemanticShaderDebugInfoDebugNoScope:
+          case NonSemanticShaderDebugInfoDebugFunctionDefinition: {
+            if (block_ == nullptr) {  // Inside function but outside blocks
+              Errorf(consumer_, src, loc,
+                     "Debug info extension instruction found inside function "
+                     "but outside block",
+                     opcode);
+            } else {
+              block_->AddInstruction(std::move(spv_inst));
+            }
+            break;
+          }
+          default: {
+            Errorf(consumer_, src, loc,
+                   "Debug info extension instruction other than DebugScope, "
+                   "DebugNoScope, DebugDeclare, and DebugValue found inside "
+                   "function",
+                   opcode);
+            return false;
+          }
+        }
+      } else {
+        const DebugInfoInstructions ext_inst_key =
+            DebugInfoInstructions(ext_inst_index);
+        switch (ext_inst_key) {
+          case DebugInfoDebugDeclare: {
+            if (block_ == nullptr)  // Inside function but outside blocks
+              function_->AddDebugInstructionInHeader(std::move(spv_inst));
+            else
+              block_->AddInstruction(std::move(spv_inst));
+            break;
+          }
+          case DebugInfoDebugValue: {
+            if (block_ == nullptr)  // Inside function but outside blocks
+              function_->AddDebugInstructionInHeader(std::move(spv_inst));
+            else
+              block_->AddInstruction(std::move(spv_inst));
+            break;
+          }
+          default: {
+            Errorf(consumer_, src, loc,
+                   "Debug info extension instruction other than DebugScope, "
+                   "DebugNoScope, DebugDeclare, and DebugValue found inside "
+                   "function",
+                   opcode);
+            return false;
+          }
         }
       }
+    } else {
+      if (block_ == nullptr) {  // Inside function but outside blocks
+        if (opcode != spv::Op::OpFunctionParameter) {
+          Errorf(consumer_, src, loc,
+                 "Non-OpFunctionParameter (opcode: %d) found inside "
+                 "function but outside basic block",
+                 opcode);
+          return false;
+        }
+        function_->AddParameter(std::move(spv_inst));
+      } else {
+        block_->AddInstruction(std::move(spv_inst));
+      }
+    }
+  } else {  // Outside function or graph definition
+    SPIRV_ASSERT(consumer_, function_ == nullptr);
+    SPIRV_ASSERT(consumer_, block_ == nullptr);
+    SPIRV_ASSERT(consumer_, graph_ == nullptr);
+    if (opcode == spv::Op::OpCapability ||
+        opcode == spv::Op::OpConditionalCapabilityINTEL) {
+      module_->AddCapability(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpExtension ||
+               opcode == spv::Op::OpConditionalExtensionINTEL) {
+      module_->AddExtension(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpExtInstImport) {
+      module_->AddExtInstImport(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpMemoryModel) {
+      module_->SetMemoryModel(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpSamplerImageAddressingModeNV) {
+      module_->SetSampledImageAddressMode(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpEntryPoint) {
+      module_->AddEntryPoint(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpGraphEntryPointARM) {
+      module_->AddGraphEntryPoint(std::move(spv_inst));
+    } else if (opcode == spv::Op::OpExecutionMode ||
+               opcode == spv::Op::OpExecutionModeId) {
+      module_->AddExecutionMode(std::move(spv_inst));
+    } else if (IsDebug1Inst(opcode)) {
+      module_->AddDebug1Inst(std::move(spv_inst));
+    } else if (IsDebug2Inst(opcode)) {
+      module_->AddDebug2Inst(std::move(spv_inst));
+    } else if (IsDebug3Inst(opcode)) {
+      module_->AddDebug3Inst(std::move(spv_inst));
+    } else if (IsAnnotationInst(opcode)) {
+      module_->AddAnnotationInst(std::move(spv_inst));
+    } else if (IsTypeInst(opcode)) {
+      module_->AddType(std::move(spv_inst));
+    } else if (IsConstantInst(opcode) || opcode == spv::Op::OpVariable ||
+               opcode == spv::Op::OpUntypedVariableKHR ||
+               opcode == spv::Op::OpUndef) {
+      module_->AddGlobalValue(std::move(spv_inst));
+    } else if (spvIsExtendedInstruction(opcode) &&
+               spvExtInstIsDebugInfo(inst->ext_inst_type)) {
+      module_->AddExtInstDebugInfo(std::move(spv_inst));
+    } else if (spvIsExtendedInstruction(opcode) &&
+               spvExtInstIsNonSemantic(inst->ext_inst_type)) {
+      // If there are no functions or graphs, add the non-semantic instructions
+      // to the global values. Otherwise append it to the list of the last
+      // function or graph.
+      auto func_begin = module_->begin();
+      auto func_end = module_->end();
+      // graphs come last so we need to check first
+      if (module_->graphs().size() > 0) {
+        module_->graphs().back()->AddNonSemanticInstruction(
+            std::move(spv_inst));
+        // then check functions
+      } else if (func_begin != func_end) {
+        (--func_end)->AddNonSemanticInstruction(std::move(spv_inst));
+      } else {
+        module_->AddGlobalValue(std::move(spv_inst));
+      }
+    } else {
+      Errorf(consumer_, src, loc,
+             "Unhandled inst type (opcode: %d) found outside function "
+             "definition.",
+             opcode);
+      return false;
     }
   }
   return true;

--- a/test/opt/ir_loader_test.cpp
+++ b/test/opt/ir_loader_test.cpp
@@ -1575,6 +1575,67 @@ OpGraphEndARM
 )");
 }
 
+TEST(IrBuilder, RoundTripSimpleGraphWithBodyAndNonSemanticInstructions) {
+  DoRoundTripCheck(R"(OpCapability Shader
+OpCapability TensorsARM
+OpCapability GraphARM
+OpExtension "SPV_ARM_tensors"
+OpExtension "SPV_ARM_graph"
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "TOSA.001000.1"
+%2 = OpExtInstImport "NonSemantic.Graph.DebugInfo.1"
+OpMemoryModel Logical GLSL450
+%3 = OpString "main"
+%4 = OpString "avg_pool2d"
+%5 = OpString "input"
+OpDecorate %6 DescriptorSet 0
+OpDecorate %6 Binding 0
+OpDecorate %7 DescriptorSet 0
+OpDecorate %7 Binding 1
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%float = OpTypeFloat 32
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_10 = OpConstant %uint 10
+%float_0 = OpConstant %float 0
+%_arr_uint_uint_1 = OpTypeArray %uint %uint_1
+%_arr_uint_uint_4 = OpTypeArray %uint %uint_4
+%21 = OpConstantComposite %_arr_uint_uint_1 %uint_1
+%22 = OpConstantComposite %_arr_uint_uint_1 %uint_2
+%23 = OpConstantComposite %_arr_uint_uint_1 %uint_4
+%24 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_10 %uint_10 %uint_3
+%25 = OpConstantComposite %_arr_uint_uint_4 %uint_1 %uint_5 %uint_5 %uint_3
+%26 = OpTypeTensorARM %float %uint_1 %21
+%27 = OpTypeTensorARM %uint %uint_1 %22
+%28 = OpTypeTensorARM %uint %uint_1 %23
+%29 = OpTypeTensorARM %float %uint_4 %24
+%30 = OpTypeTensorARM %float %uint_4 %25
+%_ptr_UniformConstant_29 = OpTypePointer UniformConstant %29
+%_ptr_UniformConstant_30 = OpTypePointer UniformConstant %30
+%33 = OpConstantComposite %28 %uint_3 %uint_3
+%34 = OpConstantComposite %28 %uint_2 %uint_2
+%35 = OpConstantComposite %29 %uint_0 %uint_0 %uint_0 %uint_0
+%36 = OpConstantComposite %27 %float_0
+%37 = OpTypeGraphARM 1 %29 %30
+%6 = OpVariable %_ptr_UniformConstant_29 UniformConstant
+%7 = OpVariable %_ptr_UniformConstant_30 UniformConstant
+OpGraphEntryPointARM %38 "main" %6 %7
+%38 = OpGraphARM %37
+%39 = OpGraphInputARM %29 %uint_0
+%40 = OpExtInst %30 %1 AVG_POOL2D %33 %34 %35 %uint_2 %39 %36 %36
+OpGraphSetOutputARM %40 %uint_0
+OpGraphEndARM
+%41 = OpExtInst %void %2 DebugGraph %38 %3
+%42 = OpExtInst %void %2 DebugTensor %39 %5
+%43 = OpExtInst %void %2 DebugOperation %41 %4 %39
+)");
+}
+
 TEST(IrBuilder, GraphInsideGraph) {
   DoErrorMessageCheck("%2 = OpGraphARM %1\n%3 = OpGraphARM %2",
                       "graph inside graph", 2);


### PR DESCRIPTION
They were moved to before graphs in modules with no functions which broke round-trippability with no changes and also introduced illegal forward references.

The changes in ir_loader.cpp are mostly if/else nesting changes to reduce the number of nesting levels, improve readability and keep the logic to handle non semantic instructions in one place.