### PR TITLE
opt: Filter duplicate decorations during serialization

### DIFF
--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -17,10 +17,12 @@
 #include <algorithm>
 #include <cstring>
 #include <ostream>
+#include <unordered_set>
 
 #include "source/operand.h"
 #include "source/opt/ir_context.h"
 #include "source/opt/reflect.h"
+#include "source/util/hash_combine.h"
 
 namespace spvtools {
 namespace opt {
@@ -149,7 +151,8 @@ void Module::ForEachInst(const std::function<void(const Instruction*)>& f,
 #undef DELEGATE
 }
 
-void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
+void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
+                      bool filter_duplicates) const {
   binary->push_back(header_.magic_number);
   binary->push_back(header_.version);
   // TODO(antiagainst): should we change the generator number?
@@ -162,9 +165,21 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const {
   const Instruction* last_line_inst = nullptr;
   bool between_merge_and_branch = false;
   bool between_label_and_phi_var = false;
-  auto write_inst = [binary, skip_nop, &last_scope, &last_line_inst,
-                     &between_merge_and_branch, &between_label_and_phi_var,
+  std::unordered_set<std::vector<uint32_t>,
+                     spvtools::utils::VectorHash<uint32_t>>
+      seen_decorations;
+  auto write_inst = [binary, skip_nop, filter_duplicates, &last_scope,
+                     &last_line_inst, &between_merge_and_branch,
+                     &between_label_and_phi_var, &seen_decorations,
                      this](const Instruction* i) {
+    if (filter_duplicates && i->IsDecoration()) {
+      std::vector<uint32_t> inst_binary;
+      i->ToBinaryWithoutAttachedDebugInsts(&inst_binary);
+      if (seen_decorations.count(inst_binary)) {
+        return;
+      }
+      seen_decorations.insert(inst_binary);
+    }
     // Skip emitting line instructions between merge and branch instructions.
     auto opcode = i->opcode();
     if (between_merge_and_branch && i->IsLineInst()) {

--- a/source/opt/module.cpp
+++ b/source/opt/module.cpp
@@ -152,7 +152,7 @@ void Module::ForEachInst(const std::function<void(const Instruction*)>& f,
 }
 
 void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
-                      bool filter_duplicates) const {
+                      bool filter_duplicate_decorations) const {
   binary->push_back(header_.magic_number);
   binary->push_back(header_.version);
   // TODO(antiagainst): should we change the generator number?
@@ -168,11 +168,11 @@ void Module::ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
   std::unordered_set<std::vector<uint32_t>,
                      spvtools::utils::VectorHash<uint32_t>>
       seen_decorations;
-  auto write_inst = [binary, skip_nop, filter_duplicates, &last_scope,
-                     &last_line_inst, &between_merge_and_branch,
+  auto write_inst = [binary, skip_nop, filter_duplicate_decorations,
+                     &last_scope, &last_line_inst, &between_merge_and_branch,
                      &between_label_and_phi_var, &seen_decorations,
                      this](const Instruction* i) {
-    if (filter_duplicates && i->IsDecoration()) {
+    if (filter_duplicate_decorations && i->IsDecoration()) {
       std::vector<uint32_t> inst_binary;
       i->ToBinaryWithoutAttachedDebugInsts(&inst_binary);
       if (seen_decorations.count(inst_binary)) {

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -277,7 +277,8 @@ class Module {
 
   // Pushes the binary segments for this instruction into the back of *|binary|.
   // If |skip_nop| is true and this is a OpNop, do nothing.
-  void ToBinary(std::vector<uint32_t>* binary, bool skip_nop) const;
+  void ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
+                bool filter_duplicates = true) const;
 
   // Returns 1 more than the maximum Id value mentioned in the module.
   uint32_t ComputeIdBound() const;

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -276,9 +276,9 @@ class Module {
                    bool run_on_debug_line_insts = false) const;
 
   // Pushes the binary segments for this module into the back of *`binary`.
-  // If `skip_nop` is true and this is a OpNop, do nothing.
-  // If `filter_duplicate_decorations` is true, duplicate decorations are
-  // filtered out.
+  // If `skip_nop` is true, OpNop instructions will not be added to binary.
+  // If `filter_duplicate_decorations` is true, duplicate decorations will not
+  // be added to the binary.
   void ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
                 bool filter_duplicate_decorations = true) const;
 

--- a/source/opt/module.h
+++ b/source/opt/module.h
@@ -275,10 +275,12 @@ class Module {
   void ForEachInst(const std::function<void(const Instruction*)>& f,
                    bool run_on_debug_line_insts = false) const;
 
-  // Pushes the binary segments for this instruction into the back of *|binary|.
-  // If |skip_nop| is true and this is a OpNop, do nothing.
+  // Pushes the binary segments for this module into the back of *`binary`.
+  // If `skip_nop` is true and this is a OpNop, do nothing.
+  // If `filter_duplicate_decorations` is true, duplicate decorations are
+  // filtered out.
   void ToBinary(std::vector<uint32_t>* binary, bool skip_nop,
-                bool filter_duplicates = true) const;
+                bool filter_duplicate_decorations = true) const;
 
   // Returns 1 more than the maximum Id value mentioned in the module.
   uint32_t ComputeIdBound() const;

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -719,7 +719,8 @@ bool Optimizer::Run(const uint32_t* original_binary,
       !context->module()->ContainsDebugInfo()) {
     std::vector<uint32_t> optimized_binary_with_nop;
     context->module()->ToBinary(&optimized_binary_with_nop,
-                                /* skip_nop = */ false);
+                                /* skip_nop = */ false,
+                                /* filter_duplicates = */ false);
     assert(optimized_binary_with_nop.size() == original_binary_size &&
            "Binary size unexpectedly changed despite the optimizer saying "
            "there was no change");

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -720,7 +720,7 @@ bool Optimizer::Run(const uint32_t* original_binary,
     std::vector<uint32_t> optimized_binary_with_nop;
     context->module()->ToBinary(&optimized_binary_with_nop,
                                 /* skip_nop = */ false,
-                                /* filter_duplicates = */ false);
+                                /* filter_duplicate_decorations = */ false);
     assert(optimized_binary_with_nop.size() == original_binary_size &&
            "Binary size unexpectedly changed despite the optimizer saying "
            "there was no change");

--- a/source/util/hash_combine.h
+++ b/source/util/hash_combine.h
@@ -47,6 +47,13 @@ inline size_t hash_combine(std::size_t hash, const T& val,
   return hash_combine(hash_combine(hash, val), args...);
 }
 
+template <typename T>
+struct VectorHash {
+  size_t operator()(const std::vector<T>& v) const {
+    return hash_combine(0, v);
+  }
+};
+
 }  // namespace utils
 }  // namespace spvtools
 

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 
+#include "effcee/effcee.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "source/opt/build_module.h"
@@ -230,9 +231,21 @@ OpFunctionEnd)";
 
 // Tests that "text" does not change when it is assembled, converted into a
 // module, converted back to a binary, and then disassembled.
-void AssembleAndDisassemble(const std::string& text,
-                            const std::string& expected_text,
-                            bool filter_duplicates = true) {
+void AssembleAndDisassemble(const std::string& text) {
+  std::unique_ptr<IRContext> context = BuildModule(text);
+  std::vector<uint32_t> binary;
+
+  context->module()->ToBinary(&binary, false);
+
+  SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
+  std::string s;
+  tools.Disassemble(binary, &s);
+  EXPECT_EQ(s, text);
+}
+
+void AssembleDisassembleAndCheck(const std::string& text,
+                                 const std::string& prefix,
+                                 bool filter_duplicates) {
   std::unique_ptr<IRContext> context = BuildModule(text);
   std::vector<uint32_t> binary;
 
@@ -241,11 +254,14 @@ void AssembleAndDisassemble(const std::string& text,
   SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
   std::string s;
   tools.Disassemble(binary, &s);
-  EXPECT_EQ(s, expected_text);
-}
 
-void AssembleAndDisassemble(const std::string& text) {
-  AssembleAndDisassemble(text, text, true);
+  effcee::Options options;
+  options.SetPrefix(prefix);
+
+  auto match_result = effcee::Match(s, text, options);
+  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
+      << match_result.message() << "\nDisassembly:\n"
+      << s;
 }
 
 TEST(ModuleTest, TrailingOpLine) {
@@ -342,24 +358,20 @@ OpFunctionEnd
 }
 
 TEST(ModuleTest, ToBinaryFiltersDuplicateDecorations) {
-  const std::string text = R"(OpCapability Shader
-OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %2 "main"
-OpExecutionMode %2 LocalSize 1 1 1
-OpDecorate %1 RelaxedPrecision
-OpDecorate %1 RelaxedPrecision
-%void = OpTypeVoid
-%4 = OpTypeFunction %void
-%2 = OpFunction %void None %4
-%5 = OpLabel
-OpReturn
-OpFunctionEnd
-)";
+  const std::string text = R"(
+; CHECK-FILTER: OpDecorate [[id:%[0-9]+]] RelaxedPrecision
+; CHECK-FILTER-NOT: OpDecorate [[id]] RelaxedPrecision
+; CHECK-FILTER: %void = OpTypeVoid
 
-  const std::string expected_text = R"(OpCapability Shader
+; CHECK-NO-FILTER: OpDecorate [[id:%[0-9]+]] RelaxedPrecision
+; CHECK-NO-FILTER: OpDecorate [[id]] RelaxedPrecision
+; CHECK-NO-FILTER: %void = OpTypeVoid
+
+OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %2 "main"
 OpExecutionMode %2 LocalSize 1 1 1
+OpDecorate %1 RelaxedPrecision
 OpDecorate %1 RelaxedPrecision
 %void = OpTypeVoid
 %4 = OpTypeFunction %void
@@ -370,10 +382,10 @@ OpFunctionEnd
 )";
 
   // Test with filtering enabled (default)
-  AssembleAndDisassemble(text, expected_text, true);
+  AssembleDisassembleAndCheck(text, "CHECK-FILTER", true);
 
   // Test with filtering disabled
-  AssembleAndDisassemble(text, text, false);
+  AssembleDisassembleAndCheck(text, "CHECK-NO-FILTER", false);
 }
 }  // namespace
 }  // namespace opt

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -334,6 +334,54 @@ OpFunctionEnd
   EXPECT_EQ(1, non_semantic_ids.count(11));
   EXPECT_EQ(1, non_semantic_ids.count(12));
 }
+
+TEST(ModuleTest, ToBinaryFiltersDuplicateDecorations) {
+  const std::string text = R"(OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpDecorate %1 RelaxedPrecision
+OpDecorate %1 RelaxedPrecision
+%void = OpTypeVoid
+%fn_type = OpTypeFunction %void
+%main = OpFunction %void None %fn_type
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  std::unique_ptr<IRContext> context = BuildModule(text);
+
+  // Test with filtering enabled (default)
+  {
+    std::vector<uint32_t> binary;
+    context->module()->ToBinary(&binary, false);
+    SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
+    std::string s;
+    tools.Disassemble(binary, &s);
+
+    // Check that we have one decoration but not two.
+    size_t first = s.find("OpDecorate %1 RelaxedPrecision");
+    EXPECT_NE(first, std::string::npos);
+    size_t second = s.find("OpDecorate %1 RelaxedPrecision", first + 1);
+    EXPECT_EQ(second, std::string::npos);
+  }
+
+  // Test with filtering disabled
+  {
+    std::vector<uint32_t> binary;
+    context->module()->ToBinary(&binary, false, false);
+    SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
+    std::string s;
+    tools.Disassemble(binary, &s);
+
+    // Check that we have two decorations.
+    size_t first = s.find("OpDecorate %1 RelaxedPrecision");
+    EXPECT_NE(first, std::string::npos);
+    size_t second = s.find("OpDecorate %1 RelaxedPrecision", first + 1);
+    EXPECT_NE(second, std::string::npos);
+  }
+}
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -243,13 +243,17 @@ void AssembleAndDisassemble(const std::string& text) {
   EXPECT_EQ(s, text);
 }
 
+// Assembles `text`, serializes it to binary (with duplicate decorations
+// filtered if `filter_duplicate_decorations` is true), disassembles it, and
+// checks the output against the Effcee checks in `text` using the given
+// `prefix`.
 void AssembleDisassembleAndCheck(const std::string& text,
                                  const std::string& prefix,
-                                 bool filter_duplicates) {
+                                 bool filter_duplicate_decorations) {
   std::unique_ptr<IRContext> context = BuildModule(text);
   std::vector<uint32_t> binary;
 
-  context->module()->ToBinary(&binary, false, filter_duplicates);
+  context->module()->ToBinary(&binary, false, filter_duplicate_decorations);
 
   SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
   std::string s;

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -243,31 +243,6 @@ void AssembleAndDisassemble(const std::string& text) {
   EXPECT_EQ(s, text);
 }
 
-// Assembles `text`, serializes it to binary (with duplicate decorations
-// filtered if `filter_duplicate_decorations` is true), disassembles it, and
-// checks the output against the Effcee checks in `text` using the given
-// `prefix`.
-void AssembleDisassembleAndCheck(const std::string& text,
-                                 const std::string& prefix,
-                                 bool filter_duplicate_decorations) {
-  std::unique_ptr<IRContext> context = BuildModule(text);
-  std::vector<uint32_t> binary;
-
-  context->module()->ToBinary(&binary, false, filter_duplicate_decorations);
-
-  SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
-  std::string s;
-  tools.Disassemble(binary, &s);
-
-  effcee::Options options;
-  options.SetPrefix(prefix);
-
-  auto match_result = effcee::Match(s, text, options);
-  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
-      << match_result.message() << "\nDisassembly:\n"
-      << s;
-}
-
 TEST(ModuleTest, TrailingOpLine) {
   const std::string text = R"(OpCapability Shader
 OpCapability Linkage
@@ -359,6 +334,31 @@ OpFunctionEnd
   EXPECT_EQ(1, non_semantic_ids.count(8));
   EXPECT_EQ(1, non_semantic_ids.count(11));
   EXPECT_EQ(1, non_semantic_ids.count(12));
+}
+
+// Assembles `text`, serializes it to binary (with duplicate decorations
+// filtered if `filter_duplicate_decorations` is true), disassembles it, and
+// checks the output against the Effcee checks in `text` using the given
+// `prefix`.
+void AssembleDisassembleAndCheck(const std::string& text,
+                                 const std::string& prefix,
+                                 bool filter_duplicate_decorations) {
+  std::unique_ptr<IRContext> context = BuildModule(text);
+  std::vector<uint32_t> binary;
+
+  context->module()->ToBinary(&binary, false, filter_duplicate_decorations);
+
+  SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
+  std::string s;
+  tools.Disassemble(binary, &s);
+
+  effcee::Options options;
+  options.SetPrefix(prefix);
+
+  auto match_result = effcee::Match(s, text, options);
+  EXPECT_EQ(effcee::Result::Status::Ok, match_result.status())
+      << match_result.message() << "\nDisassembly:\n"
+      << s;
 }
 
 TEST(ModuleTest, ToBinaryFiltersDuplicateDecorations) {

--- a/test/opt/module_test.cpp
+++ b/test/opt/module_test.cpp
@@ -230,16 +230,22 @@ OpFunctionEnd)";
 
 // Tests that "text" does not change when it is assembled, converted into a
 // module, converted back to a binary, and then disassembled.
-void AssembleAndDisassemble(const std::string& text) {
+void AssembleAndDisassemble(const std::string& text,
+                            const std::string& expected_text,
+                            bool filter_duplicates = true) {
   std::unique_ptr<IRContext> context = BuildModule(text);
   std::vector<uint32_t> binary;
 
-  context->module()->ToBinary(&binary, false);
+  context->module()->ToBinary(&binary, false, filter_duplicates);
 
   SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
   std::string s;
   tools.Disassemble(binary, &s);
-  EXPECT_EQ(s, text);
+  EXPECT_EQ(s, expected_text);
+}
+
+void AssembleAndDisassemble(const std::string& text) {
+  AssembleAndDisassemble(text, text, true);
 }
 
 TEST(ModuleTest, TrailingOpLine) {
@@ -338,49 +344,36 @@ OpFunctionEnd
 TEST(ModuleTest, ToBinaryFiltersDuplicateDecorations) {
   const std::string text = R"(OpCapability Shader
 OpMemoryModel Logical GLSL450
-OpEntryPoint GLCompute %main "main"
-OpExecutionMode %main LocalSize 1 1 1
+OpEntryPoint GLCompute %2 "main"
+OpExecutionMode %2 LocalSize 1 1 1
 OpDecorate %1 RelaxedPrecision
 OpDecorate %1 RelaxedPrecision
 %void = OpTypeVoid
-%fn_type = OpTypeFunction %void
-%main = OpFunction %void None %fn_type
-%entry = OpLabel
+%4 = OpTypeFunction %void
+%2 = OpFunction %void None %4
+%5 = OpLabel
 OpReturn
 OpFunctionEnd
 )";
 
-  std::unique_ptr<IRContext> context = BuildModule(text);
+  const std::string expected_text = R"(OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %2 "main"
+OpExecutionMode %2 LocalSize 1 1 1
+OpDecorate %1 RelaxedPrecision
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%2 = OpFunction %void None %4
+%5 = OpLabel
+OpReturn
+OpFunctionEnd
+)";
 
   // Test with filtering enabled (default)
-  {
-    std::vector<uint32_t> binary;
-    context->module()->ToBinary(&binary, false);
-    SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
-    std::string s;
-    tools.Disassemble(binary, &s);
-
-    // Check that we have one decoration but not two.
-    size_t first = s.find("OpDecorate %1 RelaxedPrecision");
-    EXPECT_NE(first, std::string::npos);
-    size_t second = s.find("OpDecorate %1 RelaxedPrecision", first + 1);
-    EXPECT_EQ(second, std::string::npos);
-  }
+  AssembleAndDisassemble(text, expected_text, true);
 
   // Test with filtering disabled
-  {
-    std::vector<uint32_t> binary;
-    context->module()->ToBinary(&binary, false, false);
-    SpirvTools tools(SPV_ENV_UNIVERSAL_1_1);
-    std::string s;
-    tools.Disassemble(binary, &s);
-
-    // Check that we have two decorations.
-    size_t first = s.find("OpDecorate %1 RelaxedPrecision");
-    EXPECT_NE(first, std::string::npos);
-    size_t second = s.find("OpDecorate %1 RelaxedPrecision", first + 1);
-    EXPECT_NE(second, std::string::npos);
-  }
+  AssembleAndDisassemble(text, text, false);
 }
 }  // namespace
 }  // namespace opt


### PR DESCRIPTION
Add a mechanism to filter out duplicate decorations when writing the
SPIR-V module back to binary in Module::ToBinary. This prevents validation
errors when optimization passes (like loop unrolling) duplicate decorated
instructions.

The filtering uses a hash set of serialized instructions to identify and
skip duplicates.

A new parameter `filter_duplicates` is added to `Module::ToBinary` to
allow disabling this behavior, which is used during the optimizer's
integrity check to prevent false positive assertion failures.

Added unit test in `module_test.cpp` to verify the behavior.

Assisted by: Antigravity

Fixes: https://github.com/microsoft/DirectXShaderCompiler/issues/8609
