### PR TITLE
bazel flow: force cache regeneration

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.bazel/cache
-          key: bazel-cache-${{ runner.os }}
+          # Force a new cache version by updating the number in 'generationN'
+          key: bazel-cache-${{ runner.os }}-generation2
       - name: Build All
         run: bazel --output_user_root=~/.bazel/cache build //...
       - name: Test All


### PR DESCRIPTION
Use a new cache key to force the cache to be regenerated.

Fixes: #6741