### PR TITLE
[val] Allow TileImageEXT variables to be arrays

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -1149,7 +1149,12 @@ spv_result_t ValidateVariableTileImageEXT(ValidationState_t& _,
 
   auto result_type = _.FindDef(inst->type_id());
   if (result_type->opcode() == spv::Op::OpTypePointer) {
-    const auto pointee_type = _.FindDef(result_type->GetOperandAs<uint32_t>(2));
+    auto pointee_type = _.FindDef(result_type->GetOperandAs<uint32_t>(2));
+
+    while (pointee_type && pointee_type->opcode() == spv::Op::OpTypeArray) {
+      pointee_type = _.FindDef(pointee_type->GetOperandAs<uint32_t>(1));
+    }
+
     if (pointee_type && pointee_type->opcode() == spv::Op::OpTypeImage) {
       spv::Dim dim = static_cast<spv::Dim>(pointee_type->word(3));
       if (dim != spv::Dim::TileImageDataEXT) {


### PR DESCRIPTION
Handle the case where 'tile image variables' in the following spec refer to an  `OpTypeArray` to tile images, as pointed out in https://github.com/KhronosGroup/SPIRV-Tools/issues/6593#issuecomment-4659916241.

> The TileImageEXT Storage Class must only be used for declaring tile image variables