### PR TITLE
spirv-val: Validate DebugPrintf

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,6 +68,7 @@ create_grammar_tables_target(
             "debuginfo",
             "nonsemantic.clspvreflection",
             "nonsemantic.vkspreflection",
+            "nonsemantic.debugprintf",
         ]
     ]
 )

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -54,6 +54,7 @@ action("spvtools_core_tables") {
   f10=rebase_path("${grammar_dir}/extinst.spv-amd-shader-trinary-minmax.grammar.json", root_build_dir)
   f11=rebase_path("${grammar_dir}/extinst.nonsemantic.graph.debuginfo.grammar.json", root_build_dir)
   f12=rebase_path("${grammar_dir}/extinst.arm.experimental-ml-operations.grammar.json", root_build_dir)
+  f13=rebase_path("${grammar_dir}/extinst.nonsemantic.debugprintf.grammar.json", root_build_dir)
 
   sources = [
     "utils/Table/__init__.py",
@@ -74,6 +75,7 @@ action("spvtools_core_tables") {
     "${grammar_dir}/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json",
     "${grammar_dir}/extinst.spv-amd-shader-trinary-minmax.grammar.json",
     "${grammar_dir}/extinst.arm.experimental-ml-operations.grammar.json",
+    "${grammar_dir}/extinst.nonsemantic.debugprintf.grammar.json",
     "${grammar_dir}/spirv.core.grammar.json",
   ]
   outputs = [
@@ -96,6 +98,7 @@ action("spvtools_core_tables") {
     "--extinst=,${f10}",
     "--extinst=,${f11}",
     "--extinst=,${f12}",
+    "--extinst=,${f13}",
     "--core-tables-body-output",
     rebase_path(core_tables_body_file, root_build_dir),
     "--core-tables-header-output",
@@ -174,6 +177,10 @@ spvtools_language_header("armexperimentalmloperations") {
   name = "ArmExperimentalMLOperations"
   grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.arm.experimental-ml-operations.grammar.json"
 }
+spvtools_language_header("debugprintf") {
+  name = "NonSemanticDebugPrintf"
+  grammar_file = "${spirv_headers}/include/spirv/unified1/extinst.nonsemantic.debugprintf.grammar.json"
+}
 
 config("spvtools_public_config") {
   include_dirs = [ "include" ]
@@ -235,6 +242,7 @@ group("spvtools_language_headers") {
     ":spvtools_language_header_vkdebuginfo",
     ":spvtools_language_header_graphdebuginfo",
     ":spvtools_language_header_armexperimentalmloperations",
+    ":spvtools_language_header_debugprintf",
   ]
 }
 
@@ -247,6 +255,7 @@ static_library("spvtools") {
     ":spvtools_language_header_vkdebuginfo",
     ":spvtools_language_header_graphdebuginfo",
     ":spvtools_language_header_armexperimentalmloperations",
+    ":spvtools_language_header_debugprintf",
   ]
 
   sources = [
@@ -409,6 +418,7 @@ static_library("spvtools_val") {
     ":spvtools_language_header_vkdebuginfo",
     ":spvtools_language_header_graphdebuginfo",
     ":spvtools_language_header_armexperimentalmloperations",
+    ":spvtools_language_header_debugprintf",
   ]
   public_deps = [ ":spvtools_headers" ]
 
@@ -681,6 +691,7 @@ static_library("spvtools_opt") {
     ":spvtools_language_header_vkdebuginfo",
     ":spvtools_language_header_graphdebuginfo",
     ":spvtools_language_header_armexperimentalmloperations",
+    ":spvtools_language_header_debugprintf",
   ]
 
   if (build_with_chromium) {
@@ -1286,6 +1297,7 @@ if (build_with_chromium && spvtools_build_executables) {
       ":spvtools_language_header_vkdebuginfo",
       ":spvtools_language_header_graphdebuginfo",
       ":spvtools_language_header_armexperimentalmloperations",
+      ":spvtools_language_header_debugprintf",
       ":spvtools_tools_io",
       ":spvtools_val",
       "//testing/gmock",

--- a/include/spirv-tools/libspirv.h
+++ b/include/spirv-tools/libspirv.h
@@ -370,6 +370,7 @@ typedef enum spv_ext_inst_type_t {
   SPV_EXT_INST_TYPE_TOSA_001000_1,
   SPV_EXT_INST_TYPE_ARM_MOTION_ENGINE_100,
   SPV_EXT_INST_TYPE_ARM_EXPERIMENTAL_ML_OPERATIONS,
+  SPV_EXT_INST_TYPE_NONSEMANTIC_DEBUGPRINTF,
 
   // Multiple distinct extended instruction set types could return this
   // value, if they are prefixed with NonSemantic. and are otherwise

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -35,6 +35,7 @@ set(EI_tosa_001000_1 "${GRAMMAR_DIR}/extinst.tosa.001000.1.grammar.json")
 set(EI_arm_motion_engine_100 "${GRAMMAR_DIR}/extinst.arm.motion-engine.100.grammar.json")
 set(EI_ns_graph_debug_info "${GRAMMAR_DIR}/extinst.nonsemantic.graph.debuginfo.grammar.json")
 set(EI_arm_experimental_ml_operations "${GRAMMAR_DIR}/extinst.arm.experimental-ml-operations.grammar.json")
+set(EI_ns_debugprintf "${GRAMMAR_DIR}/extinst.nonsemantic.debugprintf.grammar.json")
 
 set(CORE_TABLES_BODY_INC_FILE ${spirv-tools_BINARY_DIR}/core_tables_body.inc)
 set(CORE_TABLES_HEADER_INC_FILE ${spirv-tools_BINARY_DIR}/core_tables_header.inc)
@@ -58,6 +59,7 @@ add_custom_command(OUTPUT ${CORE_TABLES_BODY_INC_FILE} ${CORE_TABLES_HEADER_INC_
       --extinst=,${EI_arm_motion_engine_100}
       --extinst=,${EI_ns_graph_debug_info}
       --extinst=,${EI_arm_experimental_ml_operations}
+      --extinst=,${EI_ns_debugprintf}
     DEPENDS ${GGT_SCRIPT}
             ${SPIRV_CORE_GRAMMAR_JSON_FILE}
 	    ${EI_glsl}
@@ -75,6 +77,7 @@ add_custom_command(OUTPUT ${CORE_TABLES_BODY_INC_FILE} ${CORE_TABLES_HEADER_INC_
 	    ${EI_arm_motion_engine_100}
 	    ${EI_ns_graph_debug_info}
 	    ${EI_arm_experimental_ml_operations}
+	    ${EI_ns_debugprintf}
     COMMENT "Generate grammar tables")
 add_custom_target(spirv-tools-tables DEPENDS ${CORE_TABLES_BODY_INC_FILE} ${CORE_TABLES_HEADER_INC_FILE})
 

--- a/source/ext_inst.cpp
+++ b/source/ext_inst.cpp
@@ -69,6 +69,9 @@ spv_ext_inst_type_t spvExtInstImportTypeGet(const char* name) {
   if (!strncmp("Arm.ExperimentalMLOperations.", name, 29)) {
     return SPV_EXT_INST_TYPE_ARM_EXPERIMENTAL_ML_OPERATIONS;
   }
+  if (!strcmp("NonSemantic.DebugPrintf", name)) {
+    return SPV_EXT_INST_TYPE_NONSEMANTIC_DEBUGPRINTF;
+  }
   // ensure to add any known non-semantic extended instruction sets
   // above this point, and update spvExtInstIsNonSemantic()
   if (!strncmp("NonSemantic.", name, 12)) {
@@ -82,7 +85,8 @@ bool spvExtInstIsNonSemantic(const spv_ext_inst_type_t type) {
       type == SPV_EXT_INST_TYPE_NONSEMANTIC_SHADER_DEBUGINFO_100 ||
       type == SPV_EXT_INST_TYPE_NONSEMANTIC_CLSPVREFLECTION ||
       type == SPV_EXT_INST_TYPE_NONSEMANTIC_GRAPH_DEBUGINFO ||
-      type == SPV_EXT_INST_TYPE_NONSEMANTIC_VKSPREFLECTION) {
+      type == SPV_EXT_INST_TYPE_NONSEMANTIC_VKSPREFLECTION ||
+      type == SPV_EXT_INST_TYPE_NONSEMANTIC_DEBUGPRINTF) {
     return true;
   }
   return false;

--- a/source/val/validate_extensions.cpp
+++ b/source/val/validate_extensions.cpp
@@ -35,6 +35,7 @@
 #include "spirv-tools/libspirv.h"
 #include "spirv/unified1/ArmExperimentalMLOperations.h"
 #include "spirv/unified1/NonSemanticClspvReflection.h"
+#include "spirv/unified1/NonSemanticDebugPrintf.h"
 #include "spirv/unified1/NonSemanticGraphDebugInfo.h"
 #include "spirv/unified1/NonSemanticShaderDebugInfo.h"
 
@@ -4449,6 +4450,26 @@ spv_result_t ValidateExtInstNonsemanticClspvReflection(
   return ValidateClspvReflectionInstruction(_, inst, version);
 }
 
+spv_result_t ValidateExtInstNonSemanticDebugPrintf(ValidationState_t& _,
+                                                   const Instruction* inst) {
+  if (!_.IsVoidType(inst->type_id())) {
+    return _.diag(SPV_ERROR_INVALID_DATA, inst)
+           << "DebugPrintf: "
+           << "expected result type must be a result id of OpTypeVoid";
+  }
+
+  if (inst->word(4) == NonSemanticDebugPrintfDebugPrintf) {
+    const auto* format = _.FindDef(inst->word(5));
+    if (!format || format->opcode() != spv::Op::OpString) {
+      return _.diag(SPV_ERROR_INVALID_DATA, inst)
+             << "DebugPrintf: "
+             << "expected operand Format must be a result id of OpString";
+    }
+  }
+
+  return SPV_SUCCESS;
+}
+
 spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
   const spv_ext_inst_type_t ext_inst_type =
       spv_ext_inst_type_t(inst->ext_inst_type());
@@ -4473,6 +4494,8 @@ spv_result_t ValidateExtInst(ValidationState_t& _, const Instruction* inst) {
     return ValidateExtInstNonsemanticClspvReflection(_, inst);
   } else if (ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_GRAPH_DEBUGINFO) {
     return ValidateExtInstGraphDebugInfo(_, inst);
+  } else if (ext_inst_type == SPV_EXT_INST_TYPE_NONSEMANTIC_DEBUGPRINTF) {
+    return ValidateExtInstNonSemanticDebugPrintf(_, inst);
   }
 
   return SPV_SUCCESS;

--- a/test/diff/diff_files/string_in_ext_inst_autogen.cpp
+++ b/test/diff/diff_files/string_in_ext_inst_autogen.cpp
@@ -71,7 +71,7 @@ constexpr char kDst[] = R"(               OpCapability Shader
         %foo = OpVariable %_ptr_Function_uint Function
                OpStore %foo %uint_127
          %11 = OpLoad %uint %foo
-         %13 = OpExtInst %void %12 1 %10 %11
+         %13 = OpExtInst %void %12 DebugPrintf %10 %11
                OpReturn
                OpFunctionEnd
 )";
@@ -106,8 +106,8 @@ TEST(DiffTest, StringInExtInst) {
  %4 = OpVariable %8 Function
  OpStore %4 %9
  %11 = OpLoad %7 %4
--%13 = OpExtInst %6 %12 1 %10 %11
-+%13 = OpExtInst %6 %12 1 %14 %11
+-%13 = OpExtInst %6 %12 DebugPrintf %10 %11
++%13 = OpExtInst %6 %12 DebugPrintf %14 %11
  OpReturn
  OpFunctionEnd
 )";
@@ -136,7 +136,7 @@ TEST(DiffTest, StringInExtInstNoDebug) {
         %foo = OpVariable %_ptr_Function_uint Function
                OpStore %foo %uint_127
          %11 = OpLoad %uint %foo
-         %13 = OpExtInst %void %12 1 %10 %11
+         %13 = OpExtInst %void %12 DebugPrintf %10 %11
                OpReturn
                OpFunctionEnd
 )";
@@ -160,7 +160,7 @@ TEST(DiffTest, StringInExtInstNoDebug) {
         %foo = OpVariable %_ptr_Function_uint Function
                OpStore %foo %uint_127
          %11 = OpLoad %uint %foo
-         %13 = OpExtInst %void %12 1 %10 %11
+         %13 = OpExtInst %void %12 DebugPrintf %10 %11
                OpReturn
                OpFunctionEnd
 )";
@@ -191,8 +191,8 @@ TEST(DiffTest, StringInExtInstNoDebug) {
  %9 = OpVariable %7 Function
  OpStore %9 %8
  %11 = OpLoad %6 %9
--%13 = OpExtInst %4 %12 1 %10 %11
-+%13 = OpExtInst %4 %12 1 %14 %11
+-%13 = OpExtInst %4 %12 DebugPrintf %10 %11
++%13 = OpExtInst %4 %12 DebugPrintf %14 %11
  OpReturn
  OpFunctionEnd
 )";

--- a/test/opt/eliminate_dead_functions_test.cpp
+++ b/test/opt/eliminate_dead_functions_test.cpp
@@ -398,7 +398,7 @@ OpFunctionEnd
 OpReturn
 OpFunctionEnd
 %non_semantic2 = OpExtInst %void %ext 2 %foo
-%non_semantic3 = OpExtInst %void %ext 3 
+%non_semantic3 = OpExtInst %void %ext 3
 )";
 
   SinglePassRunAndMatch<EliminateDeadFunctionsPass>(text, true);
@@ -431,7 +431,7 @@ OpFunctionEnd
 OpReturn
 OpFunctionEnd
 %non_semantic2 = OpExtInst %void %ext 2 %foo
-%non_semantic3 = OpExtInst %void %ext 3 
+%non_semantic3 = OpExtInst %void %ext 3
 %non_semantic4 = OpExtInst %void %ext 4 %non_semantic2
 %non_semantic5 = OpExtInst %void %ext 5 %non_semantic4
 )";
@@ -450,7 +450,7 @@ TEST_F(EliminateDeadFunctionsBasicTest, NonSemanticInfoRemoveDebugPrintf) {
 ; CHECK-NOT: OpStore %c % 27
 ; CHECK-NOT: % 31 = OpAccessChain %_ptr_Function_float %c %uint_0
 ; CHECK-NOT: % 32 = OpLoad %float %31
-; CHECK-NOT: % 34 = OpExtInst %void %33 1 % 28 % 32
+; CHECK-NOT: % 34 = OpExtInst %void %33 DebugPrintf % 28 % 32
 OpCapability RayTracingKHR
 OpExtension "SPV_KHR_non_semantic_info"
 OpExtension "SPV_KHR_ray_tracing"
@@ -496,7 +496,7 @@ OpDecorate %samplers Binding 0
 OpStore %36 %40
 %41 = OpAccessChain %_ptr_Function_float %36 %uint_0
 %42 = OpLoad %float %41
-%43 = OpExtInst %void %33 1 %28 %42
+%43 = OpExtInst %void %33 DebugPrintf %28 %42
 OpReturn
 OpFunctionEnd
 %foo_ = OpFunction %void None %3
@@ -508,7 +508,7 @@ OpFunctionEnd
 OpStore %c %27
 %31 = OpAccessChain %_ptr_Function_float %c %uint_0
 %32 = OpLoad %float %31
-%34 = OpExtInst %void %33 1 %28 %32
+%34 = OpExtInst %void %33 DebugPrintf %28 %32
 OpReturn
 OpFunctionEnd
 )";

--- a/test/val/val_ext_inst_test.cpp
+++ b/test/val/val_ext_inst_test.cpp
@@ -8068,6 +8068,82 @@ OpMemoryModel Logical GLSL450
   ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
 }
 
+TEST_F(ValidateExtInst, NonSemanticDebugPrintfGood) {
+  const std::string text = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%fmt = OpString "value: %d"
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%main = OpFunction %void None %4
+%6 = OpLabel
+%10 = OpExtInst %void %1 DebugPrintf %fmt %int_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_SUCCESS, ValidateInstructions());
+}
+
+TEST_F(ValidateExtInst, NonSemanticDebugPrintfFormat) {
+  const std::string text = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+%9 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%int_1 = OpConstant %int 1
+%main = OpFunction %void None %4
+%6 = OpLabel
+%10 = OpExtInst %void %9 DebugPrintf %int_1
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("DebugPrintf: expected "
+                        "operand Format must be a result id of OpString"));
+}
+
+TEST_F(ValidateExtInst, NonSemanticDebugPrintfResultType) {
+  const std::string text = R"(
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+%1 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %main "main"
+OpExecutionMode %main LocalSize 1 1 1
+%fmt = OpString "value: %d"
+%void = OpTypeVoid
+%4 = OpTypeFunction %void
+%int = OpTypeInt 32 1
+%main = OpFunction %void None %4
+%6 = OpLabel
+%10 = OpExtInst %int %1 DebugPrintf %fmt
+OpReturn
+OpFunctionEnd
+)";
+
+  CompileSuccessfully(text);
+  ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("DebugPrintf: expected "
+                        "result type must be a result id of OpTypeVoid"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools

--- a/utils/generate_language_headers.py
+++ b/utils/generate_language_headers.py
@@ -178,9 +178,14 @@ def main():
           operand_kinds = grammar_json['operand_kinds']
         else:
           operand_kinds = []
+        # TODO - extinst.nonsemantic.debugprintf.grammar.json is missing the copyright
+        if 'copyright' in grammar_json:
+          copyright = grammar_json['copyright']
+        else:
+          copyright = None
 
         grammar = ExtInstGrammar(name = grammar_name,
-                                 copyright = grammar_json['copyright'],
+                                 copyright = copyright,
                                  instructions = grammar_json['instructions'],
                                  operand_kinds = operand_kinds,
                                  version = version,


### PR DESCRIPTION
From https://github.com/KhronosGroup/glslang/pull/4404 seems like we never added any validation for the `DebugPrintf` extended instruction

(copied other PR how to add the various build command so hopefully that part works, CI will tell me I guess if not)