### PR TITLE
update protobuf to recent release

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,8 +9,8 @@ vars = {
 
   'googletest_revision': '7140cd416cecd7462a8aae488024abeee55598e4',
 
-  # Use protobufs before they gained the dependency on abseil
-  'protobuf_revision': 'v21.12',
+  # Use a recent protobuf, which can depend on abseil
+  'protobuf_revision': '35cd01f9fe9afbeea38cc7b979a3b6bfcde82c03',
 
   're2_revision': '972a15cedd008d846f1a39b2e88ce48d7f166cbd',
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ option, like so:
 
 ```sh
 # In <spirv-dir> (the SPIRV-Tools repo root):
-git clone --depth=1 --branch v3.13.0.1 https://github.com/protocolbuffers/protobuf external/protobuf
+git clone --depth=1 --branch v35.1 https://github.com/protocolbuffers/protobuf external/protobuf
 
 # In your build directory:
 cmake [-G <platform-generator>] <spirv-dir> -DSPIRV_BUILD_FUZZER=ON

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -467,7 +467,7 @@ if(SPIRV_BUILD_FUZZER)
         PUBLIC ${SPIRV_TOOLS_FULL_VISIBILITY}
         PUBLIC SPIRV-Tools-opt
         PUBLIC SPIRV-Tools-reduce
-        PUBLIC protobuf::libprotobuf)
+        PUBLIC $<BUILD_LOCAL_INTERFACE:protobuf::libprotobuf>)
 
   set_property(TARGET SPIRV-Tools-fuzz PROPERTY FOLDER "SPIRV-Tools libraries")
   spvtools_check_symbol_exports(SPIRV-Tools-fuzz)

--- a/source/fuzz/protobufs/spirvfuzz_protobufs.h
+++ b/source/fuzz/protobufs/spirvfuzz_protobufs.h
@@ -48,7 +48,7 @@
 // are directly included.  This is so that they can be compiled in a manner
 // where warnings are ignored.
 
-#include "google/protobuf/util/json_util.h"
+#include "google/protobuf/json/json.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "source/fuzz/protobufs/spvtoolsfuzz.pb.h"
 

--- a/test/fuzz/fuzz_test_util.cpp
+++ b/test/fuzz/fuzz_test_util.cpp
@@ -137,7 +137,7 @@ void DumpTransformationsBinary(
     const char* filename) {
   std::ofstream transformations_file;
   transformations_file.open(filename, std::ios::out | std::ios::binary);
-  transformations.SerializeToOstream(&transformations_file);
+  (void)transformations.SerializeToOstream(&transformations_file);
   transformations_file.close();
 }
 
@@ -145,9 +145,9 @@ void DumpTransformationsJson(
     const protobufs::TransformationSequence& transformations,
     const char* filename) {
   std::string json_string;
-  auto json_options = google::protobuf::util::JsonPrintOptions();
+  auto json_options = google::protobuf::json::PrintOptions();
   json_options.add_whitespace = true;
-  auto json_generation_status = google::protobuf::util::MessageToJsonString(
+  auto json_generation_status = google::protobuf::json::MessageToJsonString(
       transformations, &json_string, json_options);
   if (json_generation_status.ok()) {
     std::ofstream transformations_json_file(filename);

--- a/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
+++ b/test/fuzz/transformation_replace_constant_with_uniform_test.cpp
@@ -795,8 +795,6 @@ TEST(TransformationReplaceConstantWithUniformTest, NoConstantPresentForIndex) {
                                                kConsoleMessageConsumer));
   TransformationContext transformation_context(
       MakeUnique<FactManager>(context.get()), validator_options);
-  protobufs::UniformBufferElementDescriptor blockname_0 =
-      MakeUniformBufferElementDescriptor(0, 0, {0});
   protobufs::UniformBufferElementDescriptor blockname_9 =
       MakeUniformBufferElementDescriptor(0, 0, {1});
 

--- a/tools/fuzz/fuzz.cpp
+++ b/tools/fuzz/fuzz.cpp
@@ -662,7 +662,7 @@ void DumpTransformationsBinary(
     const char* filename) {
   std::ofstream transformations_file;
   transformations_file.open(filename, std::ios::out | std::ios::binary);
-  transformations.SerializeToOstream(&transformations_file);
+  (void)transformations.SerializeToOstream(&transformations_file);
   transformations_file.close();
 }
 
@@ -672,9 +672,9 @@ void DumpTransformationsJson(
     const spvtools::fuzz::protobufs::TransformationSequence& transformations,
     const char* filename) {
   std::string json_string;
-  auto json_options = google::protobuf::util::JsonPrintOptions();
+  auto json_options = google::protobuf::json::PrintOptions();
   json_options.add_whitespace = true;
-  auto json_generation_status = google::protobuf::util::MessageToJsonString(
+  auto json_generation_status = google::protobuf::json::MessageToJsonString(
       transformations, &json_string, json_options);
   if (json_generation_status.ok()) {
     std::ofstream transformations_json_file(filename);
@@ -727,7 +727,7 @@ int main(int argc, const char** argv) {
     std::string facts_json_string((std::istreambuf_iterator<char>(facts_input)),
                                   std::istreambuf_iterator<char>());
     facts_input.close();
-    if (!google::protobuf::util::JsonStringToMessage(facts_json_string,
+    if (!google::protobuf::json::JsonStringToMessage(facts_json_string,
                                                      &initial_facts)
              .ok()) {
       spvtools::Error(FuzzDiagnostic, nullptr, {}, "Error reading facts data");
@@ -800,9 +800,9 @@ int main(int argc, const char** argv) {
     }
 
     std::string json_string;
-    auto json_options = google::protobuf::util::JsonPrintOptions();
+    auto json_options = google::protobuf::json::PrintOptions();
     json_options.add_whitespace = true;
-    auto json_generation_status = google::protobuf::util::MessageToJsonString(
+    auto json_generation_status = google::protobuf::json::MessageToJsonString(
         transformations_applied, &json_string, json_options);
     if (!json_generation_status.ok()) {
       spvtools::Error(FuzzDiagnostic, nullptr, {},


### PR DESCRIPTION
In the source/fuzz CMake rules, use a generator expression to hide the link dependency on libprotobuf from exports. This seems to be needed now.