### PR TITLE
spirv-opt: Harden FixStorageClass and constant folding against ID overflow

### DIFF
--- a/source/opt/const_folding_rules.cpp
+++ b/source/opt/const_folding_rules.cpp
@@ -192,6 +192,9 @@ ConstantFoldingRule FoldInsertWithConstants() {
       const analysis::Constant* constant =
           (i == final_operand) ? object : components[i];
       Instruction* member_inst = const_mgr->GetDefiningInstruction(constant);
+      if (!member_inst) {
+        return nullptr;
+      }
       ids.push_back(member_inst->result_id());
     }
     const analysis::Constant* new_constant = const_mgr->GetConstant(type, ids);
@@ -271,10 +274,16 @@ ConstantFoldingRule FoldVectorShuffleWithConstants() {
       } else if (index < c1_components.size()) {
         Instruction* member_inst =
             const_mgr->GetDefiningInstruction(c1_components[index]);
+        if (!member_inst) {
+          return nullptr;
+        }
         ids.push_back(member_inst->result_id());
       } else {
         Instruction* member_inst = const_mgr->GetDefiningInstruction(
             c2_components[index - c1_components.size()]);
+        if (!member_inst) {
+          return nullptr;
+        }
         ids.push_back(member_inst->result_id());
       }
     }
