### PR TITLE
spirv-opt: Harden EliminateDeadMembers and FixFuncCallArguments against ID overflow

### DIFF
--- a/source/opt/eliminate_dead_members_pass.cpp
+++ b/source/opt/eliminate_dead_members_pass.cpp
@@ -26,14 +26,12 @@ constexpr uint32_t kArrayElementTypeIdx = 0;
 }  // namespace
 
 Pass::Status EliminateDeadMembersPass::Process() {
-  if (!context()->get_feature_mgr()->HasCapability(spv::Capability::Shader))
+  if (!context()->get_feature_mgr()->HasCapability(spv::Capability::Shader)) {
     return Status::SuccessWithoutChange;
+  }
 
   FindLiveMembers();
-  if (RemoveDeadMembers()) {
-    return Status::SuccessWithChange;
-  }
-  return Status::SuccessWithoutChange;
+  return RemoveDeadMembers();
 }
 
 void EliminateDeadMembersPass::FindLiveMembers() {
@@ -283,7 +281,7 @@ void EliminateDeadMembersPass::MarkMembersAsLiveForArrayLength(
   used_members_[type_id].insert(inst->GetSingleWordInOperand(1));
 }
 
-bool EliminateDeadMembersPass::RemoveDeadMembers() {
+Pass::Status EliminateDeadMembersPass::RemoveDeadMembers() {
   bool modified = false;
 
   // First update all of the OpTypeStruct instructions.
@@ -298,7 +296,9 @@ bool EliminateDeadMembersPass::RemoveDeadMembers() {
   });
 
   // Now update all of the instructions that reference the OpTypeStructs.
-  get_module()->ForEachInst([&modified, this](Instruction* inst) {
+  Pass::Status status = Status::SuccessWithoutChange;
+  bool success = get_module()->WhileEachInst([&modified, &status,
+                                              this](Instruction* inst) {
     switch (inst->opcode()) {
       case spv::Op::OpMemberName:
         modified |= UpdateOpMemberNameOrDecorate(inst);
@@ -317,9 +317,17 @@ bool EliminateDeadMembersPass::RemoveDeadMembers() {
       case spv::Op::OpAccessChain:
       case spv::Op::OpInBoundsAccessChain:
       case spv::Op::OpPtrAccessChain:
-      case spv::Op::OpInBoundsPtrAccessChain:
-        modified |= UpdateAccessChain(inst);
+      case spv::Op::OpInBoundsPtrAccessChain: {
+        Pass::Status s = UpdateAccessChain(inst);
+        if (s == Status::Failure) {
+          status = Status::Failure;
+          return false;
+        }
+        if (s == Status::SuccessWithChange) {
+          modified = true;
+        }
         break;
+      }
       case spv::Op::OpCompositeExtract:
         modified |= UpdateCompsiteExtract(inst);
         break;
@@ -350,8 +358,13 @@ bool EliminateDeadMembersPass::RemoveDeadMembers() {
       default:
         break;
     }
+    return true;
   });
-  return modified;
+
+  if (!success || status == Status::Failure) {
+    return Status::Failure;
+  }
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
 bool EliminateDeadMembersPass::UpdateOpTypeStruct(Instruction* inst) {
@@ -460,7 +473,7 @@ bool EliminateDeadMembersPass::UpdateConstantComposite(Instruction* inst) {
   return modified;
 }
 
-bool EliminateDeadMembersPass::UpdateAccessChain(Instruction* inst) {
+Pass::Status EliminateDeadMembersPass::UpdateAccessChain(Instruction* inst) {
   assert(inst->opcode() == spv::Op::OpAccessChain ||
          inst->opcode() == spv::Op::OpInBoundsAccessChain ||
          inst->opcode() == spv::Op::OpPtrAccessChain ||
@@ -501,8 +514,11 @@ bool EliminateDeadMembersPass::UpdateAccessChain(Instruction* inst) {
               context(), inst,
               IRContext::kAnalysisDefUse |
                   IRContext::kAnalysisInstrToBlockMapping);
-          uint32_t const_id =
-              ir_builder.GetUintConstant(new_member_idx)->result_id();
+          Instruction* const_inst = ir_builder.GetUintConstant(new_member_idx);
+          if (!const_inst) {
+            return Status::Failure;
+          }
+          uint32_t const_id = const_inst->result_id();
           new_operands.emplace_back(Operand({SPV_OPERAND_TYPE_ID, {const_id}}));
           modified = true;
         } else {
@@ -529,11 +545,11 @@ bool EliminateDeadMembersPass::UpdateAccessChain(Instruction* inst) {
   }
 
   if (!modified) {
-    return false;
+    return Status::SuccessWithoutChange;
   }
   inst->SetInOperands(std::move(new_operands));
   context()->UpdateDefUse(inst);
-  return true;
+  return Status::SuccessWithChange;
 }
 
 uint32_t EliminateDeadMembersPass::GetNewMemberIndex(uint32_t type_id,

--- a/source/opt/eliminate_dead_members_pass.h
+++ b/source/opt/eliminate_dead_members_pass.h
@@ -76,8 +76,8 @@ class EliminateDeadMembersPass : public MemPass {
   void MarkMembersAsLiveForArrayLength(const Instruction* inst);
 
   // Remove dead members from structs and updates any instructions that need to
-  // be updated as a consequence.  Return true if something changed.
-  bool RemoveDeadMembers();
+  // be updated as a consequence.
+  Status RemoveDeadMembers();
 
   // Update |inst|, which must be an |OpMemberName| or |OpMemberDecorate|
   // instruction, so it references the correct member after the struct is
@@ -101,8 +101,8 @@ class EliminateDeadMembersPass : public MemPass {
   // Update the |Op*AccessChain| instruction |inst| to reference the correct
   // members. All members referenced in the access chain must be live.  This
   // function must be called after the |OpTypeStruct| instruction for the type
-  // has been updated.  Return true if something changed.
-  bool UpdateAccessChain(Instruction* inst);
+  // has been updated.
+  Status UpdateAccessChain(Instruction* inst);
 
   // Update the |OpCompositeExtract| instruction |inst| to reference the correct
   // members. All members referenced in the instruction must be live.  This

--- a/source/opt/fix_func_call_arguments.cpp
+++ b/source/opt/fix_func_call_arguments.cpp
@@ -26,18 +26,31 @@ bool FixFuncCallArgumentsPass::ModuleHasASingleFunction() {
 
 Pass::Status FixFuncCallArgumentsPass::Process() {
   bool modified = false;
-  if (ModuleHasASingleFunction()) return Status::SuccessWithoutChange;
+  if (ModuleHasASingleFunction()) {
+    return Status::SuccessWithoutChange;
+  }
   for (auto& func : *get_module()) {
-    func.ForEachInst([this, &modified](Instruction* inst) {
-      if (inst->opcode() == spv::Op::OpFunctionCall) {
-        modified |= FixFuncCallArguments(inst);
-      }
-    });
+    const bool success =
+        func.WhileEachInst([this, &modified](Instruction* inst) {
+          if (inst->opcode() == spv::Op::OpFunctionCall) {
+            auto status = FixFuncCallArguments(inst);
+            if (status == Status::Failure) {
+              return false;
+            }
+            if (status == Status::SuccessWithChange) {
+              modified = true;
+            }
+          }
+          return true;
+        });
+    if (!success) {
+      return Status::Failure;
+    }
   }
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
-bool FixFuncCallArgumentsPass::FixFuncCallArguments(
+Pass::Status FixFuncCallArgumentsPass::FixFuncCallArguments(
     Instruction* func_call_inst) {
   bool modified = false;
   for (uint32_t i = 0; i < func_call_inst->NumInOperands(); ++i) {
@@ -47,6 +60,9 @@ bool FixFuncCallArgumentsPass::FixFuncCallArguments(
     if (operand_inst->opcode() == spv::Op::OpAccessChain) {
       uint32_t var_id =
           ReplaceAccessChainFuncCallArguments(func_call_inst, operand_inst);
+      if (var_id == 0) {
+        return Status::Failure;
+      }
       func_call_inst->SetInOperand(i, {var_id});
       modified = true;
     }
@@ -54,7 +70,7 @@ bool FixFuncCallArgumentsPass::FixFuncCallArguments(
   if (modified) {
     context()->UpdateDefUse(func_call_inst);
   }
-  return modified;
+  return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
 uint32_t FixFuncCallArgumentsPass::ReplaceAccessChainFuncCallArguments(
@@ -72,22 +88,31 @@ uint32_t FixFuncCallArgumentsPass::ReplaceAccessChainFuncCallArguments(
       get_def_use_mgr()->GetDef(op_ptr_type->GetSingleWordInOperand(1));
   uint32_t varType = context()->get_type_mgr()->FindPointerToType(
       op_type->result_id(), spv::StorageClass::Function);
+  if (varType == 0) {
+    return 0;
+  }
   // Create new variable
   builder.SetInsertPoint(variable_insertion_point);
-  // TODO(1841): Handle id overflow.
   Instruction* var =
       builder.AddVariable(varType, uint32_t(spv::StorageClass::Function));
+  if (!var) {
+    return 0;
+  }
   // Load access chain to the new variable before function call
   builder.SetInsertPoint(func_call_inst);
 
   uint32_t operand_id = operand_inst->result_id();
-  // TODO(1841): Handle id overflow.
   Instruction* load = builder.AddLoad(op_type->result_id(), operand_id);
+  if (!load) {
+    return 0;
+  }
   builder.AddStore(var->result_id(), load->result_id());
   // Load return value to the acesschain after function call
   builder.SetInsertPoint(next_insert_point);
-  // TODO(1841): Handle id overflow.
   load = builder.AddLoad(op_type->result_id(), var->result_id());
+  if (!load) {
+    return 0;
+  }
   builder.AddStore(operand_id, load->result_id());
 
   return var->result_id();

--- a/source/opt/fix_func_call_arguments.h
+++ b/source/opt/fix_func_call_arguments.h
@@ -35,7 +35,7 @@ class FixFuncCallArgumentsPass : public Pass {
                                                Instruction* operand_inst);
 
   // Fix function call |func_call_inst| non memory object arguments
-  bool FixFuncCallArguments(Instruction* func_call_inst);
+  Status FixFuncCallArguments(Instruction* func_call_inst);
 
   IRContext::Analysis GetPreservedAnalyses() override {
     return IRContext::kAnalysisTypes;


### PR DESCRIPTION
Hardens EliminateDeadMembersPass and FixFuncCallArgumentsPass against ID overflow:
- In EliminateDeadMembersPass, returns Pass::Status from UpdateAccessChain and
  RemoveDeadMembers. Checks for null when creating uint constant in UpdateAccessChain,
  and uses WhileEachInst in RemoveDeadMembers to terminate early on error.
- In FixFuncCallArgumentsPass, checks for null when creating variables and
  load/store instructions in ReplaceAccessChainFuncCallArguments and propagates
  failure status. Also updates Process() to use func.WhileEachInst to terminate
  early on failure.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>