### PR TITLE
opt: Fix crash in strip-debug with non-semantic info

### DIFF
--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -226,7 +226,8 @@ Instruction* IRContext::KillInst(Instruction* inst) {
   if (inst->opcode() == spv::Op::OpCapability ||
       inst->opcode() == spv::Op::OpConditionalCapabilityINTEL ||
       inst->opcode() == spv::Op::OpExtension ||
-      inst->opcode() == spv::Op::OpConditionalExtensionINTEL) {
+      inst->opcode() == spv::Op::OpConditionalExtensionINTEL ||
+      inst->opcode() == spv::Op::OpExtInstImport) {
     // We reset the feature manager, instead of updating it, because it is just
     // as much work.  We would have to remove all capabilities implied by this
     // capability that are not also implied by the remaining OpCapability

--- a/source/opt/strip_debug_info_pass.cpp
+++ b/source/opt/strip_debug_info_pass.cpp
@@ -95,8 +95,14 @@ Pass::Status StripDebugInfoPass::Process() {
 
   // clear OpLine information
   context()->module()->ForEachInst([&modified](Instruction* inst) {
-    modified |= !inst->dbg_line_insts().empty();
-    inst->dbg_line_insts().clear();
+    if (!inst->dbg_line_insts().empty()) {
+      modified = true;
+      inst->dbg_line_insts().clear();
+    }
+    if (inst->GetDebugScope().GetLexicalScope() != kNoDebugScope) {
+      modified = true;
+      inst->SetDebugScope({kNoDebugScope, kNoInlinedAt});
+    }
   });
 
   if (!get_module()->trailing_dbg_line_info().empty()) {

--- a/test/opt/strip_debug_info_test.cpp
+++ b/test/opt/strip_debug_info_test.cpp
@@ -227,6 +227,62 @@ INSTANTIATE_TEST_SUITE_P(
     })));
 // clang-format on
 
+TEST_F(StripDebugInfoTest, NonSemanticShaderDebugInfoWithDebugScope) {
+  std::vector<const char*> input = {
+      // clang-format off
+      "OpCapability Shader",
+      "OpExtension \"SPV_KHR_non_semantic_info\"",
+      "%1 = OpExtInstImport \"NonSemantic.Shader.DebugInfo.100\"",
+      "OpMemoryModel Logical GLSL450",
+      "OpEntryPoint GLCompute %main \"main\"",
+      "OpExecutionMode %main LocalSize 1 1 1",
+      "%file_name = OpString \"dummy.slang\"",
+      "%source_text = OpString \"void main() {}\"",
+      "%void = OpTypeVoid",
+      "%4 = OpTypeFunction %void",
+      "%uint = OpTypeInt 32 0",
+      "%uint_100 = OpConstant %uint 100",
+      "%uint_5 = OpConstant %uint 5",
+      "%uint_11 = OpConstant %uint 11",
+      "%source = OpExtInst %void %1 DebugSource %file_name %source_text",
+      "%scope = OpExtInst %void %1 DebugCompilationUnit %uint_100 %uint_5 %source %uint_11",
+      "%main = OpFunction %void None %4",
+      "%5 = OpLabel",
+      "%dbg_scope_inst = OpExtInst %void %1 DebugScope %scope",
+      "OpReturn",
+      "OpFunctionEnd"
+      // clang-format on
+  };
+
+  std::vector<const char*> expected = {
+      // clang-format off
+      "OpCapability Shader",
+      "OpExtension \"SPV_KHR_non_semantic_info\"",
+      "%1 = OpExtInstImport \"NonSemantic.Shader.DebugInfo.100\"",
+      "OpMemoryModel Logical GLSL450",
+      "OpEntryPoint GLCompute %2 \"main\"",
+      "OpExecutionMode %2 LocalSize 1 1 1",
+      "%3 = OpString \"dummy.slang\"",
+      "%4 = OpString \"void main() {}\"",
+      "%void = OpTypeVoid",
+      "%6 = OpTypeFunction %void",
+      "%uint = OpTypeInt 32 0",
+      "%uint_100 = OpConstant %uint 100",
+      "%uint_5 = OpConstant %uint 5",
+      "%uint_11 = OpConstant %uint 11",
+      "%2 = OpFunction %void None %6",
+      "%13 = OpLabel",
+      "OpReturn",
+      "OpFunctionEnd"
+      // clang-format on
+  };
+
+  SinglePassRunAndCheck<StripDebugInfoPass>(JoinAllInsts(input),
+                                            JoinAllInsts(expected),
+                                            /* skip_nop = */ false,
+                                            /* do_validation */ true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
Clears the DebugScope of all instructions during StripDebugInfoPass to
prevent out-of-bounds assertions when writing back instructions that
reference dead debug instructions.

Also resets the FeatureManager when OpExtInstImport is killed to maintain
context consistency if imports are removed by other passes.

Adds a unit test to verify the fix.

Fixes #6796

Assisted-by: Antigravity
