### PR TITLE
[val] Restrict Workgroup scope to OpGroupNonUniformRotateKHR only

### DIFF
--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -99,7 +99,8 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
       // Scope for Non Uniform Group Operations must be limited to Subgroup
       if ((spvOpcodeIsNonUniformGroupOperation(opcode) &&
            (opcode != spv::Op::OpGroupNonUniformQuadAllKHR) &&
-           (opcode != spv::Op::OpGroupNonUniformQuadAnyKHR)) &&
+           (opcode != spv::Op::OpGroupNonUniformQuadAnyKHR) &&
+           (opcode != spv::Op::OpGroupNonUniformRotateKHR)) &&
           (value != spv::Scope::Subgroup)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << _.VkErrorID(4642) << spvOpcodeString(opcode)
@@ -186,11 +187,19 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
   // TODO(atgoo@github.com) Add checks for OpenCL and OpenGL environments.
 
   // General SPIRV rules
-  // Scope for execution must be limited to Workgroup or Subgroup for
-  // non-uniform operations
+  // OpGroupNonUniformRotateKHR is the only non-uniform group operation that
+  // allows Workgroup scope; all others are limited to Subgroup.
   if (spvOpcodeIsNonUniformGroupOperation(opcode) &&
       opcode != spv::Op::OpGroupNonUniformQuadAllKHR &&
       opcode != spv::Op::OpGroupNonUniformQuadAnyKHR &&
+      opcode != spv::Op::OpGroupNonUniformRotateKHR &&
+      value != spv::Scope::Subgroup) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << spvOpcodeString(opcode) << ": Execution scope is limited to "
+           << "Subgroup";
+  }
+
+  if (opcode == spv::Op::OpGroupNonUniformRotateKHR &&
       value != spv::Scope::Subgroup && value != spv::Scope::Workgroup) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << spvOpcodeString(opcode)

--- a/source/val/validate_scopes.cpp
+++ b/source/val/validate_scopes.cpp
@@ -99,8 +99,7 @@ spv_result_t ValidateExecutionScope(ValidationState_t& _,
       // Scope for Non Uniform Group Operations must be limited to Subgroup
       if ((spvOpcodeIsNonUniformGroupOperation(opcode) &&
            (opcode != spv::Op::OpGroupNonUniformQuadAllKHR) &&
-           (opcode != spv::Op::OpGroupNonUniformQuadAnyKHR) &&
-           (opcode != spv::Op::OpGroupNonUniformRotateKHR)) &&
+           (opcode != spv::Op::OpGroupNonUniformQuadAnyKHR)) &&
           (value != spv::Scope::Subgroup)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << _.VkErrorID(4642) << spvOpcodeString(opcode)

--- a/test/val/val_extension_spv_khr_subgroup_rotate_test.cpp
+++ b/test/val/val_extension_spv_khr_subgroup_rotate_test.cpp
@@ -34,6 +34,7 @@ struct Case {
   std::string delta;
   std::string cluster_size;
   std::string expected_error;  // empty for no error.
+  spv_target_env target_env = SPV_ENV_UNIVERSAL_1_0;
 };
 
 inline std::ostream& operator<<(std::ostream& out, Case c) {
@@ -69,6 +70,7 @@ std::string AssemblyForCase(const Case& c) {
   if (c.shader) {
     ss << "OpMemoryModel Logical GLSL450\n";
     ss << "OpEntryPoint GLCompute %main \"main\"\n";
+    ss << "OpExecutionMode %main LocalSize 1 1 1\n";
   } else {
     ss << "OpMemoryModel Physical32 OpenCL\n";
     ss << "OpEntryPoint Kernel %main \"main\"\n";
@@ -131,11 +133,12 @@ using ValidateSpvKHRSubgroupRotate = spvtest::ValidateBase<Case>;
 TEST_P(ValidateSpvKHRSubgroupRotate, Base) {
   const auto& c = GetParam();
   const auto& assembly = AssemblyForCase(c);
-  CompileSuccessfully(assembly);
+  CompileSuccessfully(assembly, c.target_env);
   if (c.expected_error.empty()) {
-    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions()) << getDiagnosticString();
+    EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(c.target_env))
+        << getDiagnosticString();
   } else {
-    EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+    EXPECT_NE(SPV_SUCCESS, ValidateInstructions(c.target_env));
     EXPECT_THAT(getDiagnosticString(), HasSubstr(c.expected_error));
   }
 }
@@ -239,6 +242,26 @@ INSTANTIATE_TEST_SUITE_P(
              "%u32_1",
              "",
              "Execution scope is limited to Subgroup or Workgroup"}));
+
+INSTANTIATE_TEST_SUITE_P(Vulkan, ValidateSpvKHRSubgroupRotate,
+                         ::testing::Values(Case{{"GroupNonUniformRotateKHR"},
+                                                true,
+                                                "%u32",
+                                                "%subgroup",
+                                                "%u32_1",
+                                                "",
+                                                "",
+                                                SPV_ENV_VULKAN_1_1},
+                                           Case{{"GroupNonUniformRotateKHR"},
+                                                true,
+                                                "%u32",
+                                                "%workgroup",
+                                                "%u32_1",
+                                                "",
+                                                "in Vulkan environment "
+                                                "Execution scope is limited "
+                                                "to Subgroup",
+                                                SPV_ENV_VULKAN_1_1}));
 
 INSTANTIATE_TEST_SUITE_P(
     InvalidResultType, ValidateSpvKHRSubgroupRotate,

--- a/test/val/val_non_uniform_test.cpp
+++ b/test/val/val_non_uniform_test.cpp
@@ -232,14 +232,12 @@ TEST_P(GroupNonUniform, Spirv1p3) {
   CompileSuccessfully(GenerateShaderCode(sstr.str()), SPV_ENV_UNIVERSAL_1_3);
   spv_result_t result = ValidateInstructions(SPV_ENV_UNIVERSAL_1_3);
   if (error == "") {
-    if (execution_scope == spv::Scope::Subgroup ||
-        execution_scope == spv::Scope::Workgroup) {
+    if (execution_scope == spv::Scope::Subgroup) {
       EXPECT_EQ(SPV_SUCCESS, result);
     } else {
       EXPECT_EQ(SPV_ERROR_INVALID_DATA, result);
-      EXPECT_THAT(
-          getDiagnosticString(),
-          HasSubstr("Execution scope is limited to Subgroup or Workgroup"));
+      EXPECT_THAT(getDiagnosticString(),
+                  HasSubstr("Execution scope is limited to Subgroup"));
     }
   } else {
     EXPECT_EQ(SPV_ERROR_INVALID_DATA, result);


### PR DESCRIPTION
Other non-uniform group operations were incorrectly allowed to use Workgroup execution scope in the general SPIR-V rule check, only OpGroupNonUniformRotateKHR permits it

Also fix the matching Vulkan execution scope check, which was missing the same exclusion