### PR TITLE
Fix unbounded memory usage in FriendlyNameMapper

### DIFF
--- a/source/name_mapper.cpp
+++ b/source/name_mapper.cpp
@@ -78,13 +78,21 @@ void FriendlyNameMapper::SaveName(uint32_t id,
                                   const std::string& suggested_name) {
   if (name_for_id_.find(id) != name_for_id_.end()) return;
 
-  const std::string sanitized_suggested_name = Sanitize(suggested_name);
-  std::string name = sanitized_suggested_name;
+  std::string base_name;
+
+  // Limit the size of the name to limit memory usage.
+  const uint32_t kMaxSize = 256;
+  if (suggested_name.size() > kMaxSize) {
+    base_name = to_string(id);
+  } else {
+    base_name = Sanitize(suggested_name);
+  }
+  std::string name = base_name;
   auto inserted = used_names_.insert(name);
   if (!inserted.second) {
-    const std::string base_name = sanitized_suggested_name + "_";
+    const std::string base_name_prefix = base_name + "_";
     for (uint32_t index = 0; !inserted.second; ++index) {
-      name = base_name + to_string(index);
+      name = base_name_prefix + to_string(index);
       inserted = used_names_.insert(name);
     }
   }

--- a/test/name_mapper_test.cpp
+++ b/test/name_mapper_test.cpp
@@ -344,5 +344,81 @@ INSTANTIATE_TEST_SUITE_P(
         {"%1 = OpTypeBool\n%2 = OpConstantFalse %1", 2, "false"},
     }));
 
+INSTANTIATE_TEST_SUITE_P(
+    FriendlyName256CharCapLimit, FriendlyNameTest,
+    ::testing::ValuesIn(std::vector<NameIdCase>{
+        // OpName with exactly 256 chars: expect the sanitized 256 char name.
+        {"OpName %1 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         1,
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+        // OpName with 257 chars: expect the string representation of the ID.
+        {"OpName %1 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         1, "1"},
+        // OpName with 300 chars: expect the string representation of the ID.
+        {"OpName %1 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         1, "1"},
+        // OpName with 257 chars on ID 1, and another OpName with 257 chars on
+        // ID 2:
+        // expect ID 1 to map to "1" and ID 2 to map to "2".
+        {"OpName %1 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n"
+         "OpName %2 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         1, "1"},
+        {"OpName %1 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\n"
+         "OpName %2 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         2, "2"},
+        // OpName with 257 chars on ID 2, but name "2" is already used by ID 1:
+        // expect ID 2 to map to "2_0".
+        {"OpName %1 \"2\"\n"
+         "OpName %2 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         2, "2_0"},
+        // OpName with 257 chars on ID 3, but names "3" and "3_0" are already
+        // used:
+        // expect ID 3 to map to "3_1".
+        {"OpName %1 \"3\"\n"
+         "OpName %2 \"3_0\"\n"
+         "OpName %3 "
+         "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"",
+         3, "3_1"},
+    }));
+
 }  // namespace
 }  // namespace spvtools


### PR DESCRIPTION
Limit the size of friendly names suggested by FriendlyNameMapper to a
maximum of 256 characters. Suggested names exceeding this limit will
fall back to the string representation of the instruction ID to prevent
OOM vulnerability caused by recursive OpTypeArray definitions.

Fixes #6756
