### PR TITLE
spirv-opt: Harden passes against ID overflow

### DIFF
--- a/source/opt/constants.cpp
+++ b/source/opt/constants.cpp
@@ -441,11 +441,17 @@ std::unique_ptr<Instruction> ConstantManager::CreateCompositeInstruction(
 
 const Constant* ConstantManager::GetConstant(
     const Type* type, const std::vector<uint32_t>& literal_words_or_ids) {
+  if (type == nullptr) {
+    return nullptr;
+  }
   auto cst = CreateConstant(type, literal_words_or_ids);
   return cst ? RegisterConstant(std::move(cst)) : nullptr;
 }
 
 const Constant* ConstantManager::GetNullCompositeConstant(const Type* type) {
+  if (type == nullptr) {
+    return nullptr;
+  }
   std::vector<uint32_t> literal_words_or_id;
 
   if (type->AsVector()) {

--- a/source/opt/legalize_multidim_array_pass.cpp
+++ b/source/opt/legalize_multidim_array_pass.cpp
@@ -46,6 +46,9 @@ Pass::Status LegalizeMultidimArrayPass::Process() {
     if (!RewriteAccessChains(var, old_ptr_type_id)) return Status::Failure;
   }
 
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return Status::SuccessWithChange;
 }
 
@@ -104,9 +107,15 @@ uint32_t LegalizeMultidimArrayPass::FlattenArrayType(Instruction* var) {
 
   const analysis::Constant* total_elements_const =
       constant_mgr->GetIntConst(total_elements, 32, false);
+  if (!total_elements_const) {
+    return 0;
+  }
 
   Instruction* total_elements_inst =
       constant_mgr->GetDefiningInstruction(total_elements_const);
+  if (!total_elements_inst) {
+    return 0;
+  }
   uint32_t total_elements_id = total_elements_inst->result_id();
 
   // Create new OpTypeArray.
@@ -116,12 +125,18 @@ uint32_t LegalizeMultidimArrayPass::FlattenArrayType(Instruction* var) {
       {analysis::Array::LengthInfo::kConstant, total_elements}};
   analysis::Array new_array_type(element_type, length_info);
   uint32_t new_array_type_id = type_mgr->GetTypeInstruction(&new_array_type);
+  if (new_array_type_id == 0) {
+    return 0;
+  }
 
   // Create new OpTypePointer.
   spv::StorageClass sc =
       static_cast<spv::StorageClass>(ptr_type_inst->GetSingleWordInOperand(0));
   analysis::Pointer new_ptr_type(type_mgr->GetType(new_array_type_id), sc);
   uint32_t new_ptr_type_id = type_mgr->GetTypeInstruction(&new_ptr_type);
+  if (new_ptr_type_id == 0) {
+    return 0;
+  }
 
   var->SetResultType(new_ptr_type_id);
   context()->UpdateDefUse(var);
@@ -186,6 +201,9 @@ bool LegalizeMultidimArrayPass::RewriteAccessChains(Instruction* var,
           Instruction* stride_inst =
               context()->get_constant_mgr()->GetDefiningInstruction(
                   stride_const);
+          if (stride_inst == nullptr) {
+            return false;
+          }
 
           Instruction* mul_inst = builder.AddBinaryOp(
               uint_type_id, spv::Op::OpIMul, idx_id, stride_inst->result_id());

--- a/source/opt/reduce_load_size.cpp
+++ b/source/opt/reduce_load_size.cpp
@@ -43,6 +43,9 @@ Pass::Status ReduceLoadSize::Process() {
     });
   }
 
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return modified ? Status::SuccessWithChange : Status::SuccessWithoutChange;
 }
 
@@ -92,25 +95,42 @@ bool ReduceLoadSize::ReplaceExtract(Instruction* inst) {
 
   uint32_t pointer_to_result_type_id =
       type_mgr->FindPointerToType(inst->type_id(), storage_class);
-  assert(pointer_to_result_type_id != 0 &&
-         "We did not find the pointer type that we need.");
+  if (pointer_to_result_type_id == 0) {
+    return false;
+  }
 
   analysis::Integer int_type(32, false);
   const analysis::Type* uint32_type = type_mgr->GetRegisteredType(&int_type);
+  if (uint32_type == nullptr) {
+    return false;
+  }
   std::vector<uint32_t> ids;
   for (uint32_t i = 1; i < inst->NumInOperands(); ++i) {
     uint32_t index = inst->GetSingleWordInOperand(i);
     const analysis::Constant* index_const =
         const_mgr->GetConstant(uint32_type, {index});
-    ids.push_back(const_mgr->GetDefiningInstruction(index_const)->result_id());
+    if (index_const == nullptr) {
+      return false;
+    }
+    Instruction* index_inst = const_mgr->GetDefiningInstruction(index_const);
+    if (index_inst == nullptr) {
+      return false;
+    }
+    ids.push_back(index_inst->result_id());
   }
 
   Instruction* new_access_chain = ir_builder.AddAccessChain(
       pointer_to_result_type_id,
       composite_inst->GetSingleWordInOperand(kLoadPointerInIdx), ids);
-  // TODO(1841): Handle id overflow.
+  if (new_access_chain == nullptr) {
+    return false;
+  }
+
   Instruction* new_load =
       ir_builder.AddLoad(inst->type_id(), new_access_chain->result_id());
+  if (new_load == nullptr) {
+    return false;
+  }
 
   context()->ReplaceAllUsesWith(inst->result_id(), new_load->result_id());
   context()->KillInst(inst);

--- a/source/opt/replace_desc_array_access_using_var_index.cpp
+++ b/source/opt/replace_desc_array_access_using_var_index.cpp
@@ -46,6 +46,9 @@ Pass::Status ReplaceDescArrayAccessUsingVarIndex::Process() {
       if (s == Status::SuccessWithChange) status = Status::SuccessWithChange;
     }
   }
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return status;
 }
 
