### PR TITLE
spirv-val: Validate ShaderAbort explicit layout

### DIFF
--- a/source/val/validate_explicit_layout.cpp
+++ b/source/val/validate_explicit_layout.cpp
@@ -76,6 +76,7 @@ struct Impl {
     // The descriptor array type id (if there is one).
     uint32_t descriptor_array_id = 0;
     // The storage class for the memory instruction.
+    // Only used for error messages
     spv::StorageClass storage_class;
     // The layout mode (only relevant if a layout is required).
     LayoutMode layout;
@@ -343,6 +344,17 @@ struct Impl {
           vstate.HasDecoration(data_ty_id, spv::Decoration::BufferBlock);
       reference->layout = GetStorageClassLayout(sc, buffer_block);
 
+      return true;
+    } else if (inst->opcode() == spv::Op::OpAbortKHR) {
+      reference->type_id = inst->GetOperandAs<uint32_t>(0u);
+      // Abort messages doesn't have a storage class
+      reference->storage_class = spv::StorageClass::Max;
+      // Currently not specified well
+      // https://gitlab.khronos.org/spirv/SPIR-V/-/work_items/962
+      reference->layout = vstate.options()->scalar_block_layout
+                              ? LayoutMode::kScalar
+                              : LayoutMode::kStandard;
+      reference->requirement = LayoutRequirement::kRequired;
       return true;
     }
 
@@ -777,9 +789,13 @@ struct Impl {
                           spv::StorageClass storage_class, LayoutMode mode) {
     std::string s;
     std::ostringstream str(s);
-    str << " Instantiated via " << vstate.getIdName(inst->id()) << " in the "
-        << spvtools::StorageClassToString(storage_class)
-        << " storage class using " << mode << " layout rules.";
+    str << " Instantiated via " << vstate.getIdName(inst->id());
+    // OpAbortKHR is an example where there is not storage class
+    if (storage_class != spv::StorageClass::Max) {
+      str << " in the " << spvtools::StorageClassToString(storage_class)
+          << " storage class";
+    }
+    str << " using " << mode << " layout rules.";
     if (mode != LayoutMode::kScalar) {
       if (storage_class == spv::StorageClass::Workgroup) {
         str << vstate.MissingFeature(

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -15,11 +15,8 @@
 // Tests for OpExtension validator rules.
 
 #include <string>
-#include <vector>
 
 #include "gmock/gmock.h"
-#include "source/spirv_target_env.h"
-#include "test/unit_spirv.h"
 #include "test/val/val_fixtures.h"
 
 namespace spvtools {
@@ -683,6 +680,40 @@ TEST_F(ValidateSpvKHRAbort, ConstantDataLengthUnderUint64) {
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("contains 2 words of data, but needs to have 4 words "
                         "to match the array of 2 of 64-bit ints"));
+}
+
+TEST_F(ValidateSpvKHRAbort, ExplicitLayout) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability Int8
+               OpCapability AbortKHR
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_abort"
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpMemberDecorate %abortMessageLoadType 0 Offset 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %char = OpTypeInt 8 1
+       %uint = OpTypeInt 32 0
+    %uint_12 = OpConstant %uint 12
+%_arr_char_uint_12 = OpTypeArray %char %uint_12
+%_arr_char_uint_12_0 = OpTypeArray %char %uint_12
+         %11 = OpConstantDataKHR %_arr_char_uint_12 1919902305 1870091380 0
+%abortMessageLoadType = OpTypeStruct %_arr_char_uint_12_0
+%abortMessage = OpTypeStruct %_arr_char_uint_12
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+         %14 = OpCompositeConstruct %abortMessage %11
+               OpAbortKHR %abortMessageLoadType %14
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str(), SPV_ENV_VULKAN_1_3);
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_3));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Array must be explicitly laid out"));
 }
 
 }  // namespace


### PR DESCRIPTION
For https://github.com/KhronosGroup/glslang/issues/4369 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12298

`OpAbortKHR` was not validating the `Message Type` and glslang has been generating invalid SPIR-V