### PR TITLE
kokoro: fix linux-gcc-gn build

### DIFF
--- a/kokoro/scripts/linux/build-docker.sh
+++ b/kokoro/scripts/linux/build-docker.sh
@@ -42,7 +42,7 @@ function clean_dir() {
   if [[ -d "$dir" ]]; then
     rm -fr "$dir"
   fi
-  mkdir "$dir"
+  mkdir -p "$dir"
 }
 
 case $TOOL in

--- a/kokoro/scripts/linux/build.sh
+++ b/kokoro/scripts/linux/build.sh
@@ -65,6 +65,7 @@ RESULT=$?
 # This is important. If the permissions are not fixed, kokoro will fail
 # to pull build artifacts, and put the build in tool-failure state, which
 # blocks the logs.
-chown_dir "${ROOT_DIR}/build"
-chown_dir "${ROOT_DIR}/external"
+for d in build external testing buildtools out; do
+  [ ! -d "${ROOT_DIR}/$d" ] || chown_dir "${ROOT_DIR}/$d"
+done
 exit $RESULT


### PR DESCRIPTION
- fix creation of deep build dir
- Generalize the chown in the wrapper script to cover all dirs
      that might be generated during the build.
