### PR TITLE
Fix SPIR-V string decoding across endianness

### DIFF
--- a/source/binary.cpp
+++ b/source/binary.cpp
@@ -496,8 +496,8 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
 
   const uint32_t word = peek();
 
-  // Do the words in this operand have to be converted to native endianness?
-  // True for all but literal strings.
+  // Instruction callbacks receive all operand words in native endianness,
+  // including words that encode literal strings.
   bool convert_operand_endianness = true;
 
   switch (type) {
@@ -664,10 +664,24 @@ spv_result_t Parser::parseOperand(size_t inst_offset,
     case SPV_OPERAND_TYPE_LITERAL_STRING:
     case SPV_OPERAND_TYPE_OPTIONAL_LITERAL_STRING: {
       const size_t max_words = _.num_words - _.word_index;
-      std::string string =
-          spvtools::utils::MakeString(_.words + _.word_index, max_words, false);
+      std::string string;
+      bool found_terminating_null = false;
+      for (size_t word_index = 0;
+           word_index < max_words && !found_terminating_null; ++word_index) {
+        const uint32_t string_word = peekAt(_.word_index + word_index);
+        for (size_t byte_index = 0; byte_index < sizeof(string_word);
+             ++byte_index) {
+          const char c = static_cast<char>((string_word >> (8 * byte_index)) &
+                                           uint32_t{0xff});
+          if (c == '\0') {
+            found_terminating_null = true;
+            break;
+          }
+          string += c;
+        }
+      }
 
-      if (string.length() == max_words * 4)
+      if (!found_terminating_null)
         return exhaustedInputDiagnostic(inst_offset, opcode, type);
 
       // Make sure we can record the word count without overflow.

--- a/test/binary_parse_test.cpp
+++ b/test/binary_parse_test.cpp
@@ -856,6 +856,18 @@ TEST_F(BinaryParseTest, ExtendedInstruction) {
   EXPECT_EQ(nullptr, diagnostic_);
 }
 
+TEST_F(BinaryParseTest, ExtendedInstructionWithSwappedEndianness) {
+  const auto words = CompileSuccessfully(
+      "%extcl = OpExtInstImport \"OpenCL.std\" "
+      "%result = OpExtInst %float %extcl sqrt %x");
+  EXPECT_HEADER(5).WillOnce(Return(SPV_SUCCESS));
+  EXPECT_CALL(client_, Instruction(_))
+      .Times(2)
+      .WillRepeatedly(Return(SPV_SUCCESS));
+  Parse(words, SPV_SUCCESS, true);
+  EXPECT_EQ(nullptr, diagnostic_);
+}
+
 TEST_F(CxxBinaryParseTest, ExtendedInstruction) {
   const auto words = CompileSuccessfully(
       "%extcl = OpExtInstImport \"OpenCL.std\" "

--- a/test/tools/objdump/extract_source_test.cpp
+++ b/test/tools/objdump/extract_source_test.cpp
@@ -88,7 +88,7 @@ TEST(ExtractSourceTest, SimpleSource) {
                "[numthreads(1, 1, 1)] void compute_1(){ }");
 }
 
-TEST(ExtractSourceTest, SourceContinued) {
+TEST(ExtractSourceTest, MultipleSourceContinued) {
   std::string source = R"(
       OpCapability Shader
       OpMemoryModel Logical GLSL450
@@ -96,7 +96,8 @@ TEST(ExtractSourceTest, SourceContinued) {
       OpExecutionMode %1 LocalSize 1 1 1
  %2 = OpString "compute.hlsl"
       OpSource HLSL 660 %2 "[numthreads(1, 1, 1)] "
-      OpSourceContinued "void compute_1(){ }"
+      OpSourceContinued "void compute_1("
+      OpSourceContinued "){ }"
       OpName %1 "compute_1"
  %3 = OpTypeVoid
  %4 = OpTypeFunction %3

--- a/tools/objdump/extract_source.cpp
+++ b/tools/objdump/extract_source.cpp
@@ -21,6 +21,7 @@
 
 #include "source/latest_version_spirv_header.h"
 #include "source/opt/log.h"
+#include "source/util/string_utils.h"
 #include "spirv-tools/libspirv.hpp"
 #include "tools/util/cli_consumer.h"
 
@@ -28,38 +29,33 @@ namespace {
 
 constexpr auto kDefaultEnvironment = SPV_ENV_UNIVERSAL_1_6;
 
-// Extract a string literal from a given range.
-// Copies all the characters from `begin` to the first '\0' it encounters, while
-// removing escape patterns.
-// Not finding a '\0' before reaching `end` fails the extraction.
-//
-// Returns `true` if the extraction succeeded.
-// `output` value is undefined if false is returned.
-spv_result_t ExtractStringLiteral(const spv_position_t& loc, const char* begin,
-                                  const char* end, std::string* output) {
-  size_t sourceLength = std::distance(begin, end);
-  std::string escapedString;
-  escapedString.resize(sourceLength);
-
-  size_t writeIndex = 0;
-  size_t readIndex = 0;
-  for (; readIndex < sourceLength; writeIndex++, readIndex++) {
-    const char read = begin[readIndex];
-    if (read == '\0') {
-      escapedString.resize(writeIndex);
-      output->append(escapedString);
-      return SPV_SUCCESS;
-    }
-
-    if (read == '\\') {
-      ++readIndex;
-    }
-    escapedString[writeIndex] = begin[readIndex];
+// Extract a string literal from a given range of SPIR-V words.
+// Copies all the characters up to the first '\0', while removing escape
+// patterns. Not finding a '\0' before reaching `end` fails the extraction.
+spv_result_t ExtractStringLiteral(const spv_position_t& loc,
+                                  const uint32_t* begin, const uint32_t* end,
+                                  std::string* output) {
+  const size_t source_length =
+      static_cast<size_t>(std::distance(begin, end)) * sizeof(uint32_t);
+  const std::string source = spvtools::utils::MakeString(
+      begin, end, /*assert_found_terminating_null=*/false);
+  if (source.size() == source_length) {
+    spvtools::Error(spvtools::utils::CLIMessageConsumer, "", loc,
+                    "Missing NULL terminator for literal string.");
+    return SPV_ERROR_INVALID_BINARY;
   }
 
-  spvtools::Error(spvtools::utils::CLIMessageConsumer, "", loc,
-                  "Missing NULL terminator for literal string.");
-  return SPV_ERROR_INVALID_BINARY;
+  std::string unescaped_source;
+  unescaped_source.reserve(source.size());
+  for (size_t read_index = 0; read_index < source.size(); ++read_index) {
+    if (source[read_index] == '\\' && read_index + 1 < source.size()) {
+      ++read_index;
+    }
+    unescaped_source.push_back(source[read_index]);
+  }
+
+  output->append(unescaped_source);
+  return SPV_SUCCESS;
 }
 
 spv_result_t extractOpString(const spv_position_t& loc,
@@ -74,11 +70,9 @@ spv_result_t extractOpString(const spv_position_t& loc,
   }
 
   const auto& operand = instruction.operands[1];
-  const char* stringBegin =
-      reinterpret_cast<const char*>(instruction.words + operand.offset);
-  const char* stringEnd = reinterpret_cast<const char*>(
-      instruction.words + operand.offset + operand.num_words);
-  return ExtractStringLiteral(loc, stringBegin, stringEnd, output);
+  const uint32_t* string_begin = instruction.words + operand.offset;
+  const uint32_t* string_end = string_begin + operand.num_words;
+  return ExtractStringLiteral(loc, string_begin, string_end, output);
 }
 
 spv_result_t extractOpSourceContinued(
@@ -94,11 +88,9 @@ spv_result_t extractOpSourceContinued(
   }
 
   const auto& operand = instruction.operands[0];
-  const char* stringBegin =
-      reinterpret_cast<const char*>(instruction.words + operand.offset);
-  const char* stringEnd = reinterpret_cast<const char*>(
-      instruction.words + operand.offset + operand.num_words);
-  return ExtractStringLiteral(loc, stringBegin, stringEnd, output);
+  const uint32_t* string_begin = instruction.words + operand.offset;
+  const uint32_t* string_end = string_begin + operand.num_words;
+  return ExtractStringLiteral(loc, string_begin, string_end, output);
 }
 
 spv_result_t extractOpSource(const spv_position_t& loc,
@@ -124,11 +116,9 @@ spv_result_t extractOpSource(const spv_position_t& loc,
     return SPV_SUCCESS;
   }
 
-  const char* stringBegin =
-      reinterpret_cast<const char*>(instruction.words + 4);
-  const char* stringEnd =
-      reinterpret_cast<const char*>(instruction.words + instruction.num_words);
-  return ExtractStringLiteral(loc, stringBegin, stringEnd, code);
+  const uint32_t* string_begin = instruction.words + 4;
+  const uint32_t* string_end = instruction.words + instruction.num_words;
+  return ExtractStringLiteral(loc, string_begin, string_end, code);
 }
 
 }  // namespace
@@ -172,9 +162,11 @@ bool ExtractSourceFromModule(
           }
         } else if (instruction.opcode ==
                    static_cast<unsigned>(spv::Op::OpSourceContinued)) {
-          if (lastOpcode != spv::Op::OpSource) {
+          if (lastOpcode != spv::Op::OpSource &&
+              lastOpcode != spv::Op::OpSourceContinued) {
             spvtools::Error(spvtools::utils::CLIMessageConsumer, "", loc,
-                            "OpSourceContinued MUST follow an OpSource.");
+                            "OpSourceContinued MUST follow an OpSource or "
+                            "OpSourceContinued.");
             return SPV_ERROR_INVALID_BINARY;
           }
 


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/SPIRV-Tools/issues/6849

## Problem

`spirv-objdump --source` extracted SPIR-V string operands by reinterpreting parsed `uint32_t` words as a byte array. Parsed instruction words are provided in native endianness, so this produces reversed four-byte groups on big-endian hosts.

While investigating the referenced Mesa failure, another endianness issue was found in the common binary parser. `Parser::parseOperand()` decoded literal strings directly from the raw input words before applying endian correction. For an input whose endianness differs from the host, this could turn an import such as `OpenCL.std` into a byte-swapped string and reject `OpExtInstImport` before the objdump instruction callback was invoked.

This means that changing only `tools/objdump/extract_source.cpp` would fix source extraction, but would not fix the reported Mesa FTBFS: the common parser could reject the module first.

The investigation also clarified the `OpSourceContinued` behavior. The current implementation already appends the first continuation through `output->append()`. The actual remaining problem was that a second consecutive `OpSourceContinued` was rejected, even though the validator permits it to follow either `OpSource` or another `OpSourceContinued`.

## Solution

- Decode literal strings in the binary parser from endian-corrected word values obtained through `peekAt()`.
- Decode objdump string operands from their numeric SPIR-V words using the existing low-byte-first `MakeString()` implementation instead of inspecting their in-memory byte representation.
- Preserve the existing source escape handling.
- Allow `OpSourceContinued` after either `OpSource` or `OpSourceContinued`.
- Update the parser endianness comment to match the documented native-endian callback contract.

## Tests

- Added a binary parser regression test using a byte-swapped module containing `OpExtInstImport`.
- Updated the objdump source extraction test to cover multiple consecutive `OpSourceContinued` instructions.
- Built the affected targets with warnings treated as errors.
- `BinaryParseTest` and `CxxBinaryParseTest`: 36 tests passed.
- `ExtractSourceTest`: 9 tests passed.
- Full `test_spirv_unit_tests`: 6419 tests passed.
