### PR TITLE
opt: add nonwritable-propagation pass

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -168,6 +168,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/merge_return_pass.cpp \
 		source/opt/modify_maximal_reconvergence.cpp \
 		source/opt/module.cpp \
+		source/opt/nonwritable_propagation_pass.cpp \
 		source/opt/opextinst_forward_ref_fixup_pass.cpp \
 		source/opt/optimizer.cpp \
 		source/opt/pass.cpp \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -586,6 +586,8 @@ static_library("spvtools_opt") {
     "source/opt/modify_maximal_reconvergence.h",
     "source/opt/module.cpp",
     "source/opt/module.h",
+    "source/opt/nonwritable_propagation_pass.cpp",
+    "source/opt/nonwritable_propagation_pass.h",
     "source/opt/null_pass.h",
     "source/opt/opextinst_forward_ref_fixup_pass.cpp",
     "source/opt/opextinst_forward_ref_fixup_pass.h",

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -976,6 +976,14 @@ Optimizer::PassToken CreateInvocationInterlockPlacementPass();
 // This pass either adds or removes maximal reconvergence from all entry points.
 Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add);
 
+// Creates a pass that propagates NonWritable from a buffer's members to the
+// buffer variable.  Some producers decorate every member of a buffer's struct
+// NonWritable rather than decorating the variable, which hides the decoration
+// from consumers that read it off the variable.  Where every member of a
+// buffer's struct is NonWritable, this decorates the variable as well.  The
+// member decorations are left in place.
+Optimizer::PassToken CreateNonWritablePropagationPass();
+
 // Creates a pass to split combined image+sampler variables and function
 // parameters into separate image and sampler parts. Binding numbers and
 // other decorations are copied.

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -980,8 +980,10 @@ Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add);
 // buffer variable.  Some producers decorate every member of a buffer's struct
 // NonWritable rather than decorating the variable, which hides the decoration
 // from consumers that read it off the variable.  Where every member of a
-// buffer's struct is NonWritable, this decorates the variable as well.  The
-// member decorations are left in place.
+// buffer's struct is NonWritable, this decorates the variable as well and
+// removes the now-redundant member decorations.  Members that are themselves
+// structs are exempt from the check, matching DXC's output for read-only
+// buffers.  Handles both OpVariable and OpUntypedVariableKHR.
 Optimizer::PassToken CreateNonWritablePropagationPass();
 
 // Creates a pass to split combined image+sampler variables and function

--- a/include/spirv-tools/optimizer.hpp
+++ b/include/spirv-tools/optimizer.hpp
@@ -981,9 +981,9 @@ Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add);
 // NonWritable rather than decorating the variable, which hides the decoration
 // from consumers that read it off the variable.  Where every member of a
 // buffer's struct is NonWritable, this decorates the variable as well and
-// removes the now-redundant member decorations.  Members that are themselves
-// structs are exempt from the check, matching DXC's output for read-only
-// buffers.  Handles both OpVariable and OpUntypedVariableKHR.
+// removes the now-redundant member decorations.  A member without the
+// decoration, whatever its type, means the variable is left alone.  Handles
+// both OpVariable and OpUntypedVariableKHR.
 Optimizer::PassToken CreateNonWritablePropagationPass();
 
 // Creates a pass to split combined image+sampler variables and function

--- a/source/opt/CMakeLists.txt
+++ b/source/opt/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   merge_return_pass.h
   modify_maximal_reconvergence.h
   module.h
+  nonwritable_propagation_pass.h
   null_pass.h
   passes.h
   pass.h
