### PR TITLE
[val] Tie Int64ImageEXT requirement to R64 image format

### DIFF
--- a/source/val/validate_image.cpp
+++ b/source/val/validate_image.cpp
@@ -961,13 +961,6 @@ spv_result_t ValidateTypeImage(ValidationState_t& _, const Instruction* inst) {
            << "Corrupt image type definition";
   }
 
-  if (_.IsIntScalarType(info.sampled_type, 64) &&
-      !_.HasCapability(spv::Capability::Int64ImageEXT)) {
-    return _.diag(SPV_ERROR_INVALID_DATA, inst)
-           << "Capability Int64ImageEXT is required when using Sampled Type of "
-              "64-bit int";
-  }
-
   const auto target_env = _.context()->target_env;
   if (spvIsVulkanEnv(target_env)) {
     if (!_.IsFloatScalarType(info.sampled_type, 32) &&

--- a/test/val/val_image_test.cpp
+++ b/test/val/val_image_test.cpp
@@ -610,10 +610,8 @@ OpFunctionEnd
 
   const spv_target_env env = SPV_ENV_VULKAN_1_0;
   CompileSuccessfully(code, env);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability Int64ImageEXT is required when using "
-                        "Sampled Type of 64-bit int"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(), Eq(""));
 }
 
 TEST_F(ValidateImage, TypeImageI64SampledTypeVulkan) {
@@ -645,10 +643,8 @@ OpFunctionEnd
 
   const spv_target_env env = SPV_ENV_VULKAN_1_0;
   CompileSuccessfully(code, env);
-  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(env));
-  EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("Capability Int64ImageEXT is required when using "
-                        "Sampled Type of 64-bit int"));
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(), Eq(""));
 }
 
 TEST_F(ValidateImage, TypeImageU64SampledTypeVulkan) {
@@ -667,6 +663,23 @@ OpFunctionEnd
   CompileSuccessfully(code, env);
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions(env));
   EXPECT_THAT(getDiagnosticString(), Eq(""));
+}
+
+TEST_F(ValidateImage, TypeImageR64FormatNoCapabilityVulkan) {
+  const std::string code = GetShaderHeader() + R"(
+%img_type = OpTypeImage %s64 2D 0 0 0 2 R64i
+%main = OpFunction %void None %func
+%main_lab = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  const spv_target_env env = SPV_ENV_VULKAN_1_0;
+  CompileSuccessfully(code, env);
+  ASSERT_EQ(SPV_ERROR_INVALID_CAPABILITY, ValidateInstructions(env));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Operand 8 of TypeImage requires one of these "
+                        "capabilities: Int64ImageEXT"));
 }
 
 TEST_F(ValidateImage, TypeImageF32SampledTypeVulkan) {


### PR DESCRIPTION
The capability is required by the R64i/R64ui Image Format operand, not by a 64-bit Sampled Type

Related SPIRV-LLVM-Translator PR that fixes this issue there: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3773