### PR TITLE
binary: Initialize parsed operand FP encoding

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -489,6 +489,7 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
   // Assume non-numeric values.  This will be updated for literal numbers.
   parsed_operand.number_kind = SPV_NUMBER_NONE;
   parsed_operand.number_bit_width = 0;
+  parsed_operand.fp_encoding = SPV_FP_ENCODING_UNKNOWN;
 
   if (_.word_index >= _.num_words)
     return exhaustedInputDiagnostic(inst_offset, opcode, type);

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -32,7 +32,8 @@ static bool operator==(const spv_parsed_operand_t& a,
                        const spv_parsed_operand_t& b) {
   return a.offset == b.offset && a.num_words == b.num_words &&
          a.type == b.type && a.number_kind == b.number_kind &&
-         a.number_bit_width == b.number_bit_width;
+         a.number_bit_width == b.number_bit_width &&
+         a.fp_encoding == b.fp_encoding;
 }
 
 namespace spvtools {
@@ -104,7 +105,8 @@ std::ostream& operator<<(std::ostream& os, const ParsedInstruction& inst) {
     os << " { offset: " << operand.offset << " num_words: " << operand.num_words
        << " type: " << int(operand.type)
        << " number_kind: " << int(operand.number_kind)
-       << " number_bit_width: " << int(operand.number_bit_width) << "}";
+       << " number_bit_width: " << int(operand.number_bit_width)
+       << " fp_encoding: " << int(operand.fp_encoding) << "}";
   }
   os << ")";
   return os;
@@ -168,6 +170,13 @@ spv_parsed_operand_t MakeSimpleOperand(uint16_t offset,
 spv_parsed_operand_t MakeLiteralNumberOperand(uint16_t offset) {
   return {offset, 1, SPV_OPERAND_TYPE_LITERAL_INTEGER, SPV_NUMBER_UNSIGNED_INT,
           32};
+}
+
+// Returns a parsed operand for a standalone literal float value at the given
+// word offset within an instruction.
+spv_parsed_operand_t MakeLiteralFloatOperand(uint16_t offset) {
+  return {offset, 1, SPV_OPERAND_TYPE_LITERAL_FLOAT, SPV_NUMBER_FLOATING, 32,
+          SPV_FP_ENCODING_UNKNOWN};
 }
 
 // Returns a parsed operand for a literal string value at the given
@@ -786,6 +795,29 @@ TEST_F(CxxBinaryParseTest, InstructionWithStringOperand) {
     Parse(words, true, endian_swap);
     EXPECT_EQ(nullptr, diagnostic_);
   }
+}
+
+TEST_F(BinaryParseTest, LiteralFloatOperandHasUnknownEncoding) {
+  const auto instruction = MakeInstruction(
+      spv::Op::OpDecorate,
+      {1, uint32_t(spv::Decoration::FPMaxErrorDecorationINTEL), 0x20202020});
+  const auto words = Concatenate({ExpectedHeaderForBound(2), instruction});
+  InSequence calls_expected_in_specific_order;
+  EXPECT_HEADER(2).WillOnce(Return(SPV_SUCCESS));
+  const auto operands = std::vector<spv_parsed_operand_t>{
+      MakeSimpleOperand(1, SPV_OPERAND_TYPE_ID),
+      MakeSimpleOperand(2, SPV_OPERAND_TYPE_DECORATION),
+      MakeLiteralFloatOperand(3)};
+  EXPECT_CALL(
+      client_,
+      Instruction(ParsedInstruction(spv_parsed_instruction_t{
+          instruction.data(), static_cast<uint16_t>(instruction.size()),
+          uint16_t(spv::Op::OpDecorate), SPV_EXT_INST_TYPE_NONE, 0 /* type id */,
+          0 /* no result id */, operands.data(),
+          static_cast<uint16_t>(operands.size())})))
+      .WillOnce(Return(SPV_SUCCESS));
+
+  Parse(words, SPV_SUCCESS);
 }
 
 // Checks for non-zero values for the result_id and ext_inst_type members

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -41,13 +41,13 @@ namespace {
 
 using ::spvtest::Concatenate;
 using ::spvtest::MakeInstruction;
-using utils::MakeVector;
 using ::spvtest::ScopedContext;
 using ::testing::_;
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::InSequence;
 using ::testing::Return;
+using utils::MakeVector;
 
 using MaybeFlipWordsTest = spvtest::TextToBinaryTest;
 
@@ -175,7 +175,11 @@ spv_parsed_operand_t MakeLiteralNumberOperand(uint16_t offset) {
 // Returns a parsed operand for a standalone literal float value at the given
 // word offset within an instruction.
 spv_parsed_operand_t MakeLiteralFloatOperand(uint16_t offset) {
-  return {offset, 1, SPV_OPERAND_TYPE_LITERAL_FLOAT, SPV_NUMBER_FLOATING, 32,
+  return {offset,
+          1,
+          SPV_OPERAND_TYPE_LITERAL_FLOAT,
+          SPV_NUMBER_FLOATING,
+          32,
           SPV_FP_ENCODING_UNKNOWN};
 }
 
@@ -808,13 +812,12 @@ TEST_F(BinaryParseTest, LiteralFloatOperandHasUnknownEncoding) {
       MakeSimpleOperand(1, SPV_OPERAND_TYPE_ID),
       MakeSimpleOperand(2, SPV_OPERAND_TYPE_DECORATION),
       MakeLiteralFloatOperand(3)};
-  EXPECT_CALL(
-      client_,
-      Instruction(ParsedInstruction(spv_parsed_instruction_t{
-          instruction.data(), static_cast<uint16_t>(instruction.size()),
-          uint16_t(spv::Op::OpDecorate), SPV_EXT_INST_TYPE_NONE, 0 /* type id */,
-          0 /* no result id */, operands.data(),
-          static_cast<uint16_t>(operands.size())})))
+  EXPECT_CALL(client_,
+              Instruction(ParsedInstruction(spv_parsed_instruction_t{
+                  instruction.data(), static_cast<uint16_t>(instruction.size()),
+                  uint16_t(spv::Op::OpDecorate), SPV_EXT_INST_TYPE_NONE,
+                  0 /* type id */, 0 /* no result id */, operands.data(),
+                  static_cast<uint16_t>(operands.size())})))
       .WillOnce(Return(SPV_SUCCESS));
 
   Parse(words, SPV_SUCCESS);


### PR DESCRIPTION
## Problem

When `fp_encoding` was added to `spv_parsed_operand_t`, `Parser::parseOperand` did not give the field a default value. Standalone literal-float operands therefore pass an indeterminate enum to `EmitNumericLiteral`, causing the MemorySanitizer finding in [OSS-Fuzz issue 423059200](https://issues.oss-fuzz.com/issues/423059200) and nondeterministic disassembly.

The public testcase reaches this path through `OpDecorate ... FPMaxErrorDecorationINTEL <LiteralFloat>`. With compiler stack-pattern initialization, the float was omitted from the output; with zero initialization, it was printed.

## Fix

Initialize every parsed operand with `SPV_FP_ENCODING_UNKNOWN` before operand-specific parsing. Extend the parser-test equality and diagnostics to cover this field, and add a regression test for the standalone literal-float decoration path.

## Verification

- Exact OSS-Fuzz testcase disassembles with its float operand under `-ftrivial-auto-var-init=pattern`.
- `BinaryParseTest.LiteralFloatOperandHasUnknownEncoding` passes.
- All 6,418 `test_spirv_unit_tests` cases pass under stack-pattern initialization.