### PR TITLE
[val] Disallow duplicate targets for OpGroupDecorate

### DIFF
--- a/source/val/validate_annotation.cpp
+++ b/source/val/validate_annotation.cpp
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <unordered_set>
+
 #include "source/opcode.h"
 #include "source/spirv_target_env.h"
 #include "source/val/instruction.h"
@@ -548,6 +550,7 @@ spv_result_t ValidateGroupDecorate(ValidationState_t& _,
            << "OpGroupDecorate Decoration group <id> "
            << _.getIdName(decoration_group_id) << " is not a decoration group.";
   }
+  std::unordered_set<uint32_t> seen;
   for (unsigned i = 1; i < inst->operands().size(); ++i) {
     auto target_id = inst->GetOperandAs<uint32_t>(i);
     auto target = _.FindDef(target_id);
@@ -555,6 +558,10 @@ spv_result_t ValidateGroupDecorate(ValidationState_t& _,
       return _.diag(SPV_ERROR_INVALID_ID, inst)
              << "OpGroupDecorate may not target OpDecorationGroup <id> "
              << _.getIdName(target_id);
+    }
+    if (!seen.insert(target_id).second) {
+      return _.diag(SPV_ERROR_INVALID_ID, inst)
+             << "Targets contains duplicate id " << _.getIdName(target_id);
     }
   }
   return SPV_SUCCESS;

--- a/test/val/val_annotation_test.cpp
+++ b/test/val/val_annotation_test.cpp
@@ -273,6 +273,26 @@ OpDecorate %ptr ArrayStride 4
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(DecorationTest, DecorationGroupDuplicateTarget) {
+  const std::string text = R"(
+               OpCapability ClipDistance
+               OpCapability Linkage
+               OpMemoryModel Logical Simple
+          %4 = OpDecorationGroup
+               OpGroupDecorate %4 %2 %2
+       %void = OpTypeVoid
+         %19 = OpTypeFunction %void
+          %2 = OpFunction %void None %19
+  %553590816 = OpLabel
+               OpUnreachable
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_UNIVERSAL_1_0);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Targets contains duplicate id '2[%2]'"));
+}
 using MemberOnlyDecorations = spvtest::ValidateBase<std::string>;
 
 TEST_P(MemberOnlyDecorations, MemberDecoration) {


### PR DESCRIPTION
Fix https://crbug.com/oss-fuzz/497811679

* Check for duplicate targets in OpGroupDecorate