### PR TITLE
spirv-val: Check for Offset in Input/Output

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -296,6 +296,33 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
           }
         }
 
+        // Check for invalid struct member decorations on Input/Output
+        if (is_struct && (storage_class == spv::StorageClass::Input ||
+                          storage_class == spv::StorageClass::Output)) {
+          for (auto& dec : vstate.id_decorations(type_id)) {
+            if (dec.dec_type() != spv::Decoration::Offset) continue;
+            // same as below, instead of spending time checking PerTaskNV just
+            // assume legacy shaders work instead of searchign the block
+            if (vstate.HasCapability(spv::Capability::MeshShadingNV)) continue;
+            if (storage_class == spv::StorageClass::Output) {
+              // Instead of checking if the block inherits XfbBuffer/XfbStride,
+              // just assume anyone declaring TransformFeedback has a legacy
+              // shader they know is working already with Offset
+              if (!vstate.HasCapability(spv::Capability::TransformFeedback)) {
+                return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
+                       << vstate.VkErrorID(4716)
+                       << "The Output interfaces variable must not have Offset "
+                          "on any member decoration unless dealing with "
+                          "TransformFeedback.";
+              }
+            } else {
+              return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
+                     << "The Input interfaces variable must not have Offset on "
+                        "any member decoration.";
+            }
+          }
+        }
+
         if (storage_class == spv::StorageClass::Workgroup) {
           ++num_workgroup_variables;
           if (type_instr) {

--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -311,13 +311,13 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
               if (!vstate.HasCapability(spv::Capability::TransformFeedback)) {
                 return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
                        << vstate.VkErrorID(4716)
-                       << "The Output interfaces variable must not have Offset "
+                       << "The Output interface variable must not have Offset "
                           "on any member decoration unless dealing with "
                           "TransformFeedback.";
               }
             } else {
               return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
-                     << "The Input interfaces variable must not have Offset on "
+                     << "The Input interface variable must not have Offset on "
                         "any member decoration.";
             }
           }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -3288,6 +3288,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-PhysicalStorageBuffer64-04710);
     case 4711:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeForwardPointer-04711);
+    case 4716:
+      return VUID_WRAP(VUID-StandaloneSpirv-Offset-04716);
     case 4734:
       return VUID_WRAP(VUID-StandaloneSpirv-OpVariable-04734);
     case 4744:

--- a/test/opt/aggressive_dead_code_elim_test.cpp
+++ b/test/opt/aggressive_dead_code_elim_test.cpp
@@ -4850,6 +4850,7 @@ TEST_F(AggressiveDCETest, PartiallyDeadGroupMemberDecorate) {
 ; CHECK: [[output]] = OpTypeStruct
 ; CHECK-NOT: OpTypeStruct
 OpCapability Shader
+OpCapability TransformFeedback
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %main "main" %output
 OpExecutionMode %main OriginUpperLeft
@@ -4890,6 +4891,7 @@ TEST_F(AggressiveDCETest,
 ; CHECK: [[output]] = OpTypeStruct
 ; CHECK-NOT: OpTypeStruct
 OpCapability Shader
+OpCapability TransformFeedback
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %main "main" %output
 OpExecutionMode %main OriginUpperLeft

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -6984,6 +6984,94 @@ OpFunctionEnd
               AnyVUID("VUID-StandaloneSpirv-Function-12294"));
 }
 
+// From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8427
+TEST_F(ValidateDecorations, InputWithOffset) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %6 "main" %9 %10
+               OpExecutionMode %6 OriginUpperLeft
+               OpDecorate %FsOut Block
+               OpMemberDecorate %FsOut 0 Location 0
+               OpMemberDecorate %ShaderLink 0 Offset 0
+               OpDecorate %ShaderLink Block
+               OpMemberDecorate %ShaderLink 0 Location 0
+       %void = OpTypeVoid
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_0 = OpConstant %int 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+      %FsOut = OpTypeStruct %v4float
+%_ptr_Output_FsOut = OpTypePointer Output %FsOut
+ %ShaderLink = OpTypeStruct %v4float
+%_ptr_Input_ShaderLink = OpTypePointer Input %ShaderLink
+         %50 = OpTypeFunction %void
+          %9 = OpVariable %_ptr_Input_ShaderLink Input
+         %10 = OpVariable %_ptr_Output_FsOut Output
+          %6 = OpFunction %void None %50
+         %59 = OpLabel
+         %60 = OpAccessChain %_ptr_Output_v4float %10 %int_0
+         %61 = OpAccessChain %_ptr_Input_v4float %9 %int_0
+         %62 = OpLoad %v4float %61
+               OpStore %60 %62
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The Input interfaces variable must not have Offset on "
+                        "any member decoration"));
+}
+
+// From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8427
+TEST_F(ValidateDecorations, OutputWithOffset) {
+  const std::string text = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %6 "main" %9 %10
+               OpExecutionMode %6 OriginUpperLeft
+               OpMemberDecorate %FsOut 0 Offset 0
+               OpDecorate %FsOut Block
+               OpMemberDecorate %FsOut 0 Location 0
+               OpDecorate %ShaderLink Block
+               OpMemberDecorate %ShaderLink 0 Location 0
+       %void = OpTypeVoid
+        %int = OpTypeInt 32 1
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%_ptr_Output_v4float = OpTypePointer Output %v4float
+      %int_0 = OpConstant %int 0
+%_ptr_Input_v4float = OpTypePointer Input %v4float
+      %FsOut = OpTypeStruct %v4float
+%_ptr_Output_FsOut = OpTypePointer Output %FsOut
+ %ShaderLink = OpTypeStruct %v4float
+%_ptr_Input_ShaderLink = OpTypePointer Input %ShaderLink
+         %50 = OpTypeFunction %void
+          %9 = OpVariable %_ptr_Input_ShaderLink Input
+         %10 = OpVariable %_ptr_Output_FsOut Output
+          %6 = OpFunction %void None %50
+         %59 = OpLabel
+         %60 = OpAccessChain %_ptr_Output_v4float %10 %int_0
+         %61 = OpAccessChain %_ptr_Input_v4float %9 %int_0
+         %62 = OpLoad %v4float %61
+               OpStore %60 %62
+               OpReturn
+               OpFunctionEnd
+)";
+
+  CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Offset-04716"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("The Output interfaces variable must not have Offset "
+                        "on any member decoration"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7023,7 +7023,7 @@ TEST_F(ValidateDecorations, InputWithOffset) {
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Input interfaces variable must not have Offset on "
+              HasSubstr("The Input interface variable must not have Offset on "
                         "any member decoration"));
 }
 
@@ -7068,7 +7068,7 @@ TEST_F(ValidateDecorations, OutputWithOffset) {
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-StandaloneSpirv-Offset-04716"));
   EXPECT_THAT(getDiagnosticString(),
-              HasSubstr("The Output interfaces variable must not have Offset "
+              HasSubstr("The Output interface variable must not have Offset "
                         "on any member decoration"));
 }
 


### PR DESCRIPTION
adds one of the missing VUs from https://github.com/KhronosGroup/SPIRV-Tools/issues/6594

Inspired by https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8427 and https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8466