@@ -234,9 +237,14 @@ bool ReplaceDescArrayAccessUsingVarIndex::CloneInstsToBlock(
   for (auto* inst_to_be_cloned : insts_to_be_cloned) {
     if (inst_to_be_cloned == inst_to_skip_cloning) continue;
     std::unique_ptr<Instruction> clone(inst_to_be_cloned->Clone(context()));
+    if (!clone) {
+      return false;
+    }
     if (inst_to_be_cloned->HasResultId()) {
       uint32_t new_id = context()->TakeNextId();
-      if (new_id == 0) return false;
+      if (new_id == 0) {
+        return false;
+      }
       clone->SetResultId(new_id);
       (*old_ids_to_new_ids)[inst_to_be_cloned->result_id()] = new_id;
     }
@@ -360,10 +368,15 @@ bool ReplaceDescArrayAccessUsingVarIndex::AddConstElementAccessToCaseBlock(
     uint32_t const_element_idx,
     std::unordered_map<uint32_t, uint32_t>* old_ids_to_new_ids) const {
   std::unique_ptr<Instruction> access_clone(access_chain->Clone(context()));
+  if (!access_clone) {
+    return false;
+  }
   UseConstIndexForAccessChain(access_clone.get(), const_element_idx);
 
   uint32_t new_access_id = context()->TakeNextId();
-  if (new_access_id == 0) return false;
+  if (new_access_id == 0) {
+    return false;
+  }
   (*old_ids_to_new_ids)[access_clone->result_id()] = new_access_id;
   access_clone->SetResultId(new_access_id);
   get_def_use_mgr()->AnalyzeInstDefUse(access_clone.get());
@@ -391,6 +404,9 @@ BasicBlock* ReplaceDescArrayAccessUsingVarIndex::CreateDefaultBlock(
   // Create null value for OpPhi
   Instruction* inst = context()->get_def_use_mgr()->GetDef((*phi_operands)[0]);
   auto* null_const_inst = GetConstNull(inst->type_id());
+  if (!null_const_inst) {
+    return nullptr;
+  }
   phi_operands->push_back(null_const_inst->result_id());
   return default_block;
 }
@@ -399,7 +415,13 @@ Instruction* ReplaceDescArrayAccessUsingVarIndex::GetConstNull(
     uint32_t type_id) const {
   assert(type_id != 0 && "Result type is expected");
   auto* type = context()->get_type_mgr()->GetType(type_id);
+  if (!type) {
+    return nullptr;
+  }
   auto* null_const = context()->get_constant_mgr()->GetConstant(type, {});
+  if (!null_const) {
+    return nullptr;
+  }
   return context()->get_constant_mgr()->GetDefiningInstruction(null_const);
 }
 

--- a/source/opt/replace_invalid_opc.cpp
+++ b/source/opt/replace_invalid_opc.cpp
@@ -43,6 +43,9 @@ Pass::Status ReplaceInvalidOpcodePass::Process() {
   for (Function& func : *get_module()) {
     modified |= RewriteFunction(&func, execution_model);
   }
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
 }
 
@@ -166,6 +169,9 @@ void ReplaceInvalidOpcodePass::ReplaceInstruction(Instruction* inst,
                                                   uint32_t column_number) {
   if (inst->result_id() != 0) {
     uint32_t const_id = GetSpecialConstant(inst->type_id());
+    if (const_id == 0) {
+      return;
+    }
     context()->KillNamesAndDecorates(inst);
     context()->ReplaceAllUsesWith(inst->result_id(), const_id);
   }
@@ -189,6 +195,9 @@ uint32_t ReplaceInvalidOpcodePass::GetSpecialConstant(uint32_t type_id) {
   if (type->opcode() == spv::Op::OpTypeVector) {
     uint32_t component_const =
         GetSpecialConstant(type->GetSingleWordInOperand(0));
+    if (component_const == 0) {
+      return 0;
+    }
     std::vector<uint32_t> ids;
     for (uint32_t i = 0; i < type->GetSingleWordInOperand(1); ++i) {
       ids.push_back(component_const);
@@ -204,8 +213,14 @@ uint32_t ReplaceInvalidOpcodePass::GetSpecialConstant(uint32_t type_id) {
     special_const =
         const_mgr->GetConstant(type_mgr->GetType(type_id), literal_words);
   }
-  assert(special_const != nullptr);
-  return const_mgr->GetDefiningInstruction(special_const)->result_id();
+  if (special_const == nullptr) {
+    return 0;
+  }
+  Instruction* const_inst = const_mgr->GetDefiningInstruction(special_const);
+  if (const_inst == nullptr) {
+    return 0;
+  }
+  return const_inst->result_id();
 }
 
 std::string ReplaceInvalidOpcodePass::BuildWarningMessage(spv::Op opcode) {

--- a/source/opt/scalar_replacement_pass.cpp
+++ b/source/opt/scalar_replacement_pass.cpp
@@ -48,6 +48,9 @@ Pass::Status ScalarReplacementPass::Process() {
       status = functionStatus;
   }
 
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return status;
 }
 
@@ -175,6 +178,9 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
       dbg_decl->GetSingleWordOperand(kDebugValueOperandExpressionIndex));
   auto* deref_expr =
       context()->get_debug_info_mgr()->DerefDebugExpression(dbg_expr);
+  if (deref_expr == nullptr) {
+    return false;
+  }
 
   // Add DebugValue instruction with Indexes operand and Deref operation.
   int32_t idx = 0;
@@ -189,9 +195,11 @@ bool ScalarReplacementPass::ReplaceWholeDebugDeclare(
             /*insert_before=*/insert_before, /*line=*/dbg_decl);
 
     if (added_dbg_value == nullptr) return false;
-    added_dbg_value->AddOperand(
-        {SPV_OPERAND_TYPE_ID,
-         {context()->get_constant_mgr()->GetSIntConstId(idx)}});
+    uint32_t idx_id = context()->get_constant_mgr()->GetSIntConstId(idx);
+    if (idx_id == 0) {
+      return false;
+    }
+    added_dbg_value->AddOperand({SPV_OPERAND_TYPE_ID, {idx_id}});
     added_dbg_value->SetOperand(kDebugValueOperandExpressionIndex,
                                 {deref_expr->result_id()});
     if (context()->AreAnalysesValid(IRContext::Analysis::kAnalysisDefUse)) {
@@ -209,15 +217,22 @@ bool ScalarReplacementPass::ReplaceWholeDebugValue(
   for (auto var : replacements) {
     // Clone the DebugValue.
     std::unique_ptr<Instruction> new_dbg_value(dbg_value->Clone(context()));
+    if (!new_dbg_value) {
+      return false;
+    }
     uint32_t new_id = TakeNextId();
-    if (new_id == 0) return false;
+    if (new_id == 0) {
+      return false;
+    }
     new_dbg_value->SetResultId(new_id);
     // Update 'Value' operand to the |replacements|.
     new_dbg_value->SetOperand(kDebugValueOperandValueIndex, {var->result_id()});
     // Append 'Indexes' operand.
-    new_dbg_value->AddOperand(
-        {SPV_OPERAND_TYPE_ID,
-         {context()->get_constant_mgr()->GetSIntConstId(idx)}});
+    uint32_t idx_id = context()->get_constant_mgr()->GetSIntConstId(idx);
+    if (idx_id == 0) {
+      return false;
+    }
+    new_dbg_value->AddOperand({SPV_OPERAND_TYPE_ID, {idx_id}});
     // Insert the new DebugValue to the basic block.
     auto* added_instr = dbg_value->InsertBefore(std::move(new_dbg_value));
     get_def_use_mgr()->AnalyzeInstDefUse(added_instr);

--- a/source/opt/split_combined_image_sampler_pass.cpp
+++ b/source/opt/split_combined_image_sampler_pass.cpp
@@ -73,6 +73,9 @@ Pass::Status SplitCombinedImageSamplerPass::Process() {
   def_use_mgr_ = nullptr;
   type_mgr_ = nullptr;
 
+  if (context()->id_overflow()) {
+    return Pass::Status::Failure;
+  }
   return Ok();
 }
 
@@ -505,6 +508,9 @@ spv_result_t SplitCombinedImageSamplerPass::RemapUses(
           auto* sampled_image =
               builder.AddSampledImage(used_type_id, use.image_part->result_id(),
                                       use.sampler_part->result_id());
+          if (!sampled_image) {
+            return SPV_ERROR_INTERNAL;
+          }
           use.user->SetOperand(use.index, {sampled_image->result_id()});
           def_use_mgr_->AnalyzeInstUse(use.user);
           break;
@@ -551,6 +557,9 @@ spv_result_t SplitCombinedImageSamplerPass::RemapFunctions() {
         // Replace this type.
         analysis::Function new_f_ty(f_ty->return_type(), new_params);
         const uint32_t new_f_ty_id = type_mgr_->GetTypeInstruction(&new_f_ty);
+        if (new_f_ty_id == 0) {
+          return SPV_ERROR_INTERNAL;
+        }
         std::unordered_set<Instruction*> users;
         def_use_mgr_->ForEachUse(
             &inst,

--- a/source/opt/ssa_rewrite_pass.cpp
+++ b/source/opt/ssa_rewrite_pass.cpp
@@ -491,6 +491,10 @@ uint32_t SSARewriter::GetPhiArgument(const PhiCandidate* phi_candidate,
     arg_id = phi_user->copy_of();
   }
 
+  if (pass_->context()->id_overflow()) {
+    return 0;
+  }
+
   assert(false &&
          "No Phi candidates in the copy-of chain are ready to be generated");
 
@@ -669,15 +673,23 @@ Pass::Status SSARewriter::RewriteFunctionIntoSSA(Function* fp) {
         return true;
       });
 
-  if (!succeeded) {
+  if (!succeeded || pass_->context()->id_overflow()) {
     return Pass::Status::Failure;
   }
 
   // Remove trivial Phis and add arguments to incomplete Phis.
   FinalizePhiCandidates();
 
+  if (pass_->context()->id_overflow()) {
+    return Pass::Status::Failure;
+  }
+
   // Finally, apply all the replacements in the IR.
   bool modified = ApplyReplacements();
+
+  if (pass_->context()->id_overflow()) {
+    return Pass::Status::Failure;
+  }
 
 #if SSA_REWRITE_DEBUGGING_LEVEL > 0
   std::cerr << "\n\n\nFunction after SSA rewrite:\n"
@@ -696,12 +708,12 @@ Pass::Status SSARewritePass::Process() {
     }
     status =
         CombineStatus(status, SSARewriter(this).RewriteFunctionIntoSSA(&fn));
+    if (status == Status::Failure || context()->id_overflow()) {
+      return Status::Failure;
+    }
     // Kill DebugDeclares for target variables.
     for (auto var_id : seen_target_vars_) {
       context()->get_debug_info_mgr()->KillDebugDeclares(var_id);
-    }
-    if (status == Status::Failure) {
-      break;
     }
   }
   return status;

--- a/source/opt/upgrade_memory_model.cpp
+++ b/source/opt/upgrade_memory_model.cpp
@@ -47,6 +47,9 @@ Pass::Status UpgradeMemoryModel::Process() {
   UpgradeBarriers();
   UpgradeMemoryScope();
 
+  if (context()->id_overflow()) {
+    return Pass::Status::Failure;
+  }
   return Pass::Status::SuccessWithChange;
 }
 
@@ -226,8 +229,10 @@ void UpgradeMemoryModel::UpgradeMemoryAndImages() {
       // |is_coherent| is never used for the same instructions as
       // |src_coherent| and |dst_coherent|.
       if (is_coherent) {
-        inst->AddOperand(
-            {SPV_OPERAND_TYPE_SCOPE_ID, {GetScopeConstant(scope)}});
+        uint32_t scope_id = GetScopeConstant(scope);
+        if (scope_id != 0) {
+          inst->AddOperand({SPV_OPERAND_TYPE_SCOPE_ID, {scope_id}});
+        }
       }
       if (get_module()->version() >= SPV_SPIRV_VERSION_WORD(1, 4)) {
         // There are two memory access operands. The first is for the target and
@@ -245,8 +250,10 @@ void UpgradeMemoryModel::UpgradeMemoryAndImages() {
           }
           // Add the target scope if necessary.
           if (dst_coherent) {
-            new_operands.push_back(
-                {SPV_OPERAND_TYPE_SCOPE_ID, {GetScopeConstant(dst_scope)}});
+            uint32_t scope_id = GetScopeConstant(dst_scope);
+            if (scope_id != 0) {
+              new_operands.push_back({SPV_OPERAND_TYPE_SCOPE_ID, {scope_id}});
+            }
           }
           // Copy the remaining current operands.
           for (uint32_t i = start_operand + num_access_words;
@@ -255,8 +262,10 @@ void UpgradeMemoryModel::UpgradeMemoryAndImages() {
           }
           // Add the source scope if necessary.
           if (src_coherent) {
-            new_operands.push_back(
-                {SPV_OPERAND_TYPE_SCOPE_ID, {GetScopeConstant(src_scope)}});
+            uint32_t scope_id = GetScopeConstant(src_scope);
+            if (scope_id != 0) {
+              new_operands.push_back({SPV_OPERAND_TYPE_SCOPE_ID, {scope_id}});
+            }
           }
           inst->SetInOperands(std::move(new_operands));
         }
@@ -265,12 +274,16 @@ void UpgradeMemoryModel::UpgradeMemoryAndImages() {
         // visible flags are used the first scope operand is for availability
         // (writes) and the second is for visibility (reads).
         if (dst_coherent) {
-          inst->AddOperand(
-              {SPV_OPERAND_TYPE_SCOPE_ID, {GetScopeConstant(dst_scope)}});
+          uint32_t scope_id = GetScopeConstant(dst_scope);
+          if (scope_id != 0) {
+            inst->AddOperand({SPV_OPERAND_TYPE_SCOPE_ID, {scope_id}});
+          }
         }
         if (src_coherent) {
-          inst->AddOperand(
-              {SPV_OPERAND_TYPE_SCOPE_ID, {GetScopeConstant(src_scope)}});
+          uint32_t scope_id = GetScopeConstant(src_scope);
+          if (scope_id != 0) {
+            inst->AddOperand({SPV_OPERAND_TYPE_SCOPE_ID, {scope_id}});
+          }
         }
       }
     });
@@ -316,8 +329,14 @@ void UpgradeMemoryModel::UpgradeSemantics(Instruction* inst,
 
   value |= uint32_t(spv::MemorySemanticsMask::Volatile);
   auto new_constant = context()->get_constant_mgr()->GetConstant(type, {value});
+  if (!new_constant) {
+    return;
+  }
   auto new_semantics =
       context()->get_constant_mgr()->GetDefiningInstruction(new_constant);
+  if (!new_semantics) {
+    return;
+  }
   inst->SetInOperand(in_operand, {new_semantics->result_id()});
 }
 
@@ -613,14 +632,22 @@ void UpgradeMemoryModel::UpgradeFlags(Instruction* inst, uint32_t in_operand,
 uint32_t UpgradeMemoryModel::GetScopeConstant(spv::Scope scope) {
   analysis::Integer int_ty(32, false);
   uint32_t int_id = context()->get_type_mgr()->GetTypeInstruction(&int_ty);
+  if (int_id == 0) {
+    return 0;
+  }
   const analysis::Constant* constant =
       context()->get_constant_mgr()->GetConstant(
           context()->get_type_mgr()->GetType(int_id),
           {static_cast<uint32_t>(scope)});
-  return context()
-      ->get_constant_mgr()
-      ->GetDefiningInstruction(constant)
-      ->result_id();
+  if (!constant) {
+    return 0;
+  }
+  Instruction* inst =
+      context()->get_constant_mgr()->GetDefiningInstruction(constant);
+  if (!inst) {
+    return 0;
+  }
+  return inst->result_id();
 }
 
 void UpgradeMemoryModel::CleanupDecorations() {
@@ -718,10 +745,14 @@ void UpgradeMemoryModel::UpgradeBarriers() {
                     semantics_type,
                     {static_cast<uint32_t>(semantics_value) |
                      uint32_t(spv::MemorySemanticsMask::OutputMemoryKHR)});
-            barrier->SetInOperand(2u, {context()
-                                           ->get_constant_mgr()
-                                           ->GetDefiningInstruction(constant)
-                                           ->result_id()});
+            if (constant) {
+              Instruction* const_inst =
+                  context()->get_constant_mgr()->GetDefiningInstruction(
+                      constant);
+              if (const_inst) {
+                barrier->SetInOperand(2u, {const_inst->result_id()});
+              }
+            }
           }
         }
       }
@@ -738,15 +769,24 @@ void UpgradeMemoryModel::UpgradeMemoryScope() {
     // * Workgroup ops (e.g. async_copy) have at most workgroup scope.
     if (spvOpcodeIsAtomicOp(inst->opcode())) {
       if (IsDeviceScope(inst->GetSingleWordInOperand(1))) {
-        inst->SetInOperand(1, {GetScopeConstant(spv::Scope::QueueFamilyKHR)});
+        uint32_t scope_id = GetScopeConstant(spv::Scope::QueueFamilyKHR);
+        if (scope_id != 0) {
+          inst->SetInOperand(1, {scope_id});
+        }
       }
     } else if (inst->opcode() == spv::Op::OpControlBarrier) {
       if (IsDeviceScope(inst->GetSingleWordInOperand(1))) {
-        inst->SetInOperand(1, {GetScopeConstant(spv::Scope::QueueFamilyKHR)});
+        uint32_t scope_id = GetScopeConstant(spv::Scope::QueueFamilyKHR);
+        if (scope_id != 0) {
+          inst->SetInOperand(1, {scope_id});
+        }
       }
     } else if (inst->opcode() == spv::Op::OpMemoryBarrier) {
       if (IsDeviceScope(inst->GetSingleWordInOperand(0))) {
-        inst->SetInOperand(0, {GetScopeConstant(spv::Scope::QueueFamilyKHR)});
+        uint32_t scope_id = GetScopeConstant(spv::Scope::QueueFamilyKHR);
+        if (scope_id != 0) {
+          inst->SetInOperand(0, {scope_id});
+        }
       }
     }
   });
@@ -789,6 +829,9 @@ void UpgradeMemoryModel::UpgradeExtInst(Instruction* ext_inst) {
   analysis::Struct struct_type(element_types);
   uint32_t struct_id =
       context()->get_type_mgr()->GetTypeInstruction(&struct_type);
+  if (struct_id == 0) {
+    return;
+  }
   // Change the operation
   GLSLstd450 new_op = is_modf ? GLSLstd450ModfStruct : GLSLstd450FrexpStruct;
   ext_inst->SetOperand(3u, {static_cast<uint32_t>(new_op)});
@@ -804,15 +847,19 @@ void UpgradeMemoryModel::UpgradeExtInst(Instruction* ext_inst) {
   InstructionBuilder builder(
       context(), where,
       IRContext::kAnalysisDefUse | IRContext::kAnalysisInstrToBlockMapping);
-  // TODO(1841): Handle id overflow.
   auto extract_0 =
       builder.AddCompositeExtract(element_type_id, ext_inst->result_id(), {0});
+  if (!extract_0) {
+    return;
+  }
   context()->ReplaceAllUsesWith(ext_inst->result_id(), extract_0->result_id());
   // The extract's input was just changed to itself, so fix that.
   extract_0->SetInOperand(0u, {ext_inst->result_id()});
-  // TODO(1841): Handle id overflow.
   auto extract_1 =
       builder.AddCompositeExtract(pointee_type_id, ext_inst->result_id(), {1});
+  if (!extract_1) {
+    return;
+  }
   builder.AddStore(ptr_id, extract_1->result_id());
 }
 

--- a/source/opt/vector_dce.cpp
+++ b/source/opt/vector_dce.cpp
@@ -29,6 +29,9 @@ Pass::Status VectorDCE::Process() {
   for (Function& function : *get_module()) {
     modified |= VectorDCEFunction(&function);
   }
+  if (context()->id_overflow()) {
+    return Status::Failure;
+  }
   return (modified ? Status::SuccessWithChange : Status::SuccessWithoutChange);
 }
 
@@ -335,9 +338,12 @@ bool VectorDCE::RewriteInstructions(
     // If no element in the current instruction is used replace it with an
     // OpUndef.
     if (live_component->second.Empty()) {
+      uint32_t undef_id = this->Type2Undef(current_inst->type_id());
+      if (undef_id == 0) {
+        return;
+      }
       modified = true;
       MarkDebugValueUsesAsDead(current_inst, &dead_dbg_value);
-      uint32_t undef_id = this->Type2Undef(current_inst->type_id());
       context()->KillNamesAndDecorates(current_inst);
       context()->ReplaceAllUsesWith(current_inst->result_id(), undef_id);
       context()->KillInst(current_inst);
@@ -392,8 +398,11 @@ bool VectorDCE::RewriteInsertInstruction(
   utils::BitVector temp = live_components;
   temp.Clear(insert_index);
   if (temp.Empty()) {
-    context()->ForgetUses(current_inst);
     uint32_t undef_id = Type2Undef(current_inst->type_id());
+    if (undef_id == 0) {
+      return false;
+    }
+    context()->ForgetUses(current_inst);
     current_inst->SetInOperand(kInsertCompositeIdInIdx, {undef_id});
     context()->AnalyzeUses(current_inst);
     return true;


### PR DESCRIPTION
Harden LegalizeMultidimArrayPass, SSARewritePass, ReduceLoadSize,
ReplaceDescArrayAccessUsingVarIndex, ReplaceInvalidOpcodePass,
ScalarReplacementPass, SplitCombinedImageSamplerPass, UpgradeMemoryModel,
and VectorDCE against ID overflow.
