### PR TITLE
optimizer: avoid writing instructions that have too many words

### DIFF
--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -205,6 +205,13 @@ bool Instruction::HasBranchWeights() const {
 void Instruction::ToBinaryWithoutAttachedDebugInsts(
     std::vector<uint32_t>* binary) const {
   const uint32_t num_words = 1 + NumOperandWords();
+  assert(num_words <= 65535 && "too many words in instruction");
+  if (num_words > 65535) {
+    // Generate an invalid instruction encoding, indicating 0 words in the,
+    // which is always invalid.
+    binary->push_back(static_cast<uint16_t>(opcode_));
+    return;
+  }
   binary->push_back((num_words << 16) | static_cast<uint16_t>(opcode_));
   for (const auto& operand : operands_) {
     binary->insert(binary->end(), operand.words.begin(), operand.words.end());

--- a/test/opt/instruction_test.cpp
+++ b/test/opt/instruction_test.cpp
@@ -315,6 +315,46 @@ TEST(InstructionTest, LessThanOperator) {
   EXPECT_TRUE(i2 < *clone);
 }
 
+TEST(InstructionTest, TooBigInstruction_64k_ReleaseBuild) {
+  IRContext context(SPV_ENV_UNIVERSAL_1_0, nullptr);
+#ifdef NDEBUG
+  // Add 65535 operands, so the instruction word count is 65536.
+  const uint32_t num_operand_words = 65535;
+  Instruction::OperandList operands;
+  operands.reserve(num_operand_words);
+  for (uint32_t i = 0; i < num_operand_words; i++) {
+    operands.push_back(Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {i}));
+  }
+  Instruction inst(&context, spv::Op::OpNop, 0, 0, operands);
+  inst.SetInOperands(std::move(operands));
+
+  std::vector<uint32_t> binary;
+  inst.ToBinaryWithoutAttachedDebugInsts(&binary);
+  EXPECT_THAT(binary,
+              Eq(std::vector<uint32_t>{static_cast<uint32_t>(spv::Op::OpNop)}));
+#endif
+}
+
+TEST(InstructionTest, TooBigInstruction_64kPlus1_ReleaseBuild) {
+  IRContext context(SPV_ENV_UNIVERSAL_1_0, nullptr);
+#ifdef NDEBUG
+  // Add 65536 operands, so the instruction word count is 65537.
+  const uint32_t num_operand_words = 65536;
+  Instruction::OperandList operands;
+  operands.reserve(num_operand_words);
+  for (uint32_t i = 0; i < num_operand_words; i++) {
+    operands.push_back(Operand(SPV_OPERAND_TYPE_LITERAL_INTEGER, {i}));
+  }
+  Instruction inst(&context, spv::Op::OpNop, 0, 0, {});
+  inst.SetInOperands(std::move(operands));
+
+  std::vector<uint32_t> binary;
+  inst.ToBinaryWithoutAttachedDebugInsts(&binary);
+  EXPECT_THAT(binary,
+              Eq(std::vector<uint32_t>{static_cast<uint32_t>(spv::Op::OpNop)}));
+#endif
+}
+
 TEST_F(DescriptorTypeTest, StorageImage) {
   const std::string text = R"(
                OpCapability Shader


### PR DESCRIPTION
If an instruction has too many words, in violation of the SPIR-V spec, then when converting to a binary:
- in a debug build, assert out
- in a release build, write a nonsense instruction that has a word count of 0.

crbug.com/513916669