### PR TITLE
Fix array length validation

### DIFF
--- a/source/val/validate_memory.cpp
+++ b/source/val/validate_memory.cpp
@@ -2433,7 +2433,7 @@ spv_result_t ValidateArrayLength(ValidationState_t& state,
       return state.diag(SPV_ERROR_INVALID_ID, inst)
              << "Pointer must be an untyped pointer object";
     }
-  } else if (pointer_ty->opcode() != spv::Op::OpTypePointer) {
+  } else if (!pointer_ty || pointer_ty->opcode() != spv::Op::OpTypePointer) {
     return state.diag(SPV_ERROR_INVALID_ID, inst)
            << "The Structure's type in Op" << spvOpcodeString(opcode)
            << " <id> " << state.getIdName(inst->id())

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -11223,6 +11223,28 @@ OpFunctionEnd
   EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
 }
 
+TEST_F(ValidateMemory, ArrayLength_BadPointer) {
+  std::string spirv = R"(
+               OpCapability ClipDistance
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpName %2097184 "pointer"
+       %void = OpTypeVoid
+          %6 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+       %8224 = OpFunction %void None %6
+      %65312 = OpLabel
+    %2097184 = OpArrayLength %uint %1 538976288
+               OpUnreachable
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The Structure's type in OpArrayLength <id> '2[%pointer]' must be a pointer to an OpTypeStruct"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_memory_test.cpp
+++ b/test/val/val_memory_test.cpp
@@ -11242,7 +11242,8 @@ TEST_F(ValidateMemory, ArrayLength_BadPointer) {
   CompileSuccessfully(spirv);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions());
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Structure's type in OpArrayLength <id> '2[%pointer]' must be a pointer to an OpTypeStruct"));
+              HasSubstr("The Structure's type in OpArrayLength <id> "
+                        "'2[%pointer]' must be a pointer to an OpTypeStruct"));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://crbug.com/oss-fuzz/529845250

* Fix a segfault from nullptr deref when an operand with no type id is passed as the pointer operand