@@ -340,7 +349,11 @@ ConstantFoldingRule FoldVectorTimesScalar() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* inst_elem = const_mgr->GetDefiningInstruction(new_elem);
+        if (!inst_elem) {
+          return nullptr;
+        }
+        ids.push_back(inst_elem->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     } else if (float_type->width() == 64) {
@@ -351,7 +364,11 @@ ConstantFoldingRule FoldVectorTimesScalar() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* inst_elem = const_mgr->GetDefiningInstruction(new_elem);
+        if (!inst_elem) {
+          return nullptr;
+        }
+        ids.push_back(inst_elem->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     }
@@ -382,9 +399,12 @@ const analysis::Constant* TransposeMatrix(const analysis::Constant* matrix,
     const auto& column_components = column->AsVectorConstant()->GetComponents();
 
     for (uint32_t row = 0; row < number_of_rows; ++row) {
-      result_elements[row].push_back(
-          const_mgr->GetDefiningInstruction(column_components[row])
-              ->result_id());
+      Instruction* def =
+          const_mgr->GetDefiningInstruction(column_components[row]);
+      if (!def) {
+        return nullptr;
+      }
+      result_elements[row].push_back(def->result_id());
     }
   }
 
@@ -393,8 +413,11 @@ const analysis::Constant* TransposeMatrix(const analysis::Constant* matrix,
   for (uint32_t col = 0; col < number_of_rows; ++col) {
     auto* element = const_mgr->GetConstant(result_type->element_type(),
                                            result_elements[col]);
-    result_columns[col] =
-        const_mgr->GetDefiningInstruction(element)->result_id();
+    Instruction* def = const_mgr->GetDefiningInstruction(element);
+    if (!def) {
+      return nullptr;
+    }
+    result_columns[col] = def->result_id();
   }
 
   // Create the matrix constant from the row ids, and return it.
@@ -465,7 +488,11 @@ ConstantFoldingRule FoldVectorTimesMatrix() {
       for (uint32_t i = 0; i < resultVectorSize; ++i) {
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     }
@@ -492,7 +519,11 @@ ConstantFoldingRule FoldVectorTimesMatrix() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     } else if (float_type->width() == 64) {
@@ -511,7 +542,11 @@ ConstantFoldingRule FoldVectorTimesMatrix() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     }
@@ -561,7 +596,11 @@ ConstantFoldingRule FoldMatrixTimesVector() {
       for (uint32_t i = 0; i < resultVectorSize; ++i) {
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     }
@@ -589,7 +628,11 @@ ConstantFoldingRule FoldMatrixTimesVector() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     } else if (float_type->width() == 64) {
@@ -609,7 +652,11 @@ ConstantFoldingRule FoldMatrixTimesVector() {
         std::vector<uint32_t> words = result.GetWords();
         const analysis::Constant* new_elem =
             const_mgr->GetConstant(float_type, words);
-        ids.push_back(const_mgr->GetDefiningInstruction(new_elem)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(new_elem);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     }
@@ -708,7 +755,11 @@ ConstantFoldingRule FoldUnaryOp(UnaryScalarFoldingRule scalar_rule) {
       // Build the constant object and return it.
       std::vector<uint32_t> ids;
       for (const analysis::Constant* member : results_components) {
-        ids.push_back(const_mgr->GetDefiningInstruction(member)->result_id());
+        Instruction* def = const_mgr->GetDefiningInstruction(member);
+        if (!def) {
+          return nullptr;
+        }
+        ids.push_back(def->result_id());
       }
       return const_mgr->GetConstant(vector_type, ids);
     } else {
@@ -769,7 +820,11 @@ ConstantFoldingRule FoldBinaryOp(BinaryScalarFoldingRule scalar_rule) {
     // Build the constant object and return it.
     std::vector<uint32_t> ids;
     for (const analysis::Constant* member : results_components) {
-      ids.push_back(const_mgr->GetDefiningInstruction(member)->result_id());
+      Instruction* def = const_mgr->GetDefiningInstruction(member);
+      if (!def) {
+        return nullptr;
+      }
+      ids.push_back(def->result_id());
     }
     return const_mgr->GetConstant(vector_type, ids);
   };

--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -173,6 +173,9 @@ std::vector<const Constant*> ConstantManager::GetOperandConstants(
 
 uint32_t ConstantManager::FindDeclaredConstant(const Constant* c,
                                                uint32_t type_id) const {
+  if (c == nullptr) {
+    return 0;
+  }
   c = FindConstant(c);
   if (c == nullptr) {
     return 0;
@@ -204,7 +207,9 @@ std::vector<const Constant*> ConstantManager::GetConstantsFromIds(
 
 Instruction* ConstantManager::BuildInstructionAndAddToModule(
     const Constant* new_const, Module::inst_iterator* pos, uint32_t type_id) {
-  // TODO(1841): Handle id overflow.
+  if (new_const == nullptr) {
+    return nullptr;
+  }
   uint32_t new_id = context()->TakeNextId();
   if (new_id == 0) {
     return nullptr;
@@ -225,6 +230,9 @@ Instruction* ConstantManager::BuildInstructionAndAddToModule(
 
 Instruction* ConstantManager::GetDefiningInstruction(
     const Constant* c, uint32_t type_id, Module::inst_iterator* pos) {
+  if (c == nullptr) {
+    return nullptr;
+  }
   uint32_t decl_id = FindDeclaredConstant(c, type_id);
   if (decl_id == 0) {
     auto iter = context()->types_values_end();
@@ -614,8 +622,14 @@ const Constant* ConstantManager::GetNumericVectorConstantWithWords(
                                      first_word + words_per_element);
     const analysis::Constant* element_constant =
         GetConstant(element_type, const_data);
-    auto element_id = GetDefiningInstruction(element_constant)->result_id();
-    element_ids.push_back(element_id);
+    if (!element_constant) {
+      return nullptr;
+    }
+    Instruction* element_inst = GetDefiningInstruction(element_constant);
+    if (!element_inst) {
+      return nullptr;
+    }
+    element_ids.push_back(element_inst->result_id());
   }
 
   return GetConstant(type, element_ids);
@@ -652,7 +666,14 @@ const Constant* ConstantManager::GetDoubleConst(double val) {
 uint32_t ConstantManager::GetSIntConstId(int32_t val) {
   Type* sint_type = context()->get_type_mgr()->GetSIntType();
   const Constant* c = GetConstant(sint_type, {static_cast<uint32_t>(val)});
-  return GetDefiningInstruction(c)->result_id();
+  if (!c) {
+    return 0;
+  }
+  Instruction* inst = GetDefiningInstruction(c);
+  if (!inst) {
+    return 0;
+  }
+  return inst->result_id();
 }
 
 const Constant* ConstantManager::GetIntConst(uint64_t val, int32_t bitWidth,

--- a/source/opt/fix_storage_class.cpp
+++ b/source/opt/fix_storage_class.cpp
@@ -48,6 +48,9 @@ Pass::Status FixStorageClass::Process() {
       }
     }
   });
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
@@ -58,58 +61,59 @@ bool FixStorageClass::PropagateStorageClass(Instruction* inst,
     return false;
   }
 
-  if (IsPointerToStorageClass(inst, storage_class)) {
-    if (inst->opcode() == spv::Op::OpPhi) {
-      if (!seen->insert(inst->result_id()).second) {
-        return false;
-      }
+  if (inst->opcode() == spv::Op::OpPhi) {
+    if (!seen->insert(inst->result_id()).second) {
+      return false;
     }
+  }
 
-    bool modified = false;
+  bool modified = false;
+  if (IsPointerToStorageClass(inst, storage_class)) {
     std::vector<Instruction*> uses;
     get_def_use_mgr()->ForEachUser(
         inst, [&uses](Instruction* use) { uses.push_back(use); });
     for (Instruction* use : uses) {
       modified |= PropagateStorageClass(use, storage_class, seen);
     }
-
-    if (inst->opcode() == spv::Op::OpPhi) {
-      seen->erase(inst->result_id());
+  } else {
+    switch (inst->opcode()) {
+      case spv::Op::OpAccessChain:
+      case spv::Op::OpPtrAccessChain:
+      case spv::Op::OpInBoundsAccessChain:
+      case spv::Op::OpCopyObject:
+      case spv::Op::OpPhi:
+      case spv::Op::OpSelect:
+        FixInstructionStorageClass(inst, storage_class, seen);
+        modified = true;
+        break;
+      case spv::Op::OpFunctionCall:
+        // We cannot be sure of the actual connection between the storage class
+        // of the parameter and the storage class of the result, so we should
+        // not do anything.  If the result type needs to be fixed, the function
+        // call should be inlined.
+        break;
+      case spv::Op::OpImageTexelPointer:
+      case spv::Op::OpLoad:
+      case spv::Op::OpStore:
+      case spv::Op::OpCopyMemory:
+      case spv::Op::OpCopyMemorySized:
+      case spv::Op::OpVariable:
+      case spv::Op::OpBitcast:
+      case spv::Op::OpAllocateNodePayloadsAMDX:
+        // Nothing to change for these opcode.  The result type is the same
+        // regardless of the storage class of the operand.
+        break;
+      default:
+        assert(false &&
+               "Not expecting instruction to have a pointer result type.");
+        break;
     }
-    return modified;
   }
 
-  switch (inst->opcode()) {
-    case spv::Op::OpAccessChain:
-    case spv::Op::OpPtrAccessChain:
-    case spv::Op::OpInBoundsAccessChain:
-    case spv::Op::OpCopyObject:
-    case spv::Op::OpPhi:
-    case spv::Op::OpSelect:
-      FixInstructionStorageClass(inst, storage_class, seen);
-      return true;
-    case spv::Op::OpFunctionCall:
-      // We cannot be sure of the actual connection between the storage class
-      // of the parameter and the storage class of the result, so we should not
-      // do anything.  If the result type needs to be fixed, the function call
-      // should be inlined.
-      return false;
-    case spv::Op::OpImageTexelPointer:
-    case spv::Op::OpLoad:
-    case spv::Op::OpStore:
-    case spv::Op::OpCopyMemory:
-    case spv::Op::OpCopyMemorySized:
-    case spv::Op::OpVariable:
-    case spv::Op::OpBitcast:
-    case spv::Op::OpAllocateNodePayloadsAMDX:
-      // Nothing to change for these opcode.  The result type is the same
-      // regardless of the storage class of the operand.
-      return false;
-    default:
-      assert(false &&
-             "Not expecting instruction to have a pointer result type.");
-      return false;
+  if (inst->opcode() == spv::Op::OpPhi) {
+    seen->erase(inst->result_id());
   }
+  return modified;
 }
 
 void FixStorageClass::FixInstructionStorageClass(
@@ -136,6 +140,9 @@ void FixStorageClass::ChangeResultStorageClass(
   uint32_t pointee_type_id = result_type_inst->GetSingleWordInOperand(1);
   uint32_t new_result_type_id =
       type_mgr->FindPointerToType(pointee_type_id, storage_class);
+  if (new_result_type_id == 0) {
+    return;
+  }
   inst->SetResultType(new_result_type_id);
   context()->UpdateDefUse(inst);
 }
@@ -168,7 +175,7 @@ bool FixStorageClass::IsPointerToStorageClass(Instruction* inst,
 
 bool FixStorageClass::ChangeResultType(Instruction* inst,
                                        uint32_t new_type_id) {
-  if (inst->type_id() == new_type_id) {
+  if (new_type_id == 0 || inst->type_id() == new_type_id) {
     return false;
   }
 

--- a/source/opt/fold.cpp
+++ b/source/opt/fold.cpp
@@ -631,6 +631,9 @@ Instruction* InstructionFolder::FoldInstructionToConstant(
     if (successful) {
       const analysis::Constant* result_const =
           const_mgr->GetConstant(const_mgr->GetType(inst), {result_val});
+      if (!result_const) {
+        return nullptr;
+      }
       Instruction* folded_inst =
           const_mgr->GetDefiningInstruction(result_const, inst->type_id());
       return folded_inst;
@@ -651,6 +654,9 @@ Instruction* InstructionFolder::FoldInstructionToConstant(
       const analysis::Constant* result_const =
           const_mgr->GetNumericVectorConstantWithWords(
               const_mgr->GetType(inst)->AsVector(), result_val);
+      if (!result_const) {
+        return nullptr;
+      }
       Instruction* folded_inst =
           const_mgr->GetDefiningInstruction(result_const, inst->type_id());
       return folded_inst;


### PR DESCRIPTION
- In FixStorageClass, check for zero/failure when getting pointer types
  and prevent infinite loop in PropagateStorageClass when type modification fails.
  Propagates Status::Failure on ID overflow.
- In ConstantManager, safely handle null Constant pointers.
- In const_folding_rules and fold, check for nullptr when retrieving
  defining instructions or creating folded constants on ID overflow.
