### PR TITLE
spirv-val: forbid multiple graph entry points with the same name

### DIFF
--- a/source/val/validate.cpp
+++ b/source/val/validate.cpp
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "source/binary.h"
@@ -225,6 +226,7 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
   bool has_mask_task_nv = false;
   bool has_mask_task_ext = false;
   std::vector<Instruction*> visited_entry_points;
+  std::unordered_set<std::string> graph_entry_point_names;
   for (auto& instruction : vstate->ordered_instructions()) {
     {
       // In order to do this work outside of Process Instruction we need to be
@@ -281,7 +283,12 @@ spv_result_t ValidateBinaryUsingContextAndValidationState(
                               execution_model == spv::ExecutionModel::MeshEXT);
       }
       if (inst->opcode() == spv::Op::OpGraphEntryPointARM) {
-        const auto graph = inst->GetOperandAs<uint32_t>(1);
+        const std::string name = inst->GetOperandAs<std::string>(1);
+        if (!graph_entry_point_names.insert(name).second) {
+          return vstate->diag(SPV_ERROR_INVALID_DATA, inst)
+                 << "Graph entry points cannot share the same name.";
+        }
+        const auto graph = inst->GetOperandAs<uint32_t>(0);
         vstate->RegisterGraphEntryPoint(graph);
       }
       if (inst->opcode() == spv::Op::OpFunctionCall) {

--- a/test/val/val_graph_test.cpp
+++ b/test/val/val_graph_test.cpp
@@ -663,6 +663,24 @@ TEST_F(ValidateGraph,
                             "corresponding graph I/O '.*'.*"));
 }
 
+TEST_F(ValidateGraph, InvalidGraphEntryPointDuplicateNames) {
+  const std::string src = R"(
+%graph_type = OpTypeGraphARM 1 %int8tensor %int8tensor
+              OpGraphEntryPointARM %graph "duplicatename" %var_int8tensor %var_int8tensor
+              OpGraphEntryPointARM %graph "duplicatename" %var_int8tensor %var_int8tensor
+     %graph = OpGraphARM %graph_type
+        %in = OpGraphInputARM %int8tensor %uint_0
+              OpGraphSetOutputARM %in %uint_0
+              OpGraphEndARM
+)";
+  std::string spvasm = GenerateModule(src);
+
+  CompileSuccessfully(spvasm, SPVENV);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPVENV));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Graph entry points cannot share the same name"));
+}
+
 //
 // Graph tests
 //


### PR DESCRIPTION
Specification update: https://github.com/KhronosGroup/SPIRV-Registry/pull/426