### PR TITLE
[val] Allow BFloat16ArithmeticINTEL to permit BFloat16 on arithmetic/relational ops and OpenCL.std ExtInst

### DIFF
--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -167,9 +167,13 @@ std::string GetExtInstName(const ValidationState_t& _,
 // Rejects an instruction whose result or any operand uses a BFloat16 or FP8
 // (E4M3/E5M2) type, i.e. an OpTypeFloat that is not IEEE 754 encoded.
 spv_result_t ValidateExtInstFloatEncoding(ValidationState_t& _,
-                                          const Instruction* inst) {
+                                          const Instruction* inst,
+                                          spv_ext_inst_type_t ext_inst_type) {
+  const bool bfloat16_arithmetic_allowed =
+      ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_STD &&
+      _.HasCapability(spv::Capability::BFloat16ArithmeticINTEL);
   auto check = [&](uint32_t type_id) -> spv_result_t {
-    if (_.IsBfloat16Type(type_id)) {
+    if (!bfloat16_arithmetic_allowed && _.IsBfloat16Type(type_id)) {
       return _.diag(SPV_ERROR_INVALID_DATA, inst)
              << GetExtInstName(_, inst) << ": doesn't support BFloat16 type.";
     }
@@ -4457,7 +4461,8 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
   // using the IEEE 754 encoding, so they don't support BFloat16 or FP8 types.
   if (ext_inst_type == SPV_EXT_INST_TYPE_GLSL_STD_450 ||
       ext_inst_type == SPV_EXT_INST_TYPE_OPENCL_STD) {
-    if (spv_result_t result = ValidateExtInstFloatEncoding(_, inst))
+    if (spv_result_t result =
+            ValidateExtInstFloatEncoding(_, inst, ext_inst_type))
       return result;
   }
 

--- a/source/val/validate_invalid_type.cpp
+++ b/source/val/validate_invalid_type.cpp
@@ -61,11 +61,54 @@ bool IsOCPMicroscalingScalarOrCompositeType(ValidationState_t& _,
   return _.ContainsOCPMicroscalingType(type_id);
 }
 
+// Returns true for the arithmetic and relational/logical instructions that
+// the BFloat16ArithmeticINTEL capability (SPV_INTEL_bfloat16_arithmetic)
+// permits to operate on the BFloat16 type.
+bool IsBfloat16ArithmeticInstruction(spv::Op opcode) {
+  switch (opcode) {
+    case spv::Op::OpFNegate:
+    case spv::Op::OpFAdd:
+    case spv::Op::OpFSub:
+    case spv::Op::OpFMul:
+    case spv::Op::OpFDiv:
+    case spv::Op::OpFRem:
+    case spv::Op::OpFMod:
+    case spv::Op::OpVectorTimesScalar:
+    case spv::Op::OpIsNan:
+    case spv::Op::OpIsInf:
+    case spv::Op::OpIsFinite:
+    case spv::Op::OpIsNormal:
+    case spv::Op::OpFOrdEqual:
+    case spv::Op::OpFUnordEqual:
+    case spv::Op::OpFOrdNotEqual:
+    case spv::Op::OpFUnordNotEqual:
+    case spv::Op::OpFOrdLessThan:
+    case spv::Op::OpFUnordLessThan:
+    case spv::Op::OpFOrdGreaterThan:
+    case spv::Op::OpFUnordGreaterThan:
+    case spv::Op::OpFOrdLessThanEqual:
+    case spv::Op::OpFUnordLessThanEqual:
+    case spv::Op::OpFOrdGreaterThanEqual:
+    case spv::Op::OpFUnordGreaterThanEqual:
+    case spv::Op::OpLessOrGreater:
+    case spv::Op::OpOrdered:
+    case spv::Op::OpUnordered:
+    case spv::Op::OpSignBitSet:
+      return true;
+    default:
+      return false;
+  }
+}
+
 spv_result_t CheckInvalidScalarOrCompositeType(ValidationState_t& _,
                                                const Instruction* inst,
                                                uint32_t type_id) {
   const spv::Op opcode = inst->opcode();
-  if (IsBfloat16ScalarOrCompositeType(_, type_id)) {
+  const bool bfloat16_arithmetic_allowed =
+      _.HasCapability(spv::Capability::BFloat16ArithmeticINTEL) &&
+      IsBfloat16ArithmeticInstruction(opcode);
+  if (!bfloat16_arithmetic_allowed &&
+      IsBfloat16ScalarOrCompositeType(_, type_id)) {
     return _.diag(SPV_ERROR_INVALID_DATA, inst)
            << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
   }
@@ -213,7 +256,10 @@ spv_result_t InvalidTypePass(ValidationState_t& _, const Instruction* inst) {
     case spv::Op::OpUnordered:
     case spv::Op::OpSignBitSet: {
       const uint32_t operand_type = _.GetOperandTypeId(inst, 2);
-      if (_.IsBfloat16Type(operand_type)) {
+      const bool bfloat16_arithmetic_allowed =
+          _.HasCapability(spv::Capability::BFloat16ArithmeticINTEL) &&
+          IsBfloat16ArithmeticInstruction(opcode);
+      if (!bfloat16_arithmetic_allowed && _.IsBfloat16Type(operand_type)) {
         return _.diag(SPV_ERROR_INVALID_DATA, inst)
                << spvOpcodeString(opcode) << " doesn't support BFloat16 type.";
       }

--- a/test/val/val_invalid_type_test.cpp
+++ b/test/val/val_invalid_type_test.cpp
@@ -246,6 +246,112 @@ OpFunctionEnd
                         "capabilities: BFloat16TypeKHR"));
 }
 
+std::string GenerateBFloatArithmeticCode(const std::string& main_body) {
+  const std::string prefix =
+      R"(
+OpCapability Shader
+OpCapability BFloat16TypeKHR
+OpCapability BFloat16ArithmeticINTEL
+OpExtension "SPV_KHR_bfloat16"
+OpExtension "SPV_INTEL_bfloat16_arithmetic"
+%1 = OpExtInstImport "GLSL.std.450"
+%2 = OpExtInstImport "OpenCL.std"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpSource GLSL 450
+OpName %main "main"
+%bool = OpTypeBool
+%void = OpTypeVoid
+%bfloat16 = OpTypeFloat 16 BFloat16KHR
+%func = OpTypeFunction %void
+%bf16_1 = OpConstant %bfloat16 1
+%main = OpFunction %void None %func
+%main_entry = OpLabel)";
+
+  const std::string suffix =
+      R"(
+OpReturn
+OpFunctionEnd)";
+
+  return prefix + main_body + suffix;
+}
+
+TEST_F(ValidateInvalidType,
+       Bfloat16ArithmeticInstructionAllowedWithCapability) {
+  const std::string body = R"(
+%15 = OpFMul %bfloat16 %bf16_1 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatArithmeticCode(body).c_str(),
+                      SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+}
+
+TEST_F(ValidateInvalidType,
+       Bfloat16RelationalInstructionAllowedWithCapability) {
+  const std::string body = R"(
+%15 = OpFOrdEqual %bool %bf16_1 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatArithmeticCode(body).c_str(),
+                      SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+}
+
+TEST_F(ValidateInvalidType,
+       Bfloat16GlslStd450InstructionStillRejectedWithArithmeticCapability) {
+  const std::string body = R"(
+%15 = OpExtInst %bfloat16 %1 FClamp %bf16_1 %bf16_1 %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatArithmeticCode(body).c_str(),
+                      SPV_ENV_VULKAN_1_3);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("FClamp: doesn't support BFloat16 type."));
+}
+
+TEST_F(ValidateInvalidType,
+       Bfloat16OpenCLStdExtInstAllowedWithArithmeticCapability) {
+  const std::string body = R"(
+%15 = OpExtInst %bfloat16 %2 fabs %bf16_1
+)";
+
+  CompileSuccessfully(GenerateBFloatArithmeticCode(body).c_str(),
+                      SPV_ENV_UNIVERSAL_1_6);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+}
+
+TEST_F(ValidateInvalidType,
+       Bfloat16OpenCLStdExtInstStillRejectedWithoutArithmeticCapability) {
+  const std::string spirv = R"(
+OpCapability Kernel
+OpCapability Addresses
+OpCapability BFloat16TypeKHR
+OpExtension "SPV_KHR_bfloat16"
+%2 = OpExtInstImport "OpenCL.std"
+OpMemoryModel Physical32 OpenCL
+OpEntryPoint Kernel %main "main"
+%void = OpTypeVoid
+%func = OpTypeFunction %void
+%bfloat16 = OpTypeFloat 16 BFloat16KHR
+%bf16_1 = OpConstant %bfloat16 1
+%main = OpFunction %void None %func
+%entry = OpLabel
+%15 = OpExtInst %bfloat16 %2 fabs %bf16_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(spirv.c_str(), SPV_ENV_UNIVERSAL_1_6);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_UNIVERSAL_1_6));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("OpenCL.std fabs: doesn't support BFloat16 type."));
+}
+
 std::string GenerateFP8Code(const std::string& main_body) {
   const std::string prefix =
       R"(


### PR DESCRIPTION
Required for https://github.com/llvm/llvm-project/pull/212505

Depends on https://github.com/KhronosGroup/SPIRV-Headers/pull/604