### PR TITLE
Order the libraries in SPIRV-Tools.pc for static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ if (NOT "${SPIRV_SKIP_TESTS}")
            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-set(SPIRV_LIBRARIES "-lSPIRV-Tools-opt -lSPIRV-Tools -lSPIRV-Tools-link")
+set(SPIRV_LIBRARIES "-lSPIRV-Tools-link -lSPIRV-Tools-opt -lSPIRV-Tools")
 set(SPIRV_SHARED_LIBRARIES "-lSPIRV-Tools-shared")
 
 # Build pkg-config file


### PR DESCRIPTION
CMakeLists.txt hardcodes the pkg-config libraries as

    Libs: -L${libdir} -lSPIRV-Tools-opt -lSPIRV-Tools -lSPIRV-Tools-link

which is upside down.  libSPIRV-Tools-link needs symbols from
libSPIRV-Tools-opt and from the core library, as its NEEDED entries show
in the shared build:

    $ objdump -p /usr/lib/libSPIRV-Tools-link.so | grep NEEDED
      NEEDED               libSPIRV-Tools-opt.so
      NEEDED               libSPIRV-Tools.so

For shared libraries the order is irrelevant, but ld searches an archive
only at the place where it is named, so a static build leaves every
symbol that -link alone pulls in undefined.  Name the archives the other
way round.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>