### PR TITLE
utils: Supress GCC array-bound warning

### DIFF
--- a/source/util/timer.h
+++ b/source/util/timer.h
@@ -23,6 +23,11 @@
 #include <cassert>
 #include <iostream>
 
+#if defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 // A macro to call spvtools::utils::PrintTimerDescription(std::ostream*, bool).
 // The first argument must be given as std::ostream*. If it is NULL, the
 // function does nothing. Otherwise, it prints resource types measured by Timer
@@ -381,6 +386,10 @@ class CumulativeTimer : public Timer {
 
 }  // namespace utils
 }  // namespace spvtools
+
+#if defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
 
 #else  // defined(SPIRV_TIMER_ENABLED)
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/SPIRV-Tools/issues/6805

We do this same-ish thing in `source/utils/hex_floats.h` 

I looked, there was no changes to `timer.h` or `pass_manager.cpp` so not sure what this suddenly is happening, seems to just be something the latest GCC is catching