### PR TITLE
spirv-val: Add Explicit Alignment VUIDs

### DIFF
--- a/source/val/validate_explicit_layout.cpp
+++ b/source/val/validate_explicit_layout.cpp
@@ -517,6 +517,23 @@ struct Impl {
     return false;
   }
 
+  // Used to map the option alignment to the Vulkan VUID
+  uint32_t GetAlignVkErrorId(spv::Op opcode) {
+    if (opcode == spv::Op::OpTypeSampler) {
+      return 11476;
+    } else if (opcode == spv::Op::OpTypeSampledImage ||
+               opcode == spv::Op::OpTypeImage) {
+      return 11477;
+    } else if (opcode == spv::Op::OpTypeBufferEXT) {
+      return 11478;
+    } else if (opcode == spv::Op::OpTypeAccelerationStructureKHR) {
+      return 11479;
+    } else if (opcode == spv::Op::OpTypeTensorARM) {
+      return 11480;
+    }
+    return 0;
+  }
+
   // Returns the alignment for type_id for the given layout rules.
   uint32_t GetAlign(uint32_t type_id, LayoutMode mode,
                     const MatrixConstraints& matrix_constraints,
@@ -855,12 +872,14 @@ struct Impl {
       uint32_t align = GetAlign(member_id, mode, mat_constraints);
       if (!IsAlignedTo(offset, align)) {
         return vstate.diag(SPV_ERROR_INVALID_ID, type_inst)
+               << vstate.VkErrorID(GetAlignVkErrorId(member_inst->opcode()))
                << "Structure member " << member_idx << " at offset " << offset
                << " is not aligned to " << align << "."
                << CommonError(inst, storage_class, mode);
       }
       if (!IsAlignedTo(offset + incoming_offset, align)) {
         return vstate.diag(SPV_ERROR_INVALID_ID, type_inst)
+               << vstate.VkErrorID(GetAlignVkErrorId(member_inst->opcode()))
                << "Structure member " << member_idx << " at offset " << offset
                << " plus incoming offset " << incoming_offset
                << " is not aligned to " << align << "."

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -3589,6 +3589,18 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
         return VUID_WRAP(VUID-StandaloneSpirv-OpUntypedImageTexelPointerEXT-11416);
     case 11417:
         return VUID_WRAP(VUID-StandaloneSpirv-OpTypeUntypedPointerKHR-11417);
+    // These RuntimeSpirv are here because now we can pass in the size/alignment
+    // which in turns mean we can validate things based on runtime properties
+    case 11476:
+      return VUID_WRAP(VUID-RuntimeSpirv-samplerDescriptorAlignment-11476);
+    case 11477:
+      return VUID_WRAP(VUID-RuntimeSpirv-imageDescriptorAlignment-11477);
+    case 11478:
+      return VUID_WRAP(VUID-RuntimeSpirv-bufferDescriptorAlignment-11478);
+    case 11479:
+      return VUID_WRAP(VUID-RuntimeSpirv-bufferDescriptorAlignment-11479);
+    case 11480:
+      return VUID_WRAP(VUID-RuntimeSpirv-tensorDescriptorAlignment-11480);
     case 11482:
       return VUID_WRAP(VUID-StandaloneSpirv-DescriptorHeapEXT-11482);
     case 11805:


### PR DESCRIPTION
These VUs use to only be caught in VVL but now they are caught in `spirv-val` when we pass in the alignment, but without the VUID, the error message is a bit more confusing (when you get it from VVL)