### PR TITLE
[val] Allow untyped access chains in OpSpecConstantOp

### DIFF
--- a/source/assembly_grammar.cpp
+++ b/source/assembly_grammar.cpp
@@ -153,12 +153,16 @@ const SpecConstantOpcodeEntry kOpSpecConstantOpcodes[] = {
     CASE(InBoundsAccessChain),
     CASE(PtrAccessChain),
     CASE(InBoundsPtrAccessChain),
+    CASE(UntypedAccessChainKHR),
+    CASE(UntypedInBoundsAccessChainKHR),
+    CASE(UntypedPtrAccessChainKHR),
+    CASE(UntypedInBoundsPtrAccessChainKHR),
     CASE(CooperativeMatrixLengthNV),
     CASE(CooperativeMatrixLengthKHR)
 };
 
-// The 60 is determined by counting the opcodes listed in the spec.
-static_assert(61 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
+// The count is determined by counting the opcodes listed in the spec.
+static_assert(65 == sizeof(kOpSpecConstantOpcodes)/sizeof(kOpSpecConstantOpcodes[0]),
               "OpSpecConstantOp opcode table is incomplete");
 #undef CASE
 // clang-format on

--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -633,6 +633,10 @@ spv_result_t ValidateSpecConstantOp(ValidationState_t& _,
     case spv::Op::OpInBoundsAccessChain:
     case spv::Op::OpPtrAccessChain:
     case spv::Op::OpInBoundsPtrAccessChain:
+    case spv::Op::OpUntypedAccessChainKHR:
+    case spv::Op::OpUntypedInBoundsAccessChainKHR:
+    case spv::Op::OpUntypedPtrAccessChainKHR:
+    case spv::Op::OpUntypedInBoundsPtrAccessChainKHR:
       if (!_.HasCapability(spv::Capability::Kernel)) {
         return _.diag(SPV_ERROR_INVALID_ID, inst)
                << "Specialization constant operation " << spvOpcodeString(op)

--- a/source/val/validate_id.cpp
+++ b/source/val/validate_id.cpp
@@ -131,14 +131,15 @@ bool InstructionCanHaveTypeOperand(const Instruction* inst) {
   const auto opcode = inst->opcode();
   bool type_instruction = spvOpcodeGeneratesType(opcode);
   bool debug_instruction = spvOpcodeIsDebug(opcode) || inst->IsDebugInfo();
-  bool coop_matrix_spec_constant_op_length =
+  bool spec_constant_op_with_type_operand =
       (opcode == spv::Op::OpSpecConstantOp) &&
       (spv::Op(inst->word(3)) == spv::Op::OpCooperativeMatrixLengthNV ||
-       spv::Op(inst->word(3)) == spv::Op::OpCooperativeMatrixLengthKHR);
+       spv::Op(inst->word(3)) == spv::Op::OpCooperativeMatrixLengthKHR ||
+       spvOpcodeGeneratesUntypedPointer(spv::Op(inst->word(3))));
   return type_instruction || debug_instruction || inst->IsNonSemantic() ||
          spvOpcodeIsDecoration(opcode) || instruction_allow_set.count(opcode) ||
          spvOpcodeGeneratesUntypedPointer(opcode) ||
-         coop_matrix_spec_constant_op_length;
+         spec_constant_op_with_type_operand;
 }
 
 bool InstructionRequiresTypeOperand(const Instruction* inst) {

--- a/test/val/val_constants_test.cpp
+++ b/test/val/val_constants_test.cpp
@@ -807,6 +807,55 @@ OpMemoryModel Logical VulkanKHR
               HasSubstr("must be OpTypeCooperativeMatrixKHR"));
 }
 
+TEST_F(ValidateConstant, UntypedAccessChainSpecConstantOpGood) {
+  std::string spirv = R"(
+OpCapability Addresses
+OpCapability Kernel
+OpCapability Linkage
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Physical32 OpenCL
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_4 = OpConstant %uint 4
+%arr = OpTypeArray %uint %uint_4
+%ptr = OpTypeUntypedPointerKHR CrossWorkgroup
+%var = OpUntypedVariableKHR %ptr CrossWorkgroup %arr
+%ac = OpSpecConstantOp %ptr UntypedAccessChainKHR %arr %var %uint_0
+%iac = OpSpecConstantOp %ptr UntypedInBoundsAccessChainKHR %arr %var %uint_0
+%pac = OpSpecConstantOp %ptr UntypedPtrAccessChainKHR %arr %var %uint_0
+%ipac = OpSpecConstantOp %ptr UntypedInBoundsPtrAccessChainKHR %arr %var %uint_0
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(), Eq(""));
+}
+
+TEST_F(ValidateConstant, UntypedAccessChainSpecConstantOpRequiresKernel) {
+  std::string spirv = R"(
+OpCapability Shader
+OpCapability Linkage
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstant %uint 0
+%uint_4 = OpConstant %uint 4
+%arr = OpTypeArray %uint %uint_4
+%ptr = OpTypeUntypedPointerKHR Workgroup
+%var = OpUntypedVariableKHR %ptr Workgroup %arr
+%ac = OpSpecConstantOp %ptr UntypedInBoundsPtrAccessChainKHR %arr %var %uint_0
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Specialization constant operation "
+                        "UntypedInBoundsPtrAccessChainKHR requires Kernel "
+                        "capability"));
+}
+
 // Some check use SPV_ERROR_INVALID_DATA vs SPV_ERROR_INVALID_ID
 #define BAD_KERNEL_OPERANDS(STR, ERR)                                   \
   {                                                                     \


### PR DESCRIPTION
SPV_KHR_untyped_pointers allows the following opcodes to be used in `OpSpecConstantOp` with the `Kernel` capability:
* `OpUntypedAccessChainKHR`
* `OpUntypedInBoundsAccessChainKHR`
* `OpUntypedPtrAccessChainKHR`
* `OpUntypedInBoundsPtrAccessChainKHR`

Contributes to #6564