### PR TITLE
Fix inconsistent Target vs Targets naming in export FILE and Config.cmake

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -397,14 +397,14 @@ if(ENABLE_SPIRV_TOOLS_INSTALL)
     list(APPEND SPIRV_TOOLS_TARGETS mimalloc-static)
   endif()
   install(TARGETS ${SPIRV_TOOLS_TARGETS} EXPORT ${SPIRV_TOOLS}Targets)
-  export(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Target.cmake)
+  export(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Targets.cmake)
 
   spvtools_config_package_dir(${SPIRV_TOOLS} PACKAGE_DIR)
-  install(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Target.cmake DESTINATION ${PACKAGE_DIR})
+  install(EXPORT ${SPIRV_TOOLS}Targets FILE ${SPIRV_TOOLS}Targets.cmake DESTINATION ${PACKAGE_DIR})
 
   # Special config file for root library compared to other libs.
   file(WRITE ${CMAKE_BINARY_DIR}/${SPIRV_TOOLS}Config.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/${SPIRV_TOOLS}Target.cmake)\n"
+    "include(\${CMAKE_CURRENT_LIST_DIR}/${SPIRV_TOOLS}Targets.cmake)\n"
     "if(TARGET ${SPIRV_TOOLS})\n"
     "    set(${SPIRV_TOOLS}_LIBRARIES ${SPIRV_TOOLS})\n"
     "    get_target_property(${SPIRV_TOOLS}_INCLUDE_DIRS ${SPIRV_TOOLS} INTERFACE_INCLUDE_DIRECTORIES)\n"

--- a/source/fuzz/CMakeLists.txt
+++ b/source/fuzz/CMakeLists.txt
@@ -480,10 +480,10 @@ if(SPIRV_BUILD_FUZZER)
       endif()
 
       install(TARGETS ${SPIRV-Tools-fuzz-InstallTargets} EXPORT SPIRV-Tools-fuzzTargets)
-      export(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTarget.cmake)
+      export(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTargets.cmake)
 
       spvtools_config_package_dir(SPIRV-Tools-fuzz PACKAGE_DIR)
-      install(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTarget.cmake
+      install(EXPORT SPIRV-Tools-fuzzTargets FILE SPIRV-Tools-fuzzTargets.cmake
             DESTINATION ${PACKAGE_DIR})
 
       spvtools_generate_config_file(SPIRV-Tools-fuzz)

--- a/source/reduce/CMakeLists.txt
+++ b/source/reduce/CMakeLists.txt
@@ -97,10 +97,10 @@ spvtools_check_symbol_exports(SPIRV-Tools-reduce)
 
 if(ENABLE_SPIRV_TOOLS_INSTALL)
   install(TARGETS SPIRV-Tools-reduce EXPORT SPIRV-Tools-reduceTargets)
-  export(EXPORT SPIRV-Tools-reduceTargets FILE SPIRV-Tools-reduceTarget.cmake)
+  export(EXPORT SPIRV-Tools-reduceTargets FILE SPIRV-Tools-reduceTargets.cmake)
 
   spvtools_config_package_dir(SPIRV-Tools-reduce PACKAGE_DIR)
-  install(EXPORT SPIRV-Tools-reduceTargets FILE SPIRV-Tools-reduceTarget.cmake
+  install(EXPORT SPIRV-Tools-reduceTargets FILE SPIRV-Tools-reduceTargets.cmake
   	DESTINATION ${PACKAGE_DIR})
 
   spvtools_generate_config_file(SPIRV-Tools-reduce)


### PR DESCRIPTION
Three files use singular `Target` in `install(EXPORT ...)` FILE names and the generated `SPIRV-ToolsConfig.cmake`, while all other files and sub-projects consistently use plural `Targets`. This causes `find_package()` for SPIRV-Tools and its dependents (SPIRV-Tools-opt, -diff, -link, -lint) to fail with missing imported target errors.

Fixed:
- export/install FILE changed from Target.cmake to Targets.cmake
- Config.cmake include changed from Target.cmake to Targets.cmake

Related issue: https://github.com/KhronosGroup/SPIRV-Tools/issues/6752
