### PR TITLE
opt: Fix invalid OpSelect folding in spirv-opt

### DIFF
--- a/source/opt/folding_rules.cpp
+++ b/source/opt/folding_rules.cpp
@@ -14,14 +14,14 @@
 
 #include "source/opt/folding_rules.h"
 
-#include <limits>
-#include <memory>
 #include <optional>
 #include <utility>
 
 #include "ir_builder.h"
 #include "source/latest_version_glsl_std_450_header.h"
 #include "source/opt/ir_context.h"
+#include "source/spirv_constant.h"
+#include "source/spirv_target_env.h"
 
 namespace spvtools {
 namespace opt {
@@ -3232,6 +3232,10 @@ FoldingRule MergeBinaryOpSelect(spv::Op opcode) {
 
   return [opcode](IRContext* context, Instruction* inst,
                   const std::vector<const analysis::Constant*>& constants) {
+    analysis::ConstantManager* const_mgr = context->get_constant_mgr();
+    analysis::TypeManager* type_mgr = context->get_type_mgr();
+    analysis::DefUseManager* def_use_mgr = context->get_def_use_mgr();
+
     const analysis::Constant* const_input = ConstInput(constants);
     if (!const_input) {
       return false;
@@ -3241,9 +3245,26 @@ FoldingRule MergeBinaryOpSelect(spv::Op opcode) {
       return false;
     }
     std::vector<const analysis::Constant*> select_constants =
-        context->get_constant_mgr()->GetOperandConstants(non_const);
+        const_mgr->GetOperandConstants(non_const);
     if (!select_constants[1] || !select_constants[2]) {
       return false;
+    }
+
+    // The OpSelect that will be created below will use the condition from
+    // `non_const` and a result type matching `inst`. Before SPIR-V 1.4,
+    // OpSelect could not have a scalar condition with a vector result.
+    // We must avoid generating the OpSelect if that would happen.
+    const analysis::Type* result_type = type_mgr->GetType(inst->type_id());
+    if (result_type && result_type->AsVector()) {
+      Instruction* cond_inst =
+          def_use_mgr->GetDef(non_const->GetSingleWordInOperand(0));
+      const analysis::Type* cond_type = type_mgr->GetType(cond_inst->type_id());
+      if (cond_type && !cond_type->AsVector()) {
+        if (spvVersionForTargetEnv(context->grammar().target_env()) <
+            SPV_SPIRV_VERSION_WORD(1, 4)) {
+          return false;
+        }
+      }
     }
 
     InstructionBuilder ir_builder(
@@ -3274,15 +3295,13 @@ FoldingRule MergeBinaryOpSelect(spv::Op opcode) {
     if (context->get_instruction_folder().FoldInstruction(lhs)) {
       context->AnalyzeDefUse(lhs);
       while (lhs->opcode() == spv::Op::OpCopyObject) {
-        lhs =
-            context->get_def_use_mgr()->GetDef(lhs->GetSingleWordInOperand(0));
+        lhs = def_use_mgr->GetDef(lhs->GetSingleWordInOperand(0));
       }
     }
     if (context->get_instruction_folder().FoldInstruction(rhs)) {
       context->AnalyzeDefUse(rhs);
       while (rhs->opcode() == spv::Op::OpCopyObject) {
-        rhs =
-            context->get_def_use_mgr()->GetDef(rhs->GetSingleWordInOperand(0));
+        rhs = def_use_mgr->GetDef(rhs->GetSingleWordInOperand(0));
       }
     }
     inst->SetOpcode(spv::Op::OpSelect);

--- a/test/opt/fold_test.cpp
+++ b/test/opt/fold_test.cpp
@@ -15686,6 +15686,69 @@ INSTANTIATE_TEST_SUITE_P(ImageOperandsBitmaskFoldingTest, MatchingInstructionWit
         , 89, true)
 ));
 
+TEST(FoldingTest, SelectVectorScalarConditionSPIRV13) {
+  std::string shader = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint GLCompute %main "main"
+    %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+    %bool = OpTypeBool
+    %_ptr_Function_bool = OpTypePointer Function %bool
+    %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+    %float_8 = OpConstant %float 8
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+    %v3float_111 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+    %main = OpFunction %void None %void_fn
+    %entry = OpLabel
+    %var = OpVariable %_ptr_Function_bool Function
+    %cond = OpLoad %bool %var
+    %select = OpSelect %float %cond %float_8 %float_0
+    %mul = OpVectorTimesScalar %v3float %v3float_111 %select
+    OpReturn
+    OpFunctionEnd
+  )";
+
+  std::unique_ptr<IRContext> context;
+  Instruction* inst;
+  std::tie(context, inst) = FoldInstruction(shader, 0, SPV_ENV_UNIVERSAL_1_3);
+  EXPECT_EQ(inst, nullptr);
+}
+
+TEST(FoldingTest, SelectVectorScalarConditionSPIRV14) {
+  std::string shader = R"(
+    OpCapability Shader
+    OpMemoryModel Logical GLSL450
+    OpEntryPoint GLCompute %main "main"
+    %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+    %bool = OpTypeBool
+    %_ptr_Function_bool = OpTypePointer Function %bool
+    %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+    %float_8 = OpConstant %float 8
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
+    %v3float_111 = OpConstantComposite %v3float %float_1 %float_1 %float_1
+    %main = OpFunction %void None %void_fn
+    %entry = OpLabel
+    %var = OpVariable %_ptr_Function_bool Function
+    %cond = OpLoad %bool %var
+    %select = OpSelect %float %cond %float_8 %float_0
+    %mul = OpVectorTimesScalar %v3float %v3float_111 %select
+    OpReturn
+    OpFunctionEnd
+  )";
+
+  std::unique_ptr<IRContext> context;
+  Instruction* inst;
+  std::tie(context, inst) = FoldInstruction(shader, 0, SPV_ENV_UNIVERSAL_1_4);
+  EXPECT_NE(inst, nullptr);
+  EXPECT_EQ(inst->opcode(), spv::Op::OpSelect);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
MergeBinaryOpSelect rule was folding binary operations with select
instructions even when the result was a vector and the condition was
scalar, which is only valid in SPIR-V 1.4+. This change restricts
this folding in SPIR-V versions prior to 1.4.

Assisted by: Antigravity

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/8603