@@ -220,6 +221,7 @@ set(SPIRV_TOOLS_OPT_SOURCES
   merge_return_pass.cpp
   modify_maximal_reconvergence.cpp
   module.cpp
+  nonwritable_propagation_pass.cpp
   optimizer.cpp
   pass.cpp
   pass_manager.cpp

--- a/source/opt/nonwritable_propagation_pass.cpp
+++ b/source/opt/nonwritable_propagation_pass.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/opt/nonwritable_propagation_pass.h"
+
+#include <vector>
+
+#include "source/opt/ir_context.h"
+
+namespace spvtools {
+namespace opt {
+namespace {
+constexpr uint32_t kPointerTypePointeeIndex = 1;
+constexpr uint32_t kMemberDecorateMemberIndex = 1;
+}  // namespace
+
+Pass::Status NonWritablePropagationPass::Process() {
+  bool changed = false;
+
+  for (Instruction& var : get_module()->types_values()) {
+    if (var.opcode() != spv::Op::OpVariable) {
+      continue;
+    }
+
+    // Already decorated, so there is nothing to propagate.  Note this asks
+    // about the variable's id, not the struct type's, so the per-member
+    // decorations cannot make this true by themselves.
+    if (context()->get_decoration_mgr()->HasDecoration(
+            var.result_id(), spv::Decoration::NonWritable)) {
+      continue;
+    }
+
+    Instruction* struct_type = GetBufferStructType(var);
+    if (struct_type == nullptr) {
+      continue;
+    }
+
+    if (!AllMembersNonWritable(*struct_type)) {
+      continue;
+    }
+
+    context()->get_decoration_mgr()->AddDecoration(
+        var.result_id(), uint32_t(spv::Decoration::NonWritable));
+    changed = true;
+  }
+
+  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+}
+
+Instruction* NonWritablePropagationPass::GetBufferStructType(
+    const Instruction& var) const {
+  analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
+
+  Instruction* ptr_type = def_use_mgr->GetDef(var.type_id());
+  if (ptr_type == nullptr) {
+    return nullptr;
+  }
+
+  // The validator only accepts NonWritable on a variable pointing at a
+  // uniform block, storage buffer, storage image or tensor -- see
+  // CheckNonReadableWritableDecorations in validate_decorations.cpp.  Of
+  // those, only the buffers have members to propagate from.  Together these
+  // two cover Uniform+Block, Uniform+BufferBlock and StorageBuffer+Block.
+  if (!ptr_type->IsVulkanStorageBuffer() &&
+      !ptr_type->IsVulkanUniformBuffer()) {
+    return nullptr;
+  }
+
+  Instruction* base_type = def_use_mgr->GetDef(
+      ptr_type->GetSingleWordInOperand(kPointerTypePointeeIndex));
+  if (base_type == nullptr) {
+    return nullptr;
+  }
+
+  // Unpack the optional layer of arraying, matching what the two helpers
+  // above already did to decide this was a buffer at all.
+  if (base_type->opcode() == spv::Op::OpTypeArray ||
+      base_type->opcode() == spv::Op::OpTypeRuntimeArray) {
+    base_type = def_use_mgr->GetDef(base_type->GetSingleWordInOperand(0));
+    if (base_type == nullptr) {
+      return nullptr;
+    }
+  }
+
+  if (base_type->opcode() != spv::Op::OpTypeStruct) {
+    return nullptr;
+  }
+
+  return base_type;
+}
+
+bool NonWritablePropagationPass::AllMembersNonWritable(
+    const Instruction& struct_type) const {
+  // For OpTypeStruct the in-operands are exactly the member types.
+  const uint32_t member_count = struct_type.NumInOperands();
+
+  // A struct with no members is vacuously "all members NonWritable".
+  // Decorating on that basis would be asserting read-only with no evidence
+  // for it, so leave these alone.
+  if (member_count == 0) {
+    return false;
+  }
+
+  std::vector<bool> is_non_writable(member_count, false);
+  context()->get_decoration_mgr()->ForEachDecoration(
+      struct_type.result_id(), uint32_t(spv::Decoration::NonWritable),
+      [&is_non_writable, member_count](const Instruction& deco) {
+        // ForEachDecoration also reports OpDecorate on the struct type
+        // itself, which says nothing about the individual members.
+        if (deco.opcode() != spv::Op::OpMemberDecorate) {
+          return;
+        }
+        const uint32_t member =
+            deco.GetSingleWordInOperand(kMemberDecorateMemberIndex);
+        if (member < member_count) {
+          is_non_writable[member] = true;
+        }
+      });
+
+  for (bool member_is_non_writable : is_non_writable) {
+    if (!member_is_non_writable) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace opt
+}  // namespace spvtools

--- a/source/opt/nonwritable_propagation_pass.cpp
+++ b/source/opt/nonwritable_propagation_pass.cpp
@@ -14,6 +14,7 @@
 
 #include "source/opt/nonwritable_propagation_pass.h"
 
+#include <cassert>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -94,9 +95,7 @@ Instruction* NonWritablePropagationPass::GetBufferStructType(
 
   if (var.opcode() == spv::Op::OpVariable) {
     Instruction* ptr_type = def_use_mgr->GetDef(var.type_id());
-    if (ptr_type == nullptr) {
-      return nullptr;
-    }
+    assert(ptr_type != nullptr && "Variable type id has no definition");
 
     // The validator only accepts NonWritable on a variable pointing at a
     // uniform block, storage buffer, storage image or tensor -- see
@@ -131,17 +130,13 @@ Instruction* NonWritablePropagationPass::GetBufferStructType(
     need_block_check = true;
   }
 
-  if (base_type == nullptr) {
-    return nullptr;
-  }
+  assert(base_type != nullptr && "Pointee or data type id has no definition");
 
   // Unpack the optional layer of arraying (a descriptor array of buffers).
   if (base_type->opcode() == spv::Op::OpTypeArray ||
       base_type->opcode() == spv::Op::OpTypeRuntimeArray) {
     base_type = def_use_mgr->GetDef(base_type->GetSingleWordInOperand(0));
-    if (base_type == nullptr) {
-      return nullptr;
-    }
+    assert(base_type != nullptr && "Array element type id has no definition");
   }
 
   if (base_type->opcode() != spv::Op::OpTypeStruct) {
@@ -171,8 +166,6 @@ Instruction* NonWritablePropagationPass::GetBufferStructType(
 
 bool NonWritablePropagationPass::AllMembersNonWritable(
     const Instruction& struct_type) const {
-  analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
-
   // For OpTypeStruct the in-operands are exactly the member types.
   const uint32_t member_count = struct_type.NumInOperands();
 
@@ -183,34 +176,11 @@ bool NonWritablePropagationPass::AllMembersNonWritable(
     return false;
   }
 
-  // Members that are themselves structs (directly or through an array) are
-  // exempt from the check: DXC does not decorate such members even in a
-  // read-only buffer, so requiring them would make the pass a no-op on
-  // exactly the modules it exists to fix up.
-  std::vector<bool> considered(member_count, true);
-  uint32_t considered_count = 0;
-  for (uint32_t i = 0; i < member_count; ++i) {
-    Instruction* member_type =
-        def_use_mgr->GetDef(struct_type.GetSingleWordInOperand(i));
-    while (member_type != nullptr &&
-           (member_type->opcode() == spv::Op::OpTypeArray ||
-            member_type->opcode() == spv::Op::OpTypeRuntimeArray)) {
-      member_type = def_use_mgr->GetDef(member_type->GetSingleWordInOperand(0));
-    }
-    if (member_type != nullptr &&
-        member_type->opcode() == spv::Op::OpTypeStruct) {
-      considered[i] = false;
-    } else {
-      ++considered_count;
-    }
-  }
-
-  // If every member is exempt there is no evidence in either direction --
-  // a writable buffer of structs looks exactly the same.  Leave it alone.
-  if (considered_count == 0) {
-    return false;
-  }
-
+  // Every member must carry the decoration, whatever its type.  The spec
+  // allows NonWritable on any structure member and says nothing about the
+  // member's type, so a struct-typed member without it is writable and the
+  // variable must not be decorated.  Only direct members need checking:
+  // NonWritable on a member covers everything reachable through it.
   std::vector<bool> is_non_writable(member_count, false);
   context()->get_decoration_mgr()->ForEachDecoration(
       struct_type.result_id(), uint32_t(spv::Decoration::NonWritable),
@@ -228,7 +198,7 @@ bool NonWritablePropagationPass::AllMembersNonWritable(
       });
 
   for (uint32_t i = 0; i < member_count; ++i) {
-    if (considered[i] && !is_non_writable[i]) {
+    if (!is_non_writable[i]) {
       return false;
     }
   }

--- a/source/opt/nonwritable_propagation_pass.cpp
+++ b/source/opt/nonwritable_propagation_pass.cpp
@@ -14,6 +14,8 @@
 
 #include "source/opt/nonwritable_propagation_pass.h"
 
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "source/opt/ir_context.h"
@@ -22,14 +24,22 @@ namespace spvtools {
 namespace opt {
 namespace {
 constexpr uint32_t kPointerTypePointeeIndex = 1;
+constexpr uint32_t kUntypedVariableStorageClassIndex = 0;
+constexpr uint32_t kUntypedVariableDataTypeIndex = 1;
 constexpr uint32_t kMemberDecorateMemberIndex = 1;
+constexpr uint32_t kMemberDecorateDecorationIndex = 2;
 }  // namespace
 
 Pass::Status NonWritablePropagationPass::Process() {
-  bool changed = false;
+  // Collect first, mutate after: several variables can share one struct
+  // type, and stripping that type's member decorations while other
+  // variables are still being examined would make the result depend on
+  // iteration order.
+  std::vector<std::pair<Instruction*, Instruction*>> vars_to_decorate;
 
   for (Instruction& var : get_module()->types_values()) {
-    if (var.opcode() != spv::Op::OpVariable) {
+    if (var.opcode() != spv::Op::OpVariable &&
+        var.opcode() != spv::Op::OpUntypedVariableKHR) {
       continue;
     }
 
@@ -50,41 +60,82 @@ Pass::Status NonWritablePropagationPass::Process() {
       continue;
     }
 
-    context()->get_decoration_mgr()->AddDecoration(
-        var.result_id(), uint32_t(spv::Decoration::NonWritable));
-    changed = true;
+    vars_to_decorate.push_back({&var, struct_type});
   }
 
-  return changed ? Status::SuccessWithChange : Status::SuccessWithoutChange;
+  std::unordered_set<uint32_t> structs_to_strip;
+  for (const auto& [var, struct_type] : vars_to_decorate) {
+    context()->get_decoration_mgr()->AddDecoration(
+        var->result_id(), uint32_t(spv::Decoration::NonWritable));
+    structs_to_strip.insert(struct_type->result_id());
+  }
+
+  // The propagated decoration now carries the information, so the
+  // per-member spelling is redundant on these structs and is removed.
+  for (uint32_t struct_id : structs_to_strip) {
+    context()->get_decoration_mgr()->RemoveDecorationsFrom(
+        struct_id, [](const Instruction& inst) {
+          return inst.opcode() == spv::Op::OpMemberDecorate &&
+                 inst.GetSingleWordInOperand(kMemberDecorateDecorationIndex) ==
+                     uint32_t(spv::Decoration::NonWritable);
+        });
+  }
+
+  return vars_to_decorate.empty() ? Status::SuccessWithoutChange
+                                  : Status::SuccessWithChange;
 }
 
 Instruction* NonWritablePropagationPass::GetBufferStructType(
     const Instruction& var) const {
   analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
+  Instruction* base_type = nullptr;
+  bool need_block_check = false;
+  spv::StorageClass storage_class = spv::StorageClass::Max;
 
-  Instruction* ptr_type = def_use_mgr->GetDef(var.type_id());
-  if (ptr_type == nullptr) {
-    return nullptr;
+  if (var.opcode() == spv::Op::OpVariable) {
+    Instruction* ptr_type = def_use_mgr->GetDef(var.type_id());
+    if (ptr_type == nullptr) {
+      return nullptr;
+    }
+
+    // The validator only accepts NonWritable on a variable pointing at a
+    // uniform block, storage buffer, storage image or tensor -- see
+    // CheckNonReadableWritableDecorations in validate_decorations.cpp.  Of
+    // those, only the buffers have members to propagate from.  Together
+    // these two cover Uniform+Block, Uniform+BufferBlock and
+    // StorageBuffer+Block.
+    if (!ptr_type->IsVulkanStorageBuffer() &&
+        !ptr_type->IsVulkanUniformBuffer()) {
+      return nullptr;
+    }
+
+    base_type = def_use_mgr->GetDef(
+        ptr_type->GetSingleWordInOperand(kPointerTypePointeeIndex));
+  } else {
+    // OpUntypedVariableKHR: the pointer type carries no pointee, so the
+    // struct comes from the optional data-type operand.  Without that
+    // operand there is nothing to inspect.
+    if (var.NumInOperands() <= kUntypedVariableDataTypeIndex) {
+      return nullptr;
+    }
+
+    storage_class = spv::StorageClass(
+        var.GetSingleWordInOperand(kUntypedVariableStorageClassIndex));
+    if (storage_class != spv::StorageClass::Uniform &&
+        storage_class != spv::StorageClass::StorageBuffer) {
+      return nullptr;
+    }
+
+    base_type = def_use_mgr->GetDef(
+        var.GetSingleWordInOperand(kUntypedVariableDataTypeIndex));
+    need_block_check = true;
   }
 
-  // The validator only accepts NonWritable on a variable pointing at a
-  // uniform block, storage buffer, storage image or tensor -- see
-  // CheckNonReadableWritableDecorations in validate_decorations.cpp.  Of
-  // those, only the buffers have members to propagate from.  Together these
-  // two cover Uniform+Block, Uniform+BufferBlock and StorageBuffer+Block.
-  if (!ptr_type->IsVulkanStorageBuffer() &&
-      !ptr_type->IsVulkanUniformBuffer()) {
-    return nullptr;
-  }
-
-  Instruction* base_type = def_use_mgr->GetDef(
-      ptr_type->GetSingleWordInOperand(kPointerTypePointeeIndex));
   if (base_type == nullptr) {
     return nullptr;
   }
 
-  // Unpack the optional layer of arraying, matching what the two helpers
-  // above already did to decide this was a buffer at all.
+  // Unpack the optional layer of arraying (a descriptor array of buffers).
   if (base_type->opcode() == spv::Op::OpTypeArray ||
       base_type->opcode() == spv::Op::OpTypeRuntimeArray) {
     base_type = def_use_mgr->GetDef(base_type->GetSingleWordInOperand(0));
@@ -97,11 +148,31 @@ Instruction* NonWritablePropagationPass::GetBufferStructType(
     return nullptr;
   }
 
+  // For the typed path the two helpers above already proved block-ness.
+  // The untyped path checks it here, accepting the same set:
+  // StorageBuffer+Block, Uniform+Block and Uniform+BufferBlock.
+  if (need_block_check) {
+    analysis::DecorationManager* deco_mgr = context()->get_decoration_mgr();
+    const bool has_block =
+        deco_mgr->HasDecoration(base_type->result_id(), spv::Decoration::Block);
+    const bool has_buffer_block = deco_mgr->HasDecoration(
+        base_type->result_id(), spv::Decoration::BufferBlock);
+    if (storage_class == spv::StorageClass::StorageBuffer && !has_block) {
+      return nullptr;
+    }
+    if (storage_class == spv::StorageClass::Uniform && !has_block &&
+        !has_buffer_block) {
+      return nullptr;
+    }
+  }
+
   return base_type;
 }
 
 bool NonWritablePropagationPass::AllMembersNonWritable(
     const Instruction& struct_type) const {
+  analysis::DefUseManager* def_use_mgr = context()->get_def_use_mgr();
+
   // For OpTypeStruct the in-operands are exactly the member types.
   const uint32_t member_count = struct_type.NumInOperands();
 
@@ -109,6 +180,34 @@ bool NonWritablePropagationPass::AllMembersNonWritable(
   // Decorating on that basis would be asserting read-only with no evidence
   // for it, so leave these alone.
   if (member_count == 0) {
+    return false;
+  }
+
+  // Members that are themselves structs (directly or through an array) are
+  // exempt from the check: DXC does not decorate such members even in a
+  // read-only buffer, so requiring them would make the pass a no-op on
+  // exactly the modules it exists to fix up.
+  std::vector<bool> considered(member_count, true);
+  uint32_t considered_count = 0;
+  for (uint32_t i = 0; i < member_count; ++i) {
+    Instruction* member_type =
+        def_use_mgr->GetDef(struct_type.GetSingleWordInOperand(i));
+    while (member_type != nullptr &&
+           (member_type->opcode() == spv::Op::OpTypeArray ||
+            member_type->opcode() == spv::Op::OpTypeRuntimeArray)) {
+      member_type = def_use_mgr->GetDef(member_type->GetSingleWordInOperand(0));
+    }
+    if (member_type != nullptr &&
+        member_type->opcode() == spv::Op::OpTypeStruct) {
+      considered[i] = false;
+    } else {
+      ++considered_count;
+    }
+  }
+
+  // If every member is exempt there is no evidence in either direction --
+  // a writable buffer of structs looks exactly the same.  Leave it alone.
+  if (considered_count == 0) {
     return false;
   }
 
@@ -128,8 +227,8 @@ bool NonWritablePropagationPass::AllMembersNonWritable(
         }
       });
 
-  for (bool member_is_non_writable : is_non_writable) {
-    if (!member_is_non_writable) {
+  for (uint32_t i = 0; i < member_count; ++i) {
+    if (considered[i] && !is_non_writable[i]) {
       return false;
     }
   }

--- a/source/opt/nonwritable_propagation_pass.h
+++ b/source/opt/nonwritable_propagation_pass.h
@@ -30,9 +30,9 @@ namespace opt {
 // For each buffer variable (OpVariable or OpUntypedVariableKHR) whose
 // struct has every member decorated NonWritable, this pass decorates the
 // variable NonWritable and then removes the now-redundant member
-// decorations.  Members that are themselves structs are exempt from the
-// all-members check, since DXC does not decorate those even in a read-only
-// buffer.
+// decorations.  Every direct member must carry the decoration, whatever its
+// type: a struct-typed member without it is writable as far as SPIR-V is
+// concerned, so the variable is left alone.
 class NonWritablePropagationPass : public Pass {
  public:
   const char* name() const override { return "nonwritable-propagation"; }
@@ -40,8 +40,9 @@ class NonWritablePropagationPass : public Pass {
   Status Process() override;
 
   IRContext::Analysis GetPreservedAnalyses() override {
-    // Only OpDecorate instructions are added, so every analysis except the
-    // decoration cache survives untouched.
+    // Decorations are the only thing added or removed, and the removal goes
+    // through the context, so every analysis except the decoration cache
+    // survives untouched.
     return IRContext::kAnalysisDefUse |
            IRContext::kAnalysisInstrToBlockMapping |
            IRContext::kAnalysisCombinators | IRContext::kAnalysisCFG |

--- a/source/opt/nonwritable_propagation_pass.h
+++ b/source/opt/nonwritable_propagation_pass.h
@@ -27,9 +27,12 @@ namespace opt {
 // that read the decoration off the variable -- for example the mapping APIs
 // in VK_EXT_descriptor_heap -- do not see it, so the buffer looks writable.
 //
-// For each buffer variable whose struct has every member decorated
-// NonWritable, this pass decorates the variable NonWritable as well.  The
-// member decorations are left in place; nothing is removed.
+// For each buffer variable (OpVariable or OpUntypedVariableKHR) whose
+// struct has every member decorated NonWritable, this pass decorates the
+// variable NonWritable and then removes the now-redundant member
+// decorations.  Members that are themselves structs are exempt from the
+// all-members check, since DXC does not decorate those even in a read-only
+// buffer.
 class NonWritablePropagationPass : public Pass {
  public:
   const char* name() const override { return "nonwritable-propagation"; }

--- a/source/opt/nonwritable_propagation_pass.h
+++ b/source/opt/nonwritable_propagation_pass.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIBSPIRV_OPT_NONWRITABLE_PROPAGATION_PASS_H_
+#define LIBSPIRV_OPT_NONWRITABLE_PROPAGATION_PASS_H_
+
+#include "source/opt/pass.h"
+
+namespace spvtools {
+namespace opt {
+
+// Propagates NonWritable from a buffer's members to the buffer variable.
+//
+// Some producers decorate every member of a buffer's struct NonWritable
+// instead of decorating the variable itself.  That is legal, but consumers
+// that read the decoration off the variable -- for example the mapping APIs
+// in VK_EXT_descriptor_heap -- do not see it, so the buffer looks writable.
+//
+// For each buffer variable whose struct has every member decorated
+// NonWritable, this pass decorates the variable NonWritable as well.  The
+// member decorations are left in place; nothing is removed.
+class NonWritablePropagationPass : public Pass {
+ public:
+  const char* name() const override { return "nonwritable-propagation"; }
+
+  Status Process() override;
+
+  IRContext::Analysis GetPreservedAnalyses() override {
+    // Only OpDecorate instructions are added, so every analysis except the
+    // decoration cache survives untouched.
+    return IRContext::kAnalysisDefUse |
+           IRContext::kAnalysisInstrToBlockMapping |
+           IRContext::kAnalysisCombinators | IRContext::kAnalysisCFG |
+           IRContext::kAnalysisDominatorAnalysis | IRContext::kAnalysisNameMap |
+           IRContext::kAnalysisConstants | IRContext::kAnalysisTypes;
+  }
+
+ private:
+  // Returns the OpTypeStruct backing |var|'s buffer, or nullptr if |var| is
+  // not a variable that may carry NonWritable itself.
+  Instruction* GetBufferStructType(const Instruction& var) const;
+
+  // Returns true if every member of |struct_type| is decorated NonWritable.
+  bool AllMembersNonWritable(const Instruction& struct_type) const;
+};
+
+}  // namespace opt
+}  // namespace spvtools
+
+#endif  // LIBSPIRV_OPT_NONWRITABLE_PROPAGATION_PASS_H_

--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -641,6 +641,8 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag,
              pass_args.c_str());
       return false;
     }
+  } else if (pass_name == "nonwritable-propagation") {
+    RegisterPass(CreateNonWritablePropagationPass());
   } else if (pass_name == "trim-capabilities") {
     RegisterPass(CreateTrimCapabilitiesPass());
   } else if (pass_name == "split-combined-image-sampler") {
@@ -1204,6 +1206,11 @@ Optimizer::PassToken CreateInvocationInterlockPlacementPass() {
 Optimizer::PassToken CreateModifyMaximalReconvergencePass(bool add) {
   return MakeUnique<Optimizer::PassToken::Impl>(
       MakeUnique<opt::ModifyMaximalReconvergence>(add));
+}
+
+Optimizer::PassToken CreateNonWritablePropagationPass() {
+  return MakeUnique<Optimizer::PassToken::Impl>(
+      MakeUnique<opt::NonWritablePropagationPass>());
 }
 
 Optimizer::PassToken CreateOpExtInstWithForwardReferenceFixupPass() {

--- a/source/opt/passes.h
+++ b/source/opt/passes.h
@@ -66,6 +66,7 @@
 #include "source/opt/loop_unswitch_pass.h"
 #include "source/opt/merge_return_pass.h"
 #include "source/opt/modify_maximal_reconvergence.h"
+#include "source/opt/nonwritable_propagation_pass.h"
 #include "source/opt/null_pass.h"
 #include "source/opt/opextinst_forward_ref_fixup_pass.h"
 #include "source/opt/private_to_local_pass.h"

--- a/test/opt/CMakeLists.txt
+++ b/test/opt/CMakeLists.txt
@@ -81,6 +81,7 @@ add_spvtools_unittest(TARGET opt
        modify_maximal_reconvergence_test.cpp
        module_test.cpp
        module_utils.h
+       nonwritable_propagation_test.cpp
        opextinst_forward_ref_fixup_pass_test.cpp
        optimizer_test.cpp
        pass_manager_test.cpp

--- a/test/opt/nonwritable_propagation_test.cpp
+++ b/test/opt/nonwritable_propagation_test.cpp
@@ -1,0 +1,267 @@
+// Copyright (c) 2026 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "pass_fixture.h"
+#include "pass_utils.h"
+
+namespace {
+
+using namespace spvtools;
+
+using NonWritablePropagationTest = opt::PassTest<::testing::Test>;
+
+// A storage buffer whose every member is NonWritable gets the decoration on
+// the variable as well.  This is the case DXC produces.
+TEST_F(NonWritablePropagationTest, PropagatesToStorageBuffer) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpMemberDecorate %buf 1 Offset 4
+OpMemberDecorate %buf 1 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float %float
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// The same, for a uniform block rather than a storage buffer.
+TEST_F(NonWritablePropagationTest, PropagatesToUniformBuffer) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypePointer Uniform %buf
+%var = OpVariable %ptr Uniform
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// The pre-1.3 spelling of a storage buffer: Uniform storage class with
+// BufferBlock rather than Block.
+TEST_F(NonWritablePropagationTest, PropagatesToBufferBlock) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf BufferBlock
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypePointer Uniform %buf
+%var = OpVariable %ptr Uniform
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// One writable member means the buffer as a whole is writable.  This is the
+// case an over-eager implementation would get wrong.
+TEST_F(NonWritablePropagationTest, DoesNotPropagateWhenOneMemberIsWritable) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpMemberDecorate %buf 1 Offset 4
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float %float
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// A variable that is already decorated must be left alone.  This is checked
+// on the reported status rather than the output: duplicate decorations are
+// filtered during serialization, so re-adding one is invisible in the binary
+// but would still report a change and needlessly invalidate analyses.
+TEST_F(NonWritablePropagationTest, DoesNotReportChangeWhenAlreadyDecorated) {
+  const std::string text = R"(
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  auto result =
+      SinglePassRunToBinary<opt::NonWritablePropagationPass>(text, true);
+  EXPECT_EQ(opt::Pass::Status::SuccessWithoutChange, std::get<1>(result));
+}
+
+// An empty struct is vacuously "all members NonWritable".  Decorating on that
+// basis would assert read-only with no evidence, so it is left alone.
+TEST_F(NonWritablePropagationTest, DoesNotPropagateForEmptyStruct) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%buf = OpTypeStruct
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// NonWritable is only legal on a variable pointing at a buffer or storage
+// image, so a Private variable must be left alone even though its struct is
+// fully decorated.
+TEST_F(NonWritablePropagationTest, DoesNotPropagateForNonBufferVariable) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpMemberDecorate %buf 0 NonWritable
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypePointer Private %buf
+%var = OpVariable %ptr Private
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// A descriptor array of buffers carries Block on the struct, one array layer
+// down.  The buffer helpers unpack that layer, so this propagates too.
+TEST_F(NonWritablePropagationTest, PropagatesThroughDescriptorArray) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%uint = OpTypeInt 32 0
+%uint_2 = OpConstant %uint 2
+%buf = OpTypeStruct %float
+%arr = OpTypeArray %buf %uint_2
+%ptr = OpTypePointer StorageBuffer %arr
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+}  // namespace

--- a/test/opt/nonwritable_propagation_test.cpp
+++ b/test/opt/nonwritable_propagation_test.cpp
@@ -231,6 +231,167 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
 }
 
+// A member that is itself a struct is exempt from the all-members check:
+// DXC does not decorate struct members even in a read-only buffer, so
+// requiring them would make the pass a no-op on its target input.
+TEST_F(NonWritablePropagationTest, IgnoresStructTypeMembers) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpMemberDecorate %buf 1 Offset 4
+OpMemberDecorate %inner 0 Offset 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%inner = OpTypeStruct %float
+%buf = OpTypeStruct %float %inner
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// If every member is an exempt struct there is no evidence in either
+// direction -- a writable buffer of structs looks exactly the same -- so
+// nothing is propagated.
+TEST_F(NonWritablePropagationTest, DoesNotPropagateWhenAllMembersAreStructs) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate %var NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %inner 0 Offset 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%inner = OpTypeStruct %float
+%buf = OpTypeStruct %inner
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// Once the variable is decorated, the per-member decorations are redundant
+// and are removed.  Other member decorations (Offset) must survive.
+TEST_F(NonWritablePropagationTest, RemovesMemberDecorationsAfterPropagating) {
+  const std::string text = R"(
+; CHECK: OpMemberDecorate %buf 0 Offset 0
+; CHECK-NOT: OpMemberDecorate %buf 0 NonWritable
+; CHECK: OpDecorate %var NonWritable
+; CHECK-NOT: OpMemberDecorate %buf 0 NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpName %buf "buf"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// An untyped variable carries no pointee on its pointer type, so the struct
+// comes from the data-type operand.  The propagation applies to it too.
+TEST_F(NonWritablePropagationTest, PropagatesToUntypedStorageBuffer) {
+  const std::string text = R"(
+; CHECK: OpDecorate %var NonWritable
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%var = OpUntypedVariableKHR %ptr StorageBuffer %buf
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// An untyped variable without the optional data-type operand gives the pass
+// nothing to inspect, so it is left alone.
+TEST_F(NonWritablePropagationTest,
+       DoesNotPropagateForUntypedVariableWithoutDataType) {
+  const std::string text = R"(
+; CHECK-NOT: OpDecorate %var NonWritable
+OpCapability Shader
+OpCapability UntypedPointersKHR
+OpExtension "SPV_KHR_untyped_pointers"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpDecorate %var DescriptorSet 0
+OpDecorate %var Binding 0
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%buf = OpTypeStruct %float
+%ptr = OpTypeUntypedPointerKHR StorageBuffer
+%var = OpUntypedVariableKHR %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
 // A descriptor array of buffers carries Block on the struct, one array layer
 // down.  The buffer helpers unpack that layer, so this propagates too.
 TEST_F(NonWritablePropagationTest, PropagatesThroughDescriptorArray) {

--- a/test/opt/nonwritable_propagation_test.cpp
+++ b/test/opt/nonwritable_propagation_test.cpp
@@ -231,12 +231,14 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
 }
 
-// A member that is itself a struct is exempt from the all-members check:
-// DXC does not decorate struct members even in a read-only buffer, so
-// requiring them would make the pass a no-op on its target input.
-TEST_F(NonWritablePropagationTest, IgnoresStructTypeMembers) {
+// A member that is itself a struct must carry the decoration like any other
+// member.  The spec allows NonWritable on any structure member and says
+// nothing about the member's type, so without it the member is writable and
+// the variable must not be decorated.
+TEST_F(NonWritablePropagationTest,
+       DoesNotPropagateWhenStructMemberIsUndecorated) {
   const std::string text = R"(
-; CHECK: OpDecorate %var NonWritable
+; CHECK-NOT: OpDecorate %var NonWritable
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
@@ -263,12 +265,13 @@ OpFunctionEnd
   SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
 }
 
-// If every member is an exempt struct there is no evidence in either
-// direction -- a writable buffer of structs looks exactly the same -- so
-// nothing is propagated.
-TEST_F(NonWritablePropagationTest, DoesNotPropagateWhenAllMembersAreStructs) {
+// A struct-typed member that does carry the decoration counts like any
+// other.  Only direct members are inspected: NonWritable on the member
+// covers everything reachable through it, so the inner struct's own members
+// need no decoration of their own.
+TEST_F(NonWritablePropagationTest, PropagatesWhenStructMemberIsDecorated) {
   const std::string text = R"(
-; CHECK-NOT: OpDecorate %var NonWritable
+; CHECK: OpDecorate %var NonWritable
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %main "main"
@@ -276,12 +279,50 @@ OpExecutionMode %main LocalSize 1 1 1
 OpName %var "var"
 OpDecorate %buf Block
 OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
 OpMemberDecorate %inner 0 Offset 0
 %void = OpTypeVoid
 %void_fn = OpTypeFunction %void
 %float = OpTypeFloat 32
 %inner = OpTypeStruct %float
 %buf = OpTypeStruct %inner
+%ptr = OpTypePointer StorageBuffer %buf
+%var = OpVariable %ptr StorageBuffer
+%main = OpFunction %void None %void_fn
+%entry = OpLabel
+OpReturn
+OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<opt::NonWritablePropagationPass>(text, true);
+}
+
+// The shape DXC emits for a read-only StructuredBuffer<S>: a block whose one
+// member is a runtime array of structs, NonWritable on that member and
+// nothing on the inner struct.  The member decoration is all that is needed.
+TEST_F(NonWritablePropagationTest, PropagatesForRuntimeArrayOfStructs) {
+  const std::string text = R"(
+; CHECK: OpMemberDecorate %buf 0 Offset 0
+; CHECK-NOT: OpMemberDecorate %buf 0 NonWritable
+; CHECK: OpDecorate %var NonWritable
+; CHECK-NOT: OpMemberDecorate %buf 0 NonWritable
+OpCapability Shader
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+OpName %var "var"
+OpName %buf "buf"
+OpDecorate %buf Block
+OpMemberDecorate %buf 0 Offset 0
+OpMemberDecorate %buf 0 NonWritable
+OpMemberDecorate %inner 0 Offset 0
+OpDecorate %arr ArrayStride 4
+%void = OpTypeVoid
+%void_fn = OpTypeFunction %void
+%float = OpTypeFloat 32
+%inner = OpTypeStruct %float
+%arr = OpTypeRuntimeArray %inner
+%buf = OpTypeStruct %arr
 %ptr = OpTypePointer StorageBuffer %buf
 %var = OpVariable %ptr StorageBuffer
 %main = OpFunction %void None %void_fn

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -358,8 +358,7 @@ Options (in lexicographical order):)",
                struct is already decorated NonWritable, then remove the
                now-redundant member decorations.  Some producers only decorate
                the members, which hides the decoration from consumers that
-               read it off the variable.  Members that are themselves structs
-               are exempt from the check, matching DXC output.)");
+               read it off the variable.)");
   printf(R"(
   --loop-unswitch
                Hoists loop-invariant conditionals out of loops by duplicating

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -355,9 +355,11 @@ Options (in lexicographical order):)",
   printf(R"(
   --nonwritable-propagation
                Decorate a buffer variable NonWritable when every member of its
-               struct is already decorated NonWritable.  Some producers only
-               decorate the members, which hides the decoration from consumers
-               that read it off the variable.  The member decorations are kept.)");
+               struct is already decorated NonWritable, then remove the
+               now-redundant member decorations.  Some producers only decorate
+               the members, which hides the decoration from consumers that
+               read it off the variable.  Members that are themselves structs
+               are exempt from the check, matching DXC output.)");
   printf(R"(
   --loop-unswitch
                Hoists loop-invariant conditionals out of loops by duplicating

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -353,6 +353,12 @@ Options (in lexicographical order):)",
                Note: when adding the execution mode, no attempt is made to
                determine if any ray tracing repack instructions are used.)");
   printf(R"(
+  --nonwritable-propagation
+               Decorate a buffer variable NonWritable when every member of its
+               struct is already decorated NonWritable.  Some producers only
+               decorate the members, which hides the decoration from consumers
+               that read it off the variable.  The member decorations are kept.)");
+  printf(R"(
   --loop-unswitch
                Hoists loop-invariant conditionals out of loops by duplicating
                the loop on each branch of the conditional and adjusting each


### PR DESCRIPTION
Fixes #6785.

DXC decorates every member of a buffer's struct `NonWritable` instead of decorating the variable. That's legal, but anything that reads the decoration off the variable doesn't see it, including the mapping APIs in `VK_EXT_descriptor_heap`, which is what breaks in the issue.

`--nonwritable-propagation`: for each buffer variable (`OpVariable` or `OpUntypedVariableKHR`; `StorageBuffer`+`Block`, `Uniform`+`Block` or `Uniform`+`BufferBlock`; directly or through a descriptor array) whose struct has every member decorated `NonWritable`, decorate the variable `NonWritable` and remove the now-redundant member decorations.

- Every direct member must carry the decoration, whatever its type. A struct-typed member without it means no propagation, per spec it is writable. Only direct members are inspected: `NonWritable` on a member covers everything reachable through it.
- Member decorations are removed once the variable is decorated (as requested on the issue).
- Empty structs are skipped; already-decorated variables are left alone and report no change.

The analysis is borrowed rather than rewritten: `IsVulkanStorageBuffer` / `IsVulkanUniformBuffer` decide what is a buffer on the typed path, the untyped path checks storage class and `Block`/`BufferBlock` itself, and `DecorationManager` does the rest. `GetPreservedAnalyses` drops only `kAnalysisDecorations`.

14 tests: SSBO, UBO, `BufferBlock`, descriptor array, untyped variable with and without a data type, one writable member, a struct-typed member with and without the decoration, the DXC `StructuredBuffer<S>` shape, already-decorated (asserts `SuccessWithoutChange`), empty struct, non-buffer variable, and `Offset` surviving the member-decoration removal. Every output goes through the validator.
