### PR TITLE
spirv-val: Add Offset Input VUID 12509

### DIFF
--- a/source/val/validate_decorations.cpp
+++ b/source/val/validate_decorations.cpp
@@ -317,6 +317,7 @@ spv_result_t CheckDecorationsOfEntryPoints(ValidationState_t& vstate) {
               }
             } else {
               return vstate.diag(SPV_ERROR_INVALID_ID, var_instr)
+                     << vstate.VkErrorID(12509)
                      << "The Input interface variable must not have Offset on "
                         "any member decoration.";
             }

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -3635,6 +3635,8 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-Result-12468);
     case 12469:
       return VUID_WRAP(VUID-StandaloneSpirv-Base-12469);
+    case 12509:
+      return VUID_WRAP(VUID-StandaloneSpirv-Offset-12509);
     default:
       return "";  // unknown id
   }

--- a/test/val/val_decoration_test.cpp
+++ b/test/val/val_decoration_test.cpp
@@ -7023,6 +7023,8 @@ TEST_F(ValidateDecorations, InputWithOffset) {
   CompileSuccessfully(text, SPV_ENV_VULKAN_1_2);
   EXPECT_EQ(SPV_ERROR_INVALID_ID, ValidateInstructions(SPV_ENV_VULKAN_1_2));
   EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-Offset-12509"));
+  EXPECT_THAT(getDiagnosticString(),
               HasSubstr("The Input interface variable must not have Offset on "
                         "any member decoration"));
 }


### PR DESCRIPTION
adds ` VUID-StandaloneSpirv-Offset-12509` which was added in 1.4.361 spec