### PR TITLE
update SPIRV-Headers; assembler, disassembler support for SPV_QCOM_image_processing3

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
 
   're2_revision': '972a15cedd008d846f1a39b2e88ce48d7f166cbd',
 
-  'spirv_headers_revision': '575b6512579ebde466ed3dfc04e413439d14d95d',
+  'spirv_headers_revision': '8d56066eee52f490535afd5731d5ae2fffc85036',
 
   'mimalloc_revision': 'fef6b0dd70f9d7fa0750b0d0b9fbb471203b94cd',
 }

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -337,6 +337,9 @@ typedef enum spv_operand_type_t {
   SPV_OPERAND_TYPE_OPTIONAL_CAPABILITY,
   SPV_OPERAND_TYPE_VARIABLE_CAPABILITY,
 
+  // SPV_QCOM_image_processing3
+  SPV_OPERAND_TYPE_GATHER_MODES,
+
   // This is a sentinel value, and does not represent an operand type.
   // It should come last.
   SPV_OPERAND_TYPE_NUM_OPERAND_TYPES,

--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -744,7 +744,8 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     case SPV_OPERAND_TYPE_HOST_ACCESS_QUALIFIER:
     case SPV_OPERAND_TYPE_LOAD_CACHE_CONTROL:
     case SPV_OPERAND_TYPE_STORE_CACHE_CONTROL:
-    case SPV_OPERAND_TYPE_NAMED_MAXIMUM_NUMBER_OF_REGISTERS: {
+    case SPV_OPERAND_TYPE_NAMED_MAXIMUM_NUMBER_OF_REGISTERS:
+    case SPV_OPERAND_TYPE_GATHER_MODES: {
       // A single word that is a plain enum value.
 
       // Map an optional operand type to its corresponding concrete type.

--- a/source/operand.cpp
+++ b/source/operand.cpp
@@ -225,6 +225,8 @@ const char* spvOperandTypeStr(spv_operand_type_t type) {
       return "NonSemantic.Shader.DebugInfo.100 debug operation";
     case SPV_OPERAND_TYPE_SHDEBUG100_DEBUG_TYPE_QUALIFIER:
       return "NonSemantic.Shader.DebugInfo.100 debug type qualifier";
+    case SPV_OPERAND_TYPE_GATHER_MODES:
+      return "gather modes";
 
     case SPV_OPERAND_TYPE_NONE:
       return "NONE";
@@ -347,6 +349,7 @@ bool spvOperandIsConcrete(spv_operand_type_t type) {
     case SPV_OPERAND_TYPE_SHDEBUG100_DEBUG_INFO_FLAGS:
     case SPV_OPERAND_TYPE_SHDEBUG100_DEBUG_OPERATION:
     case SPV_OPERAND_TYPE_SHDEBUG100_DEBUG_TYPE_QUALIFIER:
+    case SPV_OPERAND_TYPE_GATHER_MODES:
       return true;
     default:
       break;

--- a/test/text_to_binary.extension_test.cpp
+++ b/test/text_to_binary.extension_test.cpp
@@ -1727,5 +1727,31 @@ TEST_F(TextToBinaryTest, ConstantDataNonUTF) {
   spvContextDestroy(context);
 }
 
+// SPV_QCOM_image_processing3
+INSTANTIATE_TEST_SUITE_P(
+    SPV_QCOM_image_processing3, ExtensionRoundTripTest,
+    Combine(
+        Values(SPV_ENV_UNIVERSAL_1_4, SPV_ENV_UNIVERSAL_1_6, SPV_ENV_VULKAN_1_1,
+               SPV_ENV_VULKAN_1_4),
+        ValuesIn(std::vector<AssemblyCase>{
+            {"OpExtension \"SPV_QCOM_image_processing3\"\n",
+             MakeInstruction(spv::Op::OpExtension,
+                             MakeVector("SPV_QCOM_image_processing3"))},
+            {"OpCapability ImageGatherLinearQCOM\n",
+             MakeInstruction(
+                 spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::ImageGatherLinearQCOM})},
+            {"OpCapability ImageGatherExtendedModesQCOM\n",
+             MakeInstruction(
+                 spv::Op::OpCapability,
+                 {(uint32_t)spv::Capability::ImageGatherExtendedModesQCOM})},
+            {"%2 = OpImageGatherQCOM %1 %3 %4 %5 %6\n",
+             MakeInstruction(spv::Op::OpImageGatherQCOM, {1, 2, 3, 4, 5, 6})},
+            // Prove that we parse image operands afterward
+            {"%2 = OpImageGatherQCOM %1 %3 %4 %5 %6 Lod %7\n",
+             MakeInstruction(spv::Op::OpImageGatherQCOM,
+                             {1, 2, 3, 4, 5, 6, 2, 7})},
+        })));
+
 }  // namespace
 }  // namespace spvtools


### PR DESCRIPTION
Update SPIRV-Headers.

Adds new operand type SPV_OPERAND_TYPE_GATHER_MODES. This is not actually used since the gather mode operand is provided as an ID.