### PR TITLE
kokoro: set up a linux-gcc-gn build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ android_test/app
 compile_commands.json
 /build*/
 /buildtools/
+/testing/
 /external/abseil_cpp/
 /external/googletest
 /external/SPIRV-Headers
@@ -27,6 +28,14 @@ bazel-spirv-tools
 bazel-SPIRV-Tools
 bazel-testlogs
 MODULE.bazel.lock
+
+# These are generated when locally testing the GN kokoro scripts
+standalone.gclient
+standalone.gclient_entries
+.gclient_previous_custom_vars
+.gclient_previous_sync_commits
+.gcs_entries
+.cipd
 
 # Vim
 [._]*.s[a-w][a-z]

--- a/.gn
+++ b/.gn
@@ -12,9 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use the mostly-generic build configuration that comes from Chromium.
+# Do this to ensure that this project can be embedded in Chromium itself
+# or a Chromium-adjacent project.
 buildconfig = "//build/config/BUILDCONFIG.gn"
+
+# Use Python3 to run scripts. On Windows this will use python.exe or python.bat
+script_executable = "python3"
 
 default_args = {
   clang_use_chrome_plugins = false
+
+  # Requst a non-hermetic build.
+  # This is reasonable for standalone usage in upstream Glslang.
+  # It avoids a lot of overhead in the DEPS file and developer source trees.
+  # For example, don't download and use a custom Clang and libc++.
+  is_clang = false
+
+  # Disable various things that are are automatically turned on even
+  # we don't request a hermetic build with Clang.
   use_custom_libcxx = false
+
+  # Needed only for std::atomic_ref<T> for large Ts http://crbug.com/402171653
+  # Disable it to avoid the need to add the compiler-rt third_party dependency.
+  use_llvm_libatomic = false
 }
+
+# Export compile_commands.json to the build dir for all generated targets.
+# This is useful for editors that parse the compilation database for symbol lookup.
+export_compile_commands = [ "*" ]

--- a/DEPS
+++ b/DEPS
@@ -1,22 +1,86 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#   1. Get Chromium depot_tools, and put it in your path.
+#      See https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
+#
+#   2. From the SPIRV-Tools source tree root:
+#
+#      # Get additional build tooling, using the info in the DEPS file.
+#      cp utils/standalone.gclient .
+#      gclient sync --gclientfile=standalone.gclient
+#
+#   3. One of the tools downloaded in the previous step is the binary for 'gn'.
+#      Put it on your path.
+#
+#      # This is for Linux amd64 environments:
+#      PATH=$(pwd)/build/linux64:$PATH
+#
+#   3. Create a build tree with Ninja build recipes.
+#
+#      gn gen out/Debug
+#
+#      # Or build a release build:
+#      gn gen out/Release --args="is_debug=false"
+#
+#   4. Use ninja to build the project
+#
+#      ninja -C out/Debug
+
 use_relative_paths = True
 
