### PR TITLE
Authenticate git push in autoroll

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -23,10 +23,10 @@ jobs:
 
       # Checkout the depot tools they are needed by roll_deps.sh
       - name: Checkout depot tools
-        run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+        run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $GITHUB_WORKSPACE/../depot_tools
 
       - name: Update PATH
-        run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+        run: echo "$GITHUB_WORKSPACE/../depot_tools" >> $GITHUB_PATH
 
       - name: Download dependencies
         run: python3 utils/git-sync-deps
@@ -49,11 +49,11 @@ jobs:
       - name: Push changes and create PR
         if: steps.update_dependencies.outputs.changed == 'true'
         run: |
-          git push --force --set-upstream origin roll_deps
+          git push --force https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git roll_deps
           # Create a PR. If it aready exists, the command fails, so ignore the return code.
-          gh pr create --base main -f || true 
+          gh pr create --head roll_deps --base main -f || true 
           # Add the 'kokoro:run' label so that the kokoro tests will be run.
-          gh pr edit --add-label 'kokoro:run'
-          gh pr merge --auto --squash
+          gh pr edit roll_deps --add-label 'kokoro:run'
+          gh pr merge roll_deps --auto --squash
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Setting persist-credentials to false broke git push in autoroll workflow.
This is fixed by authenticate git push using GITHUB_TOKEN. Other changes
were made to clean up some warnings.

TAG=agy
