### PR TITLE
spirv-opt: Harden passes against ID overflow

### DIFF
--- a/source/opt/debug_info_manager.cpp
+++ b/source/opt/debug_info_manager.cpp
@@ -303,7 +303,9 @@ uint32_t DebugInfoManager::BuildDebugInlinedAtChain(
   do {
     Instruction* new_inlined_at_in_chain = CloneDebugInlinedAt(
         chain_iter_id, /* insert_before */ last_inlined_at_in_chain);
-    assert(new_inlined_at_in_chain != nullptr);
+    if (new_inlined_at_in_chain == nullptr) {
+      return kNoInlinedAt;
+    }
 
     // Set DebugInlinedAt of the new scope as the head of the chain.
     if (chain_head_id == kNoInlinedAt)
@@ -376,6 +378,9 @@ Instruction* DebugInfoManager::GetDebugOperationWithDeref() {
 Instruction* DebugInfoManager::DerefDebugExpression(Instruction* dbg_expr) {
   assert(dbg_expr->GetCommonDebugOpcode() == CommonDebugInfoDebugExpression);
   std::unique_ptr<Instruction> deref_expr(dbg_expr->Clone(context()));
+  if (!deref_expr) {
+    return nullptr;
+  }
   uint32_t result_id = context()->TakeNextId();
   if (result_id == 0) return nullptr;
   deref_expr->SetResultId(result_id);
@@ -457,6 +462,9 @@ Instruction* DebugInfoManager::CloneDebugInlinedAt(uint32_t clone_inlined_at_id,
   uint32_t result_id = context()->TakeNextId();
   if (result_id == 0) return nullptr;
   std::unique_ptr<Instruction> new_inlined_at(inlined_at->Clone(context()));
+  if (!new_inlined_at) {
+    return nullptr;
+  }
   new_inlined_at->SetResultId(result_id);
   RegisterDbgInst(new_inlined_at.get());
   if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse))
@@ -604,6 +612,9 @@ Instruction* DebugInfoManager::AddDebugValueForDecl(Instruction* dbg_decl,
   if (result_id == 0) return nullptr;
 
   std::unique_ptr<Instruction> dbg_val(dbg_decl->Clone(context()));
+  if (!dbg_val) {
+    return nullptr;
+  }
   dbg_val->SetResultId(result_id);
   dbg_val->SetInOperand(kExtInstInstructionInIdx, {CommonDebugInfoDebugValue});
   dbg_val->SetOperand(kDebugDeclareOperandVariableIndex, {value_id});

--- a/source/opt/graphics_robust_access_pass.cpp
+++ b/source/opt/graphics_robust_access_pass.cpp
@@ -862,9 +862,13 @@ Instruction* GraphicsRobustAccessPass::MakeRuntimeArrayLengthInst(
   }
   analysis::Integer uint_type_for_query(32, false);
   auto* uint_type = type_mgr->GetRegisteredType(&uint_type_for_query);
+  uint32_t uint_type_id = type_mgr->GetTypeInstruction(uint_type);
+  if (uint_type_id == 0) {
+    Fail();
+    return nullptr;
+  }
   auto* array_len = InsertInst(
-      access_chain, spv::Op::OpArrayLength, type_mgr->GetId(uint_type),
-      array_len_id,
+      access_chain, spv::Op::OpArrayLength, uint_type_id, array_len_id,
       {{SPV_OPERAND_TYPE_ID, {pointer_to_containing_struct->result_id()}},
        {SPV_OPERAND_TYPE_LITERAL_INTEGER, {member_index_of_runtime_array}}});
   return array_len;

--- a/source/opt/if_conversion.cpp
+++ b/source/opt/if_conversion.cpp
@@ -124,12 +124,17 @@ Pass::Status IfConversion::Process() {
             context()->get_type_mgr()->GetType(true_value->type_id());
         if (analysis::Vector* vec_data_ty = data_ty->AsVector()) {
           condition = SplatCondition(vec_data_ty, condition, &builder);
+          if (condition == 0) {
+            return;
+          }
         }
 
-        // TODO(1841): Handle id overflow.
         Instruction* select = builder.AddSelect(phi->type_id(), condition,
                                                 true_value->result_id(),
                                                 false_value->result_id());
+        if (!select) {
+          return;
+        }
         context()->get_def_use_mgr()->AnalyzeInstDefUse(select);
         select->UpdateDebugInfoFrom(phi);
         context()->ReplaceAllUsesWith(phi->result_id(), select->result_id());
@@ -145,6 +150,9 @@ Pass::Status IfConversion::Process() {
     context()->KillInst(inst);
   }
 
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
@@ -205,9 +213,15 @@ uint32_t IfConversion::SplatCondition(analysis::Vector* vec_data_ty,
   analysis::Vector bool_vec_ty(&bool_ty, vec_data_ty->element_count());
   uint32_t bool_vec_id =
       context()->get_type_mgr()->GetTypeInstruction(&bool_vec_ty);
+  if (bool_vec_id == 0) {
+    return 0;
+  }
   std::vector<uint32_t> ids(vec_data_ty->element_count(), cond);
-  // TODO(1841): Handle id overflow.
-  return builder->AddCompositeConstruct(bool_vec_id, ids)->result_id();
+  Instruction* construct = builder->AddCompositeConstruct(bool_vec_id, ids);
+  if (!construct) {
+    return 0;
+  }
+  return construct->result_id();
 }
 
 bool IfConversion::CheckType(uint32_t id) {

--- a/source/opt/inline_pass.cpp
+++ b/source/opt/inline_pass.cpp
@@ -168,6 +168,9 @@ bool InlinePass::CloneAndMapLocals(
     }
 
     std::unique_ptr<Instruction> var_inst(callee_var_itr->Clone(context()));
+    if (!var_inst) {
+      return false;
+    }
     uint32_t newId = context()->TakeNextId();
     if (newId == 0) {
       return false;
@@ -250,6 +253,9 @@ bool InlinePass::CloneSameBlockOps(
         // Clone pre-call same-block ops, map result id.
         const Instruction* inInst = mapItr2->second;
         std::unique_ptr<Instruction> sb_inst(inInst->Clone(context()));
+        if (!sb_inst) {
+          return false;
+        }
         if (!CloneSameBlockOps(&sb_inst, postCallSB, preCallSB, block_ptr)) {
           return false;
         }
@@ -353,6 +359,9 @@ bool InlinePass::InlineSingleInstruction(
 
   // Copy callee instruction and remap all input Ids.
   std::unique_ptr<Instruction> cp_inst(inst->Clone(context()));
+  if (!cp_inst) {
+    return false;
+  }
   cp_inst->ForEachInId([&callee2caller](uint32_t* iid) {
     const auto mapItr = callee2caller.find(*iid);
     if (mapItr != callee2caller.end()) {
@@ -636,25 +645,37 @@ bool InlinePass::GenInlineCode(
     }
   }
 
-  calleeFn->WhileEachInst([&callee2caller, this](const Instruction* cpi) {
-    // Create set of callee result ids. Used to detect forward references
-    const uint32_t rid = cpi->result_id();
-    if (rid != 0 && callee2caller.find(rid) == callee2caller.end()) {
-      const uint32_t nid = context()->TakeNextId();
-      if (nid == 0) return false;
-      callee2caller[rid] = nid;
-    }
-    return true;
-  });
+  if (!calleeFn->WhileEachInst([&callee2caller, this](const Instruction* cpi) {
+        // Create set of callee result ids. Used to detect forward references
+        const uint32_t rid = cpi->result_id();
+        if (rid != 0 && callee2caller.find(rid) == callee2caller.end()) {
+          const uint32_t nid = context()->TakeNextId();
+          if (nid == 0) return false;
+          callee2caller[rid] = nid;
+        }
+        return true;
+      })) {
+    return false;
+  }
 
   // Inline DebugClare instructions in the callee's header.
+  bool header_dbg_failed = false;
   calleeFn->ForEachDebugInstructionsInHeader(
-      [&new_blk_ptr, &callee2caller, &inlined_at_ctx, this](Instruction* inst) {
-        InlineSingleInstruction(
-            callee2caller, new_blk_ptr.get(), inst,
-            context()->get_debug_info_mgr()->BuildDebugInlinedAtChain(
-                inst->GetDebugScope().GetInlinedAt(), &inlined_at_ctx));
+      [&new_blk_ptr, &callee2caller, &inlined_at_ctx, &header_dbg_failed,
+       this](Instruction* inst) {
+        if (header_dbg_failed) {
+          return;
+        }
+        if (!InlineSingleInstruction(
+                callee2caller, new_blk_ptr.get(), inst,
+                context()->get_debug_info_mgr()->BuildDebugInlinedAtChain(
+                    inst->GetDebugScope().GetInlinedAt(), &inlined_at_ctx))) {
+          header_dbg_failed = true;
+        }
       });
+  if (header_dbg_failed) {
+    return false;
+  }
 
   // Inline the entry block of the callee function.
   if (!InlineEntryBlock(callee2caller, &new_blk_ptr, calleeFn->begin(),

--- a/source/opt/instruction.cpp
+++ b/source/opt/instruction.cpp
@@ -171,6 +171,7 @@ Instruction* Instruction::Clone(IRContext* c) const {
     if (i.IsDebugLineInst()) {
       uint32_t new_id = c->TakeNextId();
       if (new_id == 0) {
+        delete clone;
         return nullptr;
       }
       i.SetResultId(new_id);

--- a/source/opt/interface_var_sroa.cpp
+++ b/source/opt/interface_var_sroa.cpp
@@ -289,8 +289,11 @@ Pass::Status InterfaceVariableScalarReplacement::ReplaceInterfaceVarWith(
       if (status == Status::Failure) {
         return Status::Failure;
       }
-      AddComponentsToCompositesForLoads(loads_to_component_values,
-                                        &loads_to_composites, 0);
+      if (AddComponentsToCompositesForLoads(loads_to_component_values,
+                                            &loads_to_composites,
+                                            0) == Status::Failure) {
+        return Status::Failure;
+      }
     }
   } else {
     Status status = ReplaceComponentsOfInterfaceVarWith(
@@ -383,12 +386,18 @@ InterfaceVariableScalarReplacement::ReplaceMultipleComponentsOfInterfaceVarWith(
 
     uint32_t depth_to_component =
         static_cast<uint32_t>(interface_var_component_indices.size());
-    AddComponentsToCompositesForLoads(
-        loads_for_access_chain_to_component_values,
-        loads_for_access_chain_to_composites, depth_to_component);
+    if (AddComponentsToCompositesForLoads(
+            loads_for_access_chain_to_component_values,
+            loads_for_access_chain_to_composites,
+            depth_to_component) == Status::Failure) {
+      return Status::Failure;
+    }
     if (extra_array_index) ++depth_to_component;
-    AddComponentsToCompositesForLoads(loads_to_component_values,
-                                      loads_to_composites, depth_to_component);
+    if (AddComponentsToCompositesForLoads(
+            loads_to_component_values, loads_to_composites,
+            depth_to_component) == Status::Failure) {
+      return Status::Failure;
+    }
   }
   return Status::SuccessWithChange;
 }
@@ -746,6 +755,9 @@ void InterfaceVariableScalarReplacement::
     ptr = CreateAccessChainToVar(component_type_id, scalar_var,
                                  access_chain_indices, insert_before,
                                  &component_type_id);
+    if (ptr == nullptr) {
+      return;
+    }
   }
 
   StoreComponentOfValueTo(component_type_id, value_id, component_indices, ptr,
@@ -803,7 +815,8 @@ InterfaceVariableScalarReplacement::CreateCompositeConstructForComponentOfLoad(
   return composite_construct;
 }
 
-void InterfaceVariableScalarReplacement::AddComponentsToCompositesForLoads(
+Pass::Status
+InterfaceVariableScalarReplacement::AddComponentsToCompositesForLoads(
     const std::unordered_map<Instruction*, Instruction*>&
         loads_to_component_values,
     std::unordered_map<Instruction*, Instruction*>* loads_to_composites,
@@ -818,8 +831,7 @@ void InterfaceVariableScalarReplacement::AddComponentsToCompositesForLoads(
       composite_construct =
           CreateCompositeConstructForComponentOfLoad(load, depth_to_component);
       if (composite_construct == nullptr) {
-        assert(false && "Could not create composite construct");
-        return;
+        return Pass::Status::Failure;
       }
       loads_to_composites->insert({load, composite_construct});
     } else {
@@ -829,6 +841,7 @@ void InterfaceVariableScalarReplacement::AddComponentsToCompositesForLoads(
         {SPV_OPERAND_TYPE_ID, {component_value->result_id()}});
     def_use_mgr->AnalyzeInstDefUse(composite_construct);
   }
+  return Pass::Status::SuccessWithChange;
 }
 
 uint32_t InterfaceVariableScalarReplacement::GetArrayType(
@@ -921,8 +934,10 @@ InterfaceVariableScalarReplacement::CreateScalarInterfaceVarsForReplacement(
   if (extra_array_length != 0) {
     type_id = GetArrayType(type_id, extra_array_length);
   }
-  uint32_t ptr_type_id =
-      context()->get_type_mgr()->FindPointerToType(type_id, storage_class);
+  uint32_t ptr_type_id = GetPointerType(type_id, storage_class);
+  if (ptr_type_id == 0) {
+    return std::nullopt;
+  }
   uint32_t id = TakeNextId();
   if (id == 0) {
     return std::nullopt;
@@ -949,6 +964,12 @@ Pass::Status InterfaceVariableScalarReplacement::Process() {
   for (Instruction& entry_point : get_module()->entry_points()) {
     status =
         CombineStatus(status, ReplaceInterfaceVarsWithScalars(entry_point));
+    if (status == Status::Failure) {
+      break;
+    }
+  }
+  if (context()->id_overflow()) {
+    return Status::Failure;
   }
   return status;
 }

--- a/source/opt/interface_var_sroa.h
+++ b/source/opt/interface_var_sroa.h
@@ -315,7 +315,7 @@ class InterfaceVariableScalarReplacement : public Pass {
   // construct instructions using |loads_to_composites|. |depth_to_component| is
   // the number of recursive access steps to get the component from the
   // composite.
-  void AddComponentsToCompositesForLoads(
+  Pass::Status AddComponentsToCompositesForLoads(
       const std::unordered_map<Instruction*, Instruction*>&
           loads_to_component_values,
       std::unordered_map<Instruction*, Instruction*>* loads_to_composites,

--- a/source/opt/type_manager.cpp
+++ b/source/opt/type_manager.cpp
@@ -59,6 +59,9 @@ std::pair<Type*, std::unique_ptr<Pointer>> TypeManager::GetTypeAndPointerType(
 }
 
 uint32_t TypeManager::GetId(const Type* type) const {
+  if (type == nullptr) {
+    return 0;
+  }
   auto iter = type_to_id_.find(type);
   if (iter != type_to_id_.end()) {
     return (*iter).second;

--- a/test/opt/graphics_robust_access_test.cpp
+++ b/test/opt/graphics_robust_access_test.cpp
@@ -1703,4 +1703,48 @@ TEST_F(GraphicsRobustAccessTest, ReplaceIndexReportsChanged) {
 // TODO(dneto): Test OpImageTexelPointer with coordinate component index other
 // than 32 bits.
 
+TEST_F(GraphicsRobustAccessTest, ACRTArrayWithoutExistingUIntType) {
+  SetTargetEnv(SPV_ENV_VULKAN_1_0);
+  const std::string text = R"(
+               OpCapability Shader
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+               OpName %var "var"
+               OpName %ac "ac"
+               OpDecorate %rtarr ArrayStride 4
+               OpDecorate %ssbo_s BufferBlock
+               OpMemberDecorate %ssbo_s 0 Offset 0
+               OpDecorate %var DescriptorSet 0
+               OpDecorate %var Binding 0
+       %void = OpTypeVoid
+    %void_fn = OpTypeFunction %void
+      %float = OpTypeFloat 32
+      %rtarr = OpTypeRuntimeArray %float
+     %ssbo_s = OpTypeStruct %rtarr
+    %var_ptr = OpTypePointer Uniform %ssbo_s
+  %float_ptr = OpTypePointer Uniform %float
+        %var = OpVariable %var_ptr Uniform
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+
+; CHECK: %[[GLSLSTD450:\w+]] = OpExtInstImport "GLSL.std.450"
+; CHECK: %uint = OpTypeInt 32 0
+; CHECK: %[[arrlen:\w+]] = OpArrayLength %uint %var 0
+; CHECK: %[[max:\w+]] = OpISub %int %[[arrlen]] %int_1
+; CHECK: %[[smin:\w+]] = OpExtInst %int %[[GLSLSTD450]] UMin %[[max]] %[[intmax:\w+]]
+; CHECK: %[[clamp:\w+]] = OpExtInst %int %[[GLSLSTD450]] SClamp %int_0 %int_0 %[[smin]]
+; CHECK: %ac = OpAccessChain %_ptr_Uniform_float %var %int_0 %[[clamp]]
+
+       %main = OpFunction %void None %void_fn
+      %entry = OpLabel
+         %ac = OpAccessChain %float_ptr %var %int_0 %int_0
+               OpReturn
+               OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<GraphicsRobustAccessPass>(text, true);
+}
+
 }  // namespace


### PR DESCRIPTION
Harden GraphicsRobustAccessPass, IfConversion, Inliner, and
InterfaceVariableScalarReplacement against ID overflow.
