### PR TITLE
bazel: load C++ rules from rules_cc

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ load(
     "incompatible_with",
 )
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 package(
     default_visibility = ["//visibility:private"],


### PR DESCRIPTION
We’re building [xmojo](https://github.com/AnswerDotAI/xmojo), an in-process ORC-based Mojo environment for terminal and Jupyter frontends. It includes a WebGPU compiler backend that lowers Mojo kernels through LLVM’s SPIR-V target and uses SPIRV-Tools to produce WebGPU-compatible modules.

For example:

```mojo
def kernel(
    output: Pointer[
        Int32, MutAnyOrigin, address_space=AddressSpace(11)
    ],
):
    output[unsafe_offset=0] = 42
```

is compiled to SPIR-V, loaded by Dawn, and executed on Metal.

LLVM currently leaves resource-binding names as dead `i8` data in the emitted module. Dawn rejects the resulting `Int8` capability, so xmojo uses SPIRV-Tools for dead-code elimination and validation before passing the module to WebGPU.

xmojo builds against Modular’s Bazel 10 workspace and includes SPIRV-Tools as an external repository. Although SPIRV-Tools already declares `rules_cc`, its `BUILD.bazel` still relies on the removed native C++ rules, so analysis stops at its first `cc_library`:

```text
This rule has been removed from Bazel. Please add a `load()` statement for it.
```

This PR loads `cc_binary`, `cc_library`, and `cc_test` from the existing `rules_cc` dependency. With that change, `spirv_tools_opt` builds successfully and xmojo’s generated kernel executes through Dawn on Metal.
