### PR TITLE
cmake: export shared component symbols on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,13 @@ else(SPIRV_TOOLS_BUILD_STATIC)
   endif()
 endif(SPIRV_TOOLS_BUILD_STATIC)
 
+# SPIRV-Tools component libraries do not annotate all of their public C++
+# symbols. Generate Windows export tables when those components are shared so
+# that their import libraries can be linked by one another and by consumers.
+if(WIN32 AND SPIRV_TOOLS_LIBRARY_TYPE STREQUAL "SHARED")
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 function(spvtools_default_compile_options TARGET)
   target_compile_options(${TARGET} PRIVATE ${SPIRV_WARNINGS})
 


### PR DESCRIPTION
Enable CMake automatic Windows symbol exports when `SPIRV_TOOLS_LIBRARY_TYPE=SHARED`.

Without this, the generic `SPIRV-Tools` DLL produces no import library and shared components such as `SPIRV-Tools-opt.dll` fail with `LNK1181: cannot open input file SPIRV-Tools.lib`. The dedicated `SPIRV-Tools-shared` target has explicit export annotations, but the generic and component targets do not annotate all public C++ symbols.

This exact configuration is now built and consumer-tested on both win-64 and win-arm64 in conda-forge: https://github.com/conda-forge/spirv-tools-feedstock/pull/34