### PR TITLE
Optimize `SPV_KHR_opacity_micromap`

### DIFF
--- a/source/opt/aggressive_dead_code_elim_pass.cpp
+++ b/source/opt/aggressive_dead_code_elim_pass.cpp
@@ -1162,6 +1162,7 @@ void AggressiveDCEPass::InitExtensions() {
       "SPV_KHR_maximal_reconvergence",
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
+      "SPV_KHR_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
       "SPV_EXT_shader_atomic_float16_add",
       "SPV_KHR_abort",

--- a/source/opt/local_access_chain_convert_pass.cpp
+++ b/source/opt/local_access_chain_convert_pass.cpp
@@ -472,6 +472,7 @@ void LocalAccessChainConvertPass::InitExtensions() {
       "SPV_KHR_maximal_reconvergence",
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
+      "SPV_KHR_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
       "SPV_EXT_shader_atomic_float16_add",
       "SPV_KHR_abort",

--- a/source/opt/local_single_block_elim_pass.cpp
+++ b/source/opt/local_single_block_elim_pass.cpp
@@ -309,6 +309,7 @@ void LocalSingleBlockLoadStoreElimPass::InitExtensions() {
       "SPV_KHR_maximal_reconvergence",
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
+      "SPV_KHR_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
       "SPV_EXT_shader_atomic_float16_add",
       "SPV_KHR_abort",

--- a/source/opt/local_single_store_elim_pass.cpp
+++ b/source/opt/local_single_store_elim_pass.cpp
@@ -161,6 +161,7 @@ void LocalSingleStoreElimPass::InitExtensionAllowList() {
       "SPV_KHR_maximal_reconvergence",
       "SPV_NV_push_constant_bank",
       "SPV_EXT_opacity_micromap",
+      "SPV_KHR_opacity_micromap",
       "SPV_EXT_shader_invocation_reorder",
       "SPV_EXT_shader_atomic_float16_add",
       "SPV_KHR_abort",


### PR DESCRIPTION
Just like https://github.com/KhronosGroup/SPIRV-Tools/pull/6571 this allows optimization shaders containing `SPV_KHR_opacity_micromap`, required to strip dead and invalid SPIR-V ops that DXC otherwise emits.