+gclient_gn_args_file = 'build/config/gclient_args.gni'
+
+# Emit this vars for use in .gn and .gni files
+gclient_gn_args = [
+  # Needed by //build/toolchain/linux/BUILD.gn
+  # which was needed by 'action' in ./BUILD.gn
+  'build_with_chromium',
+  # Needed by //testing/test.gni
+  'generate_location_tags',
+]
+
+git_dependencies = 'SYNC'
+
 vars = {
+  # Repo sources
+  'chromium_git': 'https://chromium.googlesource.com',
   'github': 'https://github.com',
 
+  # Building context
+  'build_with_chromium': False,
+  'spirv_tools_standalone': True,
+  'generate_location_tags': False,
+
+  # Commits for GN-related tooling
+  'spirv_tools_gn_version': 'git_revision:ec56d4d935a0e2ab9d52b88dd00c93ec51233055',
+  'spirv_tools_build_version': '2316930a88b15a036fa5f72e2b2c2ba08e2904a0',
+
+  # Commits for SPIRV-Tools dependencies
+
   'abseil_revision': 'c34b1491291f7673fd758ea3aa08517231497b97',
-
   'effcee_revision': '910ed15722d5d05c9d71ecf36c1a22243cb79b02',
-
   'googletest_revision': 'a25f43576effe4ebe887412a603cddfa8fc3ba64',
-
   # Use a recent protobuf, which can depend on abseil
   'protobuf_revision': '35cd01f9fe9afbeea38cc7b979a3b6bfcde82c03',
-
   're2_revision': '972a15cedd008d846f1a39b2e88ce48d7f166cbd',
-
   'spirv_headers_revision': '27009dcaecd266ea7fb969bca44ebc87dcdc6269',
-
   'mimalloc_revision': '76d3f8a934f9761e4ee75fa8b071e58d482f2758',
+
+  # SPIRV-Tools standalone GN-only dependencies
+  'chromium_testing_version': '555e7546214837372345fef14e25eed42ff2ea07',
 }
 
 deps = {
@@ -41,5 +105,72 @@ deps = {
 
   'external/mimalloc':
       Var('github') + '/microsoft/mimalloc.git@' + Var('mimalloc_revision'),
+
+  # Get buildtools.
+  # We need the 'gn' binary.
+  'buildtools': {
+    'url': Var('chromium_git') + '/chromium/src/buildtools@11cc2bd83053cb790b7516aa3eb3f3935fb05a0e',
+    'condition': 'spirv_tools_standalone',
+  },
+  'buildtools/linux64': {
+    'packages': [{
+      'package': 'gn/gn/linux-${{arch}}',
+      'version': Var('spirv_tools_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'spirv_tools_standalone and host_os == "linux"',
+  },
+  'buildtools/mac': {
+    'packages': [{
+      'package': 'gn/gn/mac-${{arch}}',
+      'version': Var('spirv_tools_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'spirv_tools_standalone and host_os == "mac"',
+  },
+  'buildtools/win': {
+    'packages': [{
+      'package': 'gn/gn/windows-amd64',
+      'version': Var('spirv_tools_gn_version'),
+    }],
+    'dep_type': 'cipd',
+    'condition': 'spirv_tools_standalone and host_os == "win"',
+  },
+
+  # Get //build from Chromium.
+  # It contains the generic //build/config/BUILDCONFIG.gn that sets up most rules
+  # for C++ compilation.
+  'build': {
+  'url': Var('chromium_git') + '/chromium/src/build@' + Var('spirv_tools_build_version'),
+    'condition': 'spirv_tools_standalone',
+  },
+  # For fuzzing
+  'testing': {
+    'url': Var('chromium_git') + '/chromium/src/testing@' + Var('chromium_testing_version'),
+    'condition': 'spirv_tools_standalone',
+  },
 }
 
+hooks = [
+  # The Chromium BUILDCONFIG.gn has a false dependency on the sysroots.
+  # Pull the compilers and system libraries for hermetic builds
+  {
+    'name': 'sysroot_x86',
+    'pattern': '.',
+    'condition': 'spirv_tools_standalone and checkout_linux and checkout_x86',
+    'action': ['vpython3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x86'],
+  },
+  {
+    'name': 'sysroot_x64',
+    'pattern': '.',
+    'condition': 'spirv_tools_standalone and checkout_linux and checkout_x64',
+    'action': ['vpython3', 'build/linux/sysroot_scripts/install-sysroot.py',
+               '--arch=x64'],
+  },
+]
+
+
+recursedeps = [
+  'buildtools',
+]

--- a/build_overrides/build.gni
+++ b/build_overrides/build.gni
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Get user-specfied settings. This path is specified in the top-level DEPS file.
+import("//build/config/gclient_args.gni")
+
+spirv_tools_standalone = true
+
 # Variable that can be used to support multiple build scenarios, like having
 # Chromium specific targets in a client project's GN file etc.
 build_with_chromium = false

--- a/kokoro/linux-gcc-gn/build.sh
+++ b/kokoro/linux-gcc-gn/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on any error.
+set -e
+# Display commands being run.
+set -x
+
+SCRIPT_DIR=`dirname "$BASH_SOURCE"`
+source $SCRIPT_DIR/../scripts/linux/build.sh RELEASE gn-selected-compiler gn

--- a/kokoro/linux-gcc-gn/continuous.cfg
+++ b/kokoro/linux-gcc-gn/continuous.cfg
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Continuous build configuration.
+build_file: "SPIRV-Tools/kokoro/linux-gcc-gn/build.sh"

--- a/kokoro/linux-gcc-gn/presubmit.cfg
+++ b/kokoro/linux-gcc-gn/presubmit.cfg
@@ -1,0 +1,16 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Presubmit build configuration.
+build_file: "SPIRV-Tools/kokoro/linux-gcc-gn/build.sh"

--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -45,10 +45,14 @@ function clean_dir() {
   mkdir "$dir"
 }
 
-if [ $TOOL != "cmake-shaderc-smoketest" ] && [ $TOOL != "cmake-dxc-smoketest" ]; then
-  # Get source for dependencies, as specified in the DEPS file
-  /usr/bin/python3 utils/git-sync-deps --treeless
-fi
+case $TOOL in
+  cmake-shaderc-smoketest|cmake-dxc-smoketest|gn)
+    ;;
+  *)
+    # Get source for dependencies, as specified in the DEPS file
+    python3 utils/git-sync-deps --prefix=external --treeless
+esac
+
 
 if [ $TOOL = "cmake" ]; then
   using cmake-3.31.2
@@ -244,4 +248,54 @@ elif [ $TOOL = "bazel" ]; then
   echo $(date): Starting bazel test...
   bazel test --cxxopt=-std=c++17 :all
   echo $(date): Bazel test completed.
+
+elif [ $TOOL = "gn" ]; then
+  using ninja-1.10.0
+  echo $(date -Iseconds): Start GN build...
+
+  echo "$(date -Iseconds): Fetching depot_tools..."
+  rm -rf /tmp/depot_tools
+  mkdir -p /tmp/depot_tools
+  git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /tmp/depot_tools
+  export PATH="/tmp/depot_tools:$PATH"
+
+  echo "$(date -Iseconds): Syncing client..."
+  # Silence gn related babble
+  export GCLIENT_SUPPRESS_GIT_VERSION_WARNING=1
+  # For the 'root' user, silence gclient metrics collection.
+  if [[ -z "$USER" ]]; then
+    mkdir -p $HOME/.config/depot_tools
+    echo  >$HOME/.config/depot_tools/metrics.cfg '{"is-googler": false, "countdown": 0, "opt-in": false, "version": 1}'
+  fi
+
+  # Erase the GN args from any previous run of gclient.
+  # This is important for local testing.
+  rm -f build/config/gclient_args.gni
+
+  # Sync dependencies and generate default GN args from the DEPS file.
+  cp utils/standalone.gclient .
+  gclient sync -v -D --gclientfile=standalone.gclient
+
+  echo "$(date -Iseconds): Generate Ninja build plan..."
+
+  # Ensure the gn binary is on the path
+  export PATH=$(pwd)/buildtools/linux64:$PATH
+  # which -a gn  # There should be two
+
+  if [ $CONFIG = "RELEASE" ]; then
+    arg="is_debug=false"
+    BUILD_DIR=out/release
+  else
+    arg="is_debug=true"
+    BUILD_DIR=out/debug
+  fi
+  clean_dir "$BUILD_DIR"
+  gn gen "$BUILD_DIR" --args="$arg"
+
+  echo "$(date -Iseconds): Building..."
+  ninja -v -C "$BUILD_DIR"
+  echo "$(date -Iseconds): Done"
+
+else
+  echo "Unknown TOOL '$TOOL'"
 fi

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -35,6 +35,13 @@ function chown_dir() {
   fi
 }
 
+# Set up a volume mapping for kokoro artifacts only if the corresponding
+# env var exists. The env var will not exist when manally testing this script.
+ARTIFACTS_MAPPING=
+if [ -n "${KOKORO_ARTIFACTS_DIR}" ]; then
+  ARTIFACTS_MAPPING="--volume ${KOKORO_ARTIFACTS_DIR}:${KOKORO_ARTIFACTS_DIR}"
+fi
+
 set +e
 # Allow build failures
 
@@ -42,7 +49,7 @@ set +e
 docker run --rm -i \
   --privileged \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
-  --volume "${KOKORO_ARTIFACTS_DIR}:${KOKORO_ARTIFACTS_DIR}" \
+  $ARTIFACTS_MAPPING \
   --workdir "${ROOT_DIR}" \
   --env SCRIPT_DIR=${SCRIPT_DIR} \
   --env ROOT_DIR=${ROOT_DIR} \

--- a/kokoro/scripts/macos/build.sh
+++ b/kokoro/scripts/macos/build.sh
@@ -36,7 +36,7 @@ chmod +x ninja
 export PATH="$PWD:$PATH"
 
 cd $SRC
-python3 utils/git-sync-deps --treeless
+python3 utils/git-sync-deps --prefix=external --treeless
 
 mkdir build && cd $SRC/build
 

--- a/kokoro/scripts/windows/build.bat
+++ b/kokoro/scripts/windows/build.bat
@@ -33,7 +33,7 @@ if %VS_VERSION% == 2022 (
 )
 
 cd %SRC%
-python utils/git-sync-deps --treeless
+python utils/git-sync-deps --prefix=external --treeless
 
 mkdir build
 cd build

--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -77,9 +77,9 @@ def git_executable():
       major=None
       minor=None
       try:
-        version_info = subprocess.check_output([git, '--version']).decode('utf-8')
+        version_info = subprocess.check_output([git, '--version']).decode('utf-8').strip('\r\n')
         match = re.search(r"^git version (\d+)\.(\d+)",version_info)
-        print("Using {}".format(version_info))
+        print("git-sync-deps: using {}".format(version_info))
         if match:
           major = int(match.group(1))
           minor = int(match.group(2))
@@ -217,11 +217,13 @@ def parse_file_to_dict(path):
   return dictionary
 
 
-def git_sync_deps(deps_file_path, command_line_os_requests, verbose, treeless):
+def git_sync_deps(deps_file_path, prefix, command_line_os_requests, verbose, treeless):
   """Grab dependencies, with optional platform support.
 
   Args:
     deps_file_path (string) Path to the DEPS file.
+
+    prefix (string) Only check out paths with this prefix.
 
     command_line_os_requests (list of strings) Can be empty list.
         List of strings that should each be a key in the deps_os
@@ -243,37 +245,61 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose, treeless):
 
   deps_file_directory = os.path.dirname(deps_file_path)
   deps_file = parse_file_to_dict(deps_file_path)
-  dependencies = deps_file['deps'].copy()
+  all_deps = deps_file['deps'].copy()
   os_specific_dependencies = deps_file.get('deps_os', dict())
   if 'all' in command_line_os_requests:
     for value in list(os_specific_dependencies.values()):
-      dependencies.update(value)
+      all_deps.update(value)
   else:
     for os_name in command_line_os_requests:
       # Add OS-specific dependencies
       if os_name in os_specific_dependencies:
-        dependencies.update(os_specific_dependencies[os_name])
-  for directory in dependencies:
-    for other_dir in dependencies:
-      if directory.startswith(other_dir + '/'):
-        raise Exception('%r is parent of %r' % (other_dir, directory))
-  list_of_arg_lists = []
-  for directory in sorted(dependencies):
-    if '@' in dependencies[directory]:
-      repo, checkoutable = dependencies[directory].split('@', 1)
-    else:
-      raise Exception("please specify commit or tag")
+        all_deps.update(os_specific_dependencies[os_name])
+  dependencies = dict()
+  for k,v in all_deps.items():
+    if k.startswith(prefix):
+      dependencies[k] = v
 
-    relative_directory = os.path.join(deps_file_directory, directory)
+  # Schedule the checkouts in batches, where a parent is always in
+  # a batch before its descendants.
+  while len(dependencies) > 0:
+    # Find a batch of directories we can checkout in parallel.
+    list_of_arg_lists = []
+    pending_dirs = []
+    # Sort subdirs so parents appear before children
+    for subdir in sorted(dependencies):
+      if len([d for d in pending_dirs if subdir.startswith(d)]) == 0:
+        # Doesn't conflict with any pending work.
+        pending_dirs.append(f"{subdir}/")
 
-    list_of_arg_lists.append(
-      (git, repo, checkoutable, relative_directory, verbose, treeless))
+        value = dependencies[subdir]
+        del dependencies[subdir]
+        if isinstance(value, dict):
+          # Note: this code does not handle conditions.
+          if 'url' in value:
+            value = value['url']
+          elif 'dep_type' in value:
+            # typically a cipd package. Skip with warning
+            print(f"git-sync-deps: warning: skipping {value['dep_type']} dependency '{subdir}'")
+            continue
 
-  multithread(git_checkout_to_directory, list_of_arg_lists)
+        if '@' in value:
+          repo, checkoutable = value.split('@', 1)
+        else:
+          print(f"subdir {subdir} value {value}")
+          raise Exception("please specify commit or tag")
+
+        relative_directory = os.path.join(deps_file_directory, subdir)
+
+        list_of_arg_lists.append(
+          (git, repo, checkoutable, relative_directory, verbose, treeless))
+
+    multithread(git_checkout_to_directory, list_of_arg_lists)
 
   for directory in deps_file.get('recursedeps', []):
-    recursive_path = os.path.join(deps_file_directory, directory, 'DEPS')
-    git_sync_deps(recursive_path, command_line_os_requests, verbose)
+    if directory.startswith(prefix):
+      recursive_path = os.path.join(deps_file_directory, directory, 'DEPS')
+      git_sync_deps(recursive_path, prefix, command_line_os_requests, verbose, treeless)
 
 
 def multithread(function, list_of_arg_lists):
@@ -301,6 +327,9 @@ def main(argv):
   argparser.add_argument("--deps",
                          default = os.environ.get('GIT_SYNC_DEPS_PATH', DEFAULT_DEPS_PATH),
                          help="location of the the DEPS file")
+  argparser.add_argument("--prefix",
+                         default = '',
+                         help="only check out paths with this prefix")
   argparser.add_argument("--verbose",
                          default=not bool(os.environ.get('GIT_SYNC_DEPS_QUIET', False)),
                          action='store_true',
@@ -330,7 +359,7 @@ def main(argv):
     print(get_deps_os_str(args.deps))
     return 0
 
-  git_sync_deps(args.deps, args.os_requests, args.verbose, args.treeless)
+  git_sync_deps(args.deps, args.prefix, args.os_requests, args.verbose, args.treeless)
   return 0
 
 

--- a/utils/standalone.gclient
+++ b/utils/standalone.gclient
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy this to the source root, then run:
+#   gclient sync -D --gclientfile=standalone.gclient
+solutions = [
+  { "name"        : ".",
+    "url"         : "https://github.com/KhronosGroup/SPIRV-Tools",
+    "deps_file"   : "DEPS",
+    "managed"     : False,
+    "custom_deps" : {
+    },
+  },
+]


### PR DESCRIPTION
Update .gitignore to ignore files generated during local GN builds

Update DEPS, GN scripting, standalone gclient client file

Support manually testing the linux kokoro scripts with podman.
- In kokoro/scripts/linux/build-docker.sh: Only set up the artifacts volume mapping when the corresponding Kokoro environment variable is set.  Otherwise podman will fail to launch the container.

git-sync-deps: understand enhanced DEPS file
    
    - Add --prefix argument to filter the subdirs we care about.
      SPIRV-Tools Cmake builds will only want --prefix=external
    - Warn that git-sync-deps will not checkout cipd or gcs dependencies
      Warn insted of erroring so that it's harmless to *not* supply
      the --prefix option
   

Issue: #2810