### PR TITLE
spirv-opt: Harden EliminateDeadFunctionsPass and IRContext against ID overflow

### DIFF
--- a/source/opt/eliminate_dead_functions_pass.cpp
+++ b/source/opt/eliminate_dead_functions_pass.cpp
@@ -39,6 +39,9 @@ Pass::Status EliminateDeadFunctionsPass::Process() {
       modified = true;
       funcIter =
           eliminatedeadfunctionsutil::EliminateFunction(context(), &funcIter);
+      if (context()->id_overflow()) {
+        return Pass::Status::Failure;
+      }
     } else {
       ++funcIter;
     }

--- a/source/opt/ir_context.cpp
+++ b/source/opt/ir_context.cpp
@@ -559,9 +559,11 @@ void IRContext::KillOperandFromDebugInstructions(Instruction* inst) {
         continue;
       auto& operand = it->GetOperand(kDebugFunctionOperandFunctionIndex);
       if (operand.words[0] == id) {
-        operand.words[0] =
-            get_debug_info_mgr()->GetDebugInfoNone()->result_id();
-        get_def_use_mgr()->AnalyzeInstUse(&*it);
+        Instruction* dbg_none = get_debug_info_mgr()->GetDebugInfoNone();
+        if (dbg_none) {
+          operand.words[0] = dbg_none->result_id();
+          get_def_use_mgr()->AnalyzeInstUse(&*it);
+        }
       }
     }
   }
@@ -573,9 +575,11 @@ void IRContext::KillOperandFromDebugInstructions(Instruction* inst) {
         continue;
       auto& operand = it->GetOperand(kDebugGlobalVariableOperandVariableIndex);
       if (operand.words[0] == id) {
-        operand.words[0] =
-            get_debug_info_mgr()->GetDebugInfoNone()->result_id();
-        get_def_use_mgr()->AnalyzeInstUse(&*it);
+        Instruction* dbg_none = get_debug_info_mgr()->GetDebugInfoNone();
+        if (dbg_none) {
+          operand.words[0] = dbg_none->result_id();
+          get_def_use_mgr()->AnalyzeInstUse(&*it);
+        }
       }
     }
   }


### PR DESCRIPTION
Modifies EliminateDeadFunctionsPass and IRContext::KillOperandFromDebugInstructions
to handle ID overflow when GetDebugInfoNone returns nullptr, avoiding null dereference.
Propagates Status::Failure in EliminateDeadFunctionsPass.
