### PR TITLE
roll: Move mimalloc to main3

### DIFF
--- a/utils/roll_deps.sh
+++ b/utils/roll_deps.sh
@@ -35,7 +35,7 @@ dependency_to_branch_map["external/effcee/"]="origin/main"
 dependency_to_branch_map["external/googletest/"]="origin/main"
 dependency_to_branch_map["external/re2/"]="origin/main"
 dependency_to_branch_map["external/spirv-headers/"]="origin/main"
-dependency_to_branch_map["external/mimalloc/"]="origin/main"
+dependency_to_branch_map["external/mimalloc/"]="origin/main3"
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..


### PR DESCRIPTION
Upstream mimalloc now uses main3 as the default branch. Updating our
scripts to track that branch when doing rolls.
