### PR TITLE
cast to unsigned char before ctype calls on untrusted input

### DIFF
--- a/source/opt/convert_to_sampled_image_pass.cpp
+++ b/source/opt/convert_to_sampled_image_pass.cpp
@@ -36,7 +36,8 @@ using utils::ParseNumber;
 // Returns true if the given char is ':', '\0' or considered as blank space
 // (i.e.: '\n', '\r', '\v', '\t', '\f' and ' ').
 bool IsSeparator(char ch) {
-  return std::strchr(":\0", ch) || std::isspace(ch) != 0;
+  return std::strchr(":\0", ch) ||
+         std::isspace(static_cast<unsigned char>(ch)) != 0;
 }
 
 // Reads characters starting from |str| until it meets a separator. Parses a
@@ -436,7 +437,7 @@ ConvertToSampledImagePass::ParseDescriptorSetBindingPairsString(
     descriptor_set_binding_pairs->push_back({descriptor_set, binding});
 
     // Skip trailing spaces.
-    while (std::isspace(*str)) str++;
+    while (std::isspace(static_cast<unsigned char>(*str))) str++;
   }
 
   return descriptor_set_binding_pairs;

--- a/source/opt/set_spec_constant_default_value_pass.cpp
+++ b/source/opt/set_spec_constant_default_value_pass.cpp
@@ -363,7 +363,8 @@ Pass::Status SetSpecConstantDefaultValuePass::Process() {
 // Returns true if the given char is ':', '\0' or considered as blank space
 // (i.e.: '\n', '\r', '\v', '\t', '\f' and ' ').
 bool IsSeparator(char ch) {
-  return std::strchr(":\0", ch) || std::isspace(ch) != 0;
+  return std::strchr(":\0", ch) ||
+         std::isspace(static_cast<unsigned char>(ch)) != 0;
 }
 
 std::unique_ptr<SetSpecConstantDefaultValuePass::SpecIdToValueStrMap>
@@ -375,7 +376,8 @@ SetSpecConstantDefaultValuePass::ParseDefaultValuesString(const char* str) {
   // The parsing loop, break when points to the end.
   while (*str) {
     // Find the spec id.
-    while (std::isspace(*str)) str++;  // skip leading spaces.
+    while (std::isspace(static_cast<unsigned char>(*str)))
+      str++;  // skip leading spaces.
     const char* entry_begin = str;
     while (!IsSeparator(*str)) str++;
     const char* entry_end = str;
@@ -407,7 +409,7 @@ SetSpecConstantDefaultValuePass::ParseDefaultValuesString(const char* str) {
     (*spec_id_to_value)[spec_id] = std::string(val_begin, val_end - val_begin);
 
     // Skip trailing spaces.
-    while (std::isspace(*str)) str++;
+    while (std::isspace(static_cast<unsigned char>(*str))) str++;
   }
 
   return spec_id_to_value;

--- a/source/spirv_target_env.cpp
+++ b/source/spirv_target_env.cpp
@@ -226,7 +226,8 @@ bool spvReadEnvironmentFromText(const std::vector<char>& text,
         char minor = text[minor_digit_pos];
         char next_char =
             minor_digit_pos + 1 < text.size() ? text[minor_digit_pos + 1] : 0;
-        if (std::isdigit(minor) && !std::isdigit(next_char)) {
+        if (std::isdigit(static_cast<unsigned char>(minor)) &&
+            !std::isdigit(static_cast<unsigned char>(next_char))) {
           const auto index = minor - '0';
           assert(index >= 0);
           if (static_cast<size_t>(index) < ordered_universal_envs.size()) {
@@ -243,7 +244,7 @@ bool spvReadEnvironmentFromText(const std::vector<char>& text,
       for (; i < text.size(); ++i) {
         if (text[i] == '\n') break;
       }
-    } else if (!std::isspace(c)) {
+    } else if (!std::isspace(static_cast<unsigned char>(c))) {
       // Allow blanks, but end the search if we find something else.
       break;
     }

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -45,7 +45,7 @@
 #include "spirv-tools/libspirv.h"
 
 bool spvIsValidIDCharacter(const char value) {
-  return value == '_' || 0 != ::isalnum(value);
+  return value == '_' || 0 != ::isalnum(static_cast<unsigned char>(value));
 }
 
 // Returns true if the given string represents a valid ID name.

--- a/tools/io.cpp
+++ b/tools/io.cpp
@@ -96,7 +96,9 @@ enum class HexMode {
 
 // Whether a character should be skipped as whitespace / separator /
 // end-of-file.
-bool IsSpace(char c) { return isspace(c) || c == ',' || c == '\0'; }
+bool IsSpace(char c) {
+  return isspace(static_cast<unsigned char>(c)) || c == ',' || c == '\0';
+}
 
 bool IsHexStream(const std::vector<char>& stream) {
   for (char c : stream) {
@@ -115,7 +117,8 @@ bool IsHexStream(const std::vector<char>& stream) {
 
 bool MatchIgnoreCase(const char* token, const char* expect, size_t len) {
   for (size_t i = 0; i < len; ++i) {
-    if (tolower(token[i]) != tolower(expect[i])) {
+    if (tolower(static_cast<unsigned char>(token[i])) !=
+        tolower(static_cast<unsigned char>(expect[i]))) {
       return false;
     }
   }
@@ -258,7 +261,7 @@ class HexTokenizer {
       }
 
       token_chars[i] = c;
-      if (!isxdigit(c)) {
+      if (!isxdigit(static_cast<unsigned char>(c))) {
         ParseError("encountered non-hex character");
       }
     }
@@ -272,7 +275,7 @@ class HexTokenizer {
   // Consume one hex digit.
   char NextHexDigit() {
     char c = Next();
-    if (!isxdigit(c)) {
+    if (!isxdigit(static_cast<unsigned char>(c))) {
       ParseError("encountered non-hex character");
     }
     return c;


### PR DESCRIPTION
ctype functions get a plain `char` that can be negative when the byte is >= 0x80, which is undefined for everything but unsigned char and EOF:
- text.cpp `spvIsValidIDCharacter` and spirv_target_env.cpp version scan run over raw assembly text
- the spec-constant and sampled-image option parsers walk an arbitrary `const char*`
- io.cpp hex tokenizer feeds file bytes straight into isspace/tolower/isxdigit
cast each argument to unsigned char at the call site. hex_float.h already does the right thing via istream::peek (returns int) so it is left alone.