### PR TITLE
Validate ArrayStride on OpConstantDataKHR result types

### DIFF
--- a/source/val/validate_constants.cpp
+++ b/source/val/validate_constants.cpp
@@ -713,6 +713,13 @@ spv_result_t ValidateConstantData(ValidationState_t& _,
            << "Result type must be an array of integer scalar type.";
   }
 
+  // The Data literals are tightly packed, so an explicit layout stride on the
+  // result type would contradict how the constant is encoded.
+  if (_.HasDecoration(array_inst->id(), spv::Decoration::ArrayStride)) {
+    return _.diag(SPV_ERROR_INVALID_ID, inst)
+           << "Result type must not be decorated with ArrayStride.";
+  }
+
   const uint32_t int_width = element_type_inst->word(2);
   const uint32_t data_words = static_cast<uint32_t>(inst->words().size() - 3);
 
@@ -780,6 +787,7 @@ spv_result_t ConstantPass(ValidationState_t& _, const Instruction* inst) {
         return error;
       break;
     case spv::Op::OpConstantDataKHR:
+    case spv::Op::OpSpecConstantDataKHR:
       if (auto error = ValidateConstantData(_, inst)) return error;
       break;
     default:

--- a/test/val/val_extension_spv_khr_abort_test.cpp
+++ b/test/val/val_extension_spv_khr_abort_test.cpp
@@ -716,6 +716,58 @@ TEST_F(ValidateSpvKHRAbort, ExplicitLayout) {
               HasSubstr("Array must be explicitly laid out"));
 }
 
+TEST_F(ValidateSpvKHRAbort, ConstantDataArrayStride) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %uint_array ArrayStride 4
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpConstant %uint 1
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpConstantDataKHR %uint_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type must not be decorated with ArrayStride"));
+}
+
+TEST_F(ValidateSpvKHRAbort, SpecConstantDataArrayStride) {
+  const std::string str = R"(
+               OpCapability Shader
+               OpCapability ConstantDataKHR
+               OpExtension "SPV_KHR_constant_data"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %uint_array ArrayStride 4
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+  %uint_size = OpConstant %uint 1
+ %uint_array = OpTypeArray %uint %uint_size
+       %data = OpSpecConstantDataKHR %uint_array 1
+  %void_func = OpTypeFunction %void
+       %main = OpFunction %void None %void_func
+ %main_label = OpLabel
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(str.c_str());
+  EXPECT_NE(SPV_SUCCESS, ValidateInstructions());
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("Result type must not be decorated with ArrayStride"));
+}
+
 }  // namespace
 }  // namespace val
 }  // namespace spvtools


### PR DESCRIPTION
The SPV_KHR_constant_data Data literals are tightly packed, so the extension requires that Result Type must not be decorated with ArrayStride, which would contradict how the constant is encoded.  Add that check to ValidateConstantData().

Also dispatch OpSpecConstantDataKHR to ValidateConstantData().  The extension applies the same result type and Data size rules to both constant-creation instructions, but only OpConstantDataKHR was being validated.
