### PR TITLE
github workflows: tighten security

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       # Checkout the depot tools they are needed by roll_deps.sh
       - name: Checkout depot tools

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: '0'
+          persist-credentials: false
       - name: Download dependencies
         run: python3 utils/git-sync-deps
       - name: Mount Bazel cache
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: '0'
+          persist-credentials: false
       - name: Download dependencies
         run: python3 utils/git-sync-deps
       - name: Mount Bazel cache

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
         - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        - uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.02
+          with:
+            persist-credentials: false
+        - uses: lukka/get-cmake@f5b8fbb4d77cec1acc5a5f9f0df4beffaf5d98d9 # v4.3.4
         - name: Download dependencies
           run: python3 utils/git-sync-deps
         # NOTE: The MacOS SDK ships universal binaries. CI should reflect this.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Prepare CHANGELOG for version
         run: |
-          python utils/generate_changelog.py CHANGES "${{ github.ref_name }}" VERSION_CHANGELOG
+          python utils/generate_changelog.py CHANGES "${GITHUB_REF_NAME}" VERSION_CHANGELOG
       - name: Create release
         run: |
-          gh release create -t "Release ${{ github.ref_name }}" -F VERSION_CHANGELOG "${{ github.ref_name }}"
+          gh release create -t "Release ${GITHUB_REF_NAME}" -F VERSION_CHANGELOG "${GITHUB_REF_NAME}"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: '0'
+          persist-credentials: false
       - name: Build web
         run: docker compose -f source/wasm/docker-compose.yml --project-directory . up
       - name: Run tests


### PR DESCRIPTION
- don't persist credentials when using actions/checkout
- use GITHUB_REF_NAME instead of github.ref_name expansion.


crbug.com/529861263