### PR TITLE
Fix build for LLVM's remove transitive includes

### DIFF
--- a/source/val/validate_cfg.cpp
+++ b/source/val/validate_cfg.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
In the latest LLVM roll this file requires the iterator header for std::back_inserter

I believe LLVM has recently removed transitive includes by default, see:

https://github.com/llvm/llvm-project/commit/ce5b2e876494cb95f02d9f915081e2b8781e74d1