### PR TITLE
Validate the Volatile semantics VUIDs for ray tracing built-ins

### DIFF
--- a/source/val/validate_builtins.cpp
+++ b/source/val/validate_builtins.cpp
@@ -258,6 +258,47 @@ bool IsExecutionModelValidForRtBuiltIn(spv::BuiltIn builtin,
   return false;
 }
 
+// VUID-StandaloneSpirv-VulkanMemoryModel-04678 and -04679 name these built-ins.
+// Both VUIDs cover the same set; they differ only in what carries the Volatile
+// semantics, which depends on whether VulkanMemoryModel is declared.
+bool IsVolatileSemanticsBuiltIn(spv::BuiltIn built_in) {
+  switch (built_in) {
+    case spv::BuiltIn::SMIDNV:
+    case spv::BuiltIn::WarpIDNV:
+    case spv::BuiltIn::SubgroupSize:
+    case spv::BuiltIn::SubgroupLocalInvocationId:
+    case spv::BuiltIn::SubgroupEqMask:
+    case spv::BuiltIn::SubgroupGeMask:
+    case spv::BuiltIn::SubgroupGtMask:
+    case spv::BuiltIn::SubgroupLeMask:
+    case spv::BuiltIn::SubgroupLtMask:
+    case spv::BuiltIn::RayTmaxKHR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// The requirement only applies to the ray tracing stages, and RayTmaxKHR is
+// listed for an intersection shader only.
+bool NeedsVolatileSemantics(spv::BuiltIn built_in,
+                            spv::ExecutionModel execution_model) {
+  if (built_in == spv::BuiltIn::RayTmaxKHR) {
+    return execution_model == spv::ExecutionModel::IntersectionKHR;
+  }
+  if (!IsVolatileSemanticsBuiltIn(built_in)) return false;
+  switch (execution_model) {
+    case spv::ExecutionModel::RayGenerationKHR:
+    case spv::ExecutionModel::ClosestHitKHR:
+    case spv::ExecutionModel::MissKHR:
+    case spv::ExecutionModel::IntersectionKHR:
+    case spv::ExecutionModel::CallableKHR:
+      return true;
+    default:
+      return false;
+  }
+}
+
 // Helper class managing validation of built-ins.
 // TODO: Generic functionality of this class can be moved into
 // ValidationState_t to be made available to other users.
@@ -351,6 +392,8 @@ class BuiltInsValidator {
                                                const Instruction& inst);
   // Used for GlobalInvocationId, LocalInvocationId, NumWorkgroups, WorkgroupId.
   spv_result_t ValidateComputeShaderI32Vec3InputAtDefinition(
+      const Decoration& decoration, const Instruction& inst);
+  spv_result_t ValidateVolatileSemanticsAtDefinition(
       const Decoration& decoration, const Instruction& inst);
   spv_result_t ValidateNVSMOrARMCoreBuiltinsAtDefinition(const Decoration& decoration,
                                               const Instruction& inst);
@@ -566,6 +609,11 @@ class BuiltInsValidator {
   spv_result_t ValidateComputeI32InputAtReference(
       const Decoration& decoration, const Instruction& built_in_inst,
       const Instruction& referenced_inst,
+      const Instruction& referenced_from_inst);
+
+  spv_result_t ValidateVolatileSemanticsAtReference(
+      const Decoration& decoration, const Instruction& built_in_inst,
+      uint32_t variable_id, const Instruction& referenced_inst,
       const Instruction& referenced_from_inst);
 
   spv_result_t ValidateNVSMOrARMCoreBuiltinsAtReference(
@@ -4491,6 +4539,80 @@ spv_result_t BuiltInsValidator::ValidateNVSMOrARMCoreBuiltinsAtReference(
   return SPV_SUCCESS;
 }
 
+spv_result_t BuiltInsValidator::ValidateVolatileSemanticsAtDefinition(
+    const Decoration& decoration, const Instruction& inst) {
+  // Which stage the variable is used from is only known at a reference, so the
+  // whole rule is checked there. A member decoration names a Block type rather
+  // than a variable, and the Volatile decoration the rule asks for sits on the
+  // variable, so that id is picked up as the chain walks past it.
+  const uint32_t variable_id =
+      decoration.struct_member_index() == Decoration::kInvalidMember ? inst.id()
+                                                                     : 0u;
+  return ValidateVolatileSemanticsAtReference(decoration, inst, variable_id,
+                                              inst, inst);
+}
+
+spv_result_t BuiltInsValidator::ValidateVolatileSemanticsAtReference(
+    const Decoration& decoration, const Instruction& built_in_inst,
+    uint32_t variable_id, const Instruction& referenced_inst,
+    const Instruction& referenced_from_inst) {
+  if (variable_id == 0 &&
+      referenced_from_inst.opcode() == spv::Op::OpVariable) {
+    variable_id = referenced_from_inst.id();
+  }
+
+  if (spvIsVulkanEnv(_.context()->target_env)) {
+    const spv::BuiltIn built_in = decoration.builtin();
+    for (const spv::ExecutionModel execution_model : execution_models_) {
+      if (!NeedsVolatileSemantics(built_in, execution_model)) continue;
+
+      if (_.HasCapability(spv::Capability::VulkanMemoryModel)) {
+        // The load carries the semantics, so only a load is interesting here.
+        if (referenced_from_inst.opcode() != spv::Op::OpLoad) continue;
+        // OpLoad's memory operands are optional and follow the pointer.
+        const uint32_t mask =
+            referenced_from_inst.operands().size() > 3
+                ? referenced_from_inst.GetOperandAs<uint32_t>(3)
+                : 0u;
+        if (!(mask & uint32_t(spv::MemoryAccessMask::Volatile))) {
+          return _.diag(SPV_ERROR_INVALID_DATA, &referenced_from_inst)
+                 << _.VkErrorID(4679)
+                 << spvLogStringForEnv(_.context()->target_env)
+                 << " spec requires OpLoad to use the Volatile memory operand "
+                    "when it accesses a variable with the BuiltIn "
+                 << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
+                                                  uint32_t(built_in))
+                 << " decoration, because VulkanMemoryModel is declared. "
+                 << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
+                                     referenced_from_inst, execution_model);
+        }
+      } else if (variable_id != 0 &&
+                 !_.HasDecoration(variable_id, spv::Decoration::Volatile)) {
+        return _.diag(SPV_ERROR_INVALID_DATA, _.FindDef(variable_id))
+               << _.VkErrorID(4678)
+               << spvLogStringForEnv(_.context()->target_env)
+               << " spec requires the Volatile decoration on a variable with "
+                  "the BuiltIn "
+               << _.grammar().lookupOperandName(SPV_OPERAND_TYPE_BUILT_IN,
+                                                uint32_t(built_in))
+               << " decoration when VulkanMemoryModel is not declared. "
+               << GetReferenceDesc(decoration, built_in_inst, referenced_inst,
+                                   referenced_from_inst, execution_model);
+      }
+    }
+  }
+
+  if (function_id_ == 0) {
+    // Propagate this rule to all dependant ids in the global scope.
+    id_to_at_reference_checks_[referenced_from_inst.id()].push_back(std::bind(
+        &BuiltInsValidator::ValidateVolatileSemanticsAtReference, this,
+        decoration, built_in_inst, variable_id, referenced_from_inst,
+        std::placeholders::_1));
+  }
+
+  return SPV_SUCCESS;
+}
+
 spv_result_t BuiltInsValidator::ValidatePrimitiveShadingRateAtDefinition(
     const Decoration& decoration, const Instruction& inst) {
   return ValidatePrimitiveShadingRateAtReference(decoration, inst, inst, inst);
@@ -5064,6 +5186,13 @@ spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinition(
 spv_result_t BuiltInsValidator::ValidateSingleBuiltInAtDefinitionVulkan(
     const Decoration& decoration, const Instruction& inst,
     const spv::BuiltIn label) {
+  if (IsVolatileSemanticsBuiltIn(label)) {
+    if (spv_result_t error =
+            ValidateVolatileSemanticsAtDefinition(decoration, inst)) {
+      return error;
+    }
+  }
+
   // If you are adding a new BuiltIn enum, please register it here.
   // If the newly added enum has validation rules associated with it
   // consider leaving a TODO and/or creating an issue.

--- a/source/val/validation_state.cpp
+++ b/source/val/validation_state.cpp
@@ -3254,6 +3254,10 @@ std::string ValidationState_t::VkErrorID(uint32_t id,
       return VUID_WRAP(VUID-StandaloneSpirv-FPRoundingMode-04675);
     case 4677:
       return VUID_WRAP(VUID-StandaloneSpirv-Invariant-04677);
+    case 4678:
+      return VUID_WRAP(VUID-StandaloneSpirv-VulkanMemoryModel-04678);
+    case 4679:
+      return VUID_WRAP(VUID-StandaloneSpirv-VulkanMemoryModel-04679);
     case 4680:
       return VUID_WRAP(VUID-StandaloneSpirv-OpTypeRuntimeArray-04680);
     case 4682:

--- a/test/val/val_builtins_test.cpp
+++ b/test/val/val_builtins_test.cpp
@@ -2500,11 +2500,34 @@ INSTANTIATE_TEST_SUITE_P(
     RayTSuccess,
     ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
     Combine(Values(SPV_ENV_VULKAN_1_2), Values("RayTmaxKHR", "RayTminKHR"),
-            Values("AnyHitKHR", "ClosestHitKHR", "IntersectionKHR", "MissKHR"),
-            Values("Input"), Values("%f32"),
+            Values("AnyHitKHR", "ClosestHitKHR", "MissKHR"), Values("Input"),
+            Values("%f32"), Values("OpCapability RayTracingKHR\n"),
+            Values("OpExtension \"SPV_KHR_ray_tracing\"\n"), Values(nullptr),
+            Values(TestResult())));
+
+// VUID-StandaloneSpirv-VulkanMemoryModel-04678 singles out RayTmaxKHR in an
+// intersection shader, so the two builtins part company on that stage.
+INSTANTIATE_TEST_SUITE_P(
+    RayTminIntersectionSuccess,
+    ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(Values(SPV_ENV_VULKAN_1_2), Values("RayTminKHR"),
+            Values("IntersectionKHR"), Values("Input"), Values("%f32"),
             Values("OpCapability RayTracingKHR\n"),
             Values("OpExtension \"SPV_KHR_ray_tracing\"\n"), Values(nullptr),
             Values(TestResult())));
+
+INSTANTIATE_TEST_SUITE_P(
+    RayTmaxIntersectionNeedsVolatile,
+    ValidateGenericCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(Values(SPV_ENV_VULKAN_1_2), Values("RayTmaxKHR"),
+            Values("IntersectionKHR"), Values("Input"), Values("%f32"),
+            Values("OpCapability RayTracingKHR\n"),
+            Values("OpExtension \"SPV_KHR_ray_tracing\"\n"), Values(nullptr),
+            Values(TestResult(
+                SPV_ERROR_INVALID_DATA,
+                "requires the Volatile decoration on a variable with the "
+                "BuiltIn",
+                "when VulkanMemoryModel is not declared"))));
 
 INSTANTIATE_TEST_SUITE_P(
     RayTNotExecutionMode,
@@ -2852,11 +2875,14 @@ INSTANTIATE_TEST_SUITE_P(
                "\"SPV_NV_mesh_shader\"\n"),
         Values(nullptr), Values(TestResult())));
 
+// SMIDNV and WarpIDNV are the two of these that
+// VUID-StandaloneSpirv-VulkanMemoryModel-04678 names, and it does not list the
+// any-hit stage, so the grid splits three ways along that boundary.
 INSTANTIATE_TEST_SUITE_P(
     SMBuiltinsInputRaySuccess,
     ValidateVulkanCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
     Combine(
-        Values("SMCountNV", "SMIDNV", "WarpsPerSMNV", "WarpIDNV"),
+        Values("SMCountNV", "WarpsPerSMNV"),
         Values("RayGenerationNV", "IntersectionNV", "AnyHitNV", "ClosestHitNV",
                "MissNV", "CallableNV"),
         Values("Input"), Values("%u32"),
@@ -2864,6 +2890,34 @@ INSTANTIATE_TEST_SUITE_P(
         Values("OpExtension \"SPV_NV_shader_sm_builtins\"\nOpExtension "
                "\"SPV_NV_ray_tracing\"\n"),
         Values(nullptr), Values(TestResult())));
+
+INSTANTIATE_TEST_SUITE_P(
+    SMBuiltinsInputAnyHitSuccess,
+    ValidateVulkanCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(
+        Values("SMIDNV", "WarpIDNV"), Values("AnyHitNV"), Values("Input"),
+        Values("%u32"),
+        Values("OpCapability ShaderSMBuiltinsNV\nOpCapability RayTracingNV\n"),
+        Values("OpExtension \"SPV_NV_shader_sm_builtins\"\nOpExtension "
+               "\"SPV_NV_ray_tracing\"\n"),
+        Values(nullptr), Values(TestResult())));
+
+INSTANTIATE_TEST_SUITE_P(
+    SMBuiltinsInputRayNeedsVolatile,
+    ValidateVulkanCombineBuiltInExecutionModelDataTypeCapabilityExtensionResult,
+    Combine(
+        Values("SMIDNV", "WarpIDNV"),
+        Values("RayGenerationNV", "IntersectionNV", "ClosestHitNV", "MissNV",
+               "CallableNV"),
+        Values("Input"), Values("%u32"),
+        Values("OpCapability ShaderSMBuiltinsNV\nOpCapability RayTracingNV\n"),
+        Values("OpExtension \"SPV_NV_shader_sm_builtins\"\nOpExtension "
+               "\"SPV_NV_ray_tracing\"\n"),
+        Values(nullptr),
+        Values(TestResult(
+            SPV_ERROR_INVALID_DATA,
+            "requires the Volatile decoration on a variable with the BuiltIn",
+            "when VulkanMemoryModel is not declared"))));
 
 INSTANTIATE_TEST_SUITE_P(
     SMBuiltinsNotInput,
@@ -3680,7 +3734,8 @@ OpDecorate %gl_ViewportIndex PerPrimitiveNV
   ASSERT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_1));
   EXPECT_THAT(getDiagnosticString(),
               HasSubstr("needs to be a 32-bit int scalar"));
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("is not an int scalar"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("is not an int scalar"));
 }
 
 TEST_P(ValidateVulkanSubgroupBuiltIns, InMain) {
@@ -7238,7 +7293,8 @@ TEST_F(ValidateBuiltIns, HitTriangleVertexPositionType) {
 )";
   CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_3);
   EXPECT_EQ(SPV_ERROR_INVALID_DATA, ValidateInstructions(SPV_ENV_VULKAN_1_3));
-  EXPECT_THAT(getDiagnosticString(), HasSubstr("array length must be 3"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("array length must be 3"));
   EXPECT_THAT(getDiagnosticString(),
               AnyVUID("VUID-HitTriangleVertexPositionsKHR-"
                       "HitTriangleVertexPositionsKHR-08749"));
@@ -7539,6 +7595,195 @@ TEST_F(ValidateBuiltIns,
       HasSubstr("According to the Vulkan spec BuiltIn TileApronSizeQCOM "
                 "variable must be a 2-component 32-bit "
                 "unsigned int vector."));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsRequiresDecoration) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint RayGenerationKHR %main "main" %var
+               OpDecorate %var BuiltIn SubgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeInt 32 0
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-VulkanMemoryModel-04678"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("requires the Volatile decoration on a variable with "
+                "the BuiltIn SubgroupSize"));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsDecorationSatisfiesRequirement) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint RayGenerationKHR %main "main" %var
+               OpDecorate %var BuiltIn SubgroupSize
+               OpDecorate %var Volatile
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeInt 32 0
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsRequiresVolatileLoad) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpCapability VulkanMemoryModel
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical Vulkan
+               OpEntryPoint RayGenerationKHR %main "main" %var
+               OpDecorate %var BuiltIn SubgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeInt 32 0
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-VulkanMemoryModel-04679"));
+  EXPECT_THAT(getDiagnosticString(),
+              HasSubstr("requires OpLoad to use the Volatile memory operand"));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsVolatileLoadSatisfiesRequirement) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpCapability VulkanMemoryModel
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical Vulkan
+               OpEntryPoint RayGenerationKHR %main "main" %var
+               OpDecorate %var BuiltIn SubgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeInt 32 0
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var Volatile
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsRayTmaxInIntersection) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint IntersectionKHR %main "main" %var
+               OpDecorate %var BuiltIn RayTmaxKHR
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeFloat 32
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_ERROR_INVALID_DATA,
+            ValidateInstructions(SPV_ENV_VULKAN_1_2));
+  EXPECT_THAT(getDiagnosticString(),
+              AnyVUID("VUID-StandaloneSpirv-VulkanMemoryModel-04678"));
+  EXPECT_THAT(
+      getDiagnosticString(),
+      HasSubstr("requires the Volatile decoration on a variable with "
+                "the BuiltIn RayTmaxKHR"));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsRayTmaxOutsideIntersectionIsFine) {
+  const std::string spirv = R"(
+               OpCapability RayTracingKHR
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpExtension "SPV_KHR_ray_tracing"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint ClosestHitKHR %main "main" %var
+               OpDecorate %var BuiltIn RayTmaxKHR
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeFloat 32
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
+}
+
+TEST_F(ValidateBuiltIns, VolatileSemanticsIgnoresNonRayTracingStage) {
+  const std::string spirv = R"(
+               OpCapability GroupNonUniform
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %var
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %var BuiltIn SubgroupSize
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %type = OpTypeInt 32 0
+    %ptr_var = OpTypePointer Input %type
+        %var = OpVariable %ptr_var Input
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+          %6 = OpLoad %type %var
+               OpReturn
+               OpFunctionEnd
+)";
+  CompileSuccessfully(spirv, SPV_ENV_VULKAN_1_2);
+  EXPECT_EQ(SPV_SUCCESS, ValidateInstructions(SPV_ENV_VULKAN_1_2));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #6587. Neither VUID was checked; both numbers appeared in the tree only in `source/opt/spread_volatile_semantics.h`, which exists to satisfy them.

A ray generation shader that reads `SubgroupSize` with no `Volatile` anywhere passed on `vulkan1.2`, `1.3`, `1.4` and universal before this.

Spec text, from `Vulkan-Docs/appendices/spirvenv.adoc`, since the two numbers are easy to transpose. **04678**: VulkanMemoryModel *not* declared, so the `Volatile` decoration goes on the variable. **04679**: VulkanMemoryModel declared, so the `OpLoad` takes the `Volatile` memory operand instead. Both cover `SMIDNV`, `WarpIDNV`, `SubgroupSize`, `SubgroupLocalInvocationId` and the five `Subgroup*Mask` built-ins in ray generation, closest hit, miss, intersection and callable, plus `RayTmaxKHR` in an intersection shader.

The stage is only knowable at a reference, and 04679 has to reach the `OpLoad`, so this runs as a `BuiltInsValidator` at-reference rule using `execution_models_` and `id_to_at_reference_checks_`. It keys off the built-in at the `ValidateSingleBuiltInAtDefinition` layer rather than going inside `ValidateI32InputAtDefinition`, `ValidateNVSMOrARMCoreBuiltinsAtDefinition` or `ValidateRayTracingBuiltinsAtDefinition`, because each of those also covers built-ins the VUIDs do not name. A member decoration names the Block type rather than the variable, so the variable id is picked up as the chain walks past `OpVariable`.

Three existing grids asserted success for combinations the VUIDs make invalid, so they are split along the VUID boundary. That split is worth a look, because the boundary is exactly what the old grids were too coarse to express: `SMCountNV` and `WarpsPerSMNV` are not listed, the any-hit stage is not listed, and `RayTminKHR` is not listed for an intersection shader. The failures were a useful check on the implementation — of the 24 `SMBuiltinsInputRaySuccess` cases only the 10 the VUID names went red, and `AnyHitNV` stayed green on its own.

Seven new `ValidateBuiltIns` tests cover both VUIDs violated and satisfied, plus the three out-of-scope shapes. Reverting only the two source files turns 34 tests red; with the change the validator suite is 68760 passing, and `test_opt` 3770, `test_spirv_unit_tests` 6418 and the C/C++ interface tests are unaffected.

`clang-format` is not installed here, so the formatting is by hand against the surrounding code and an 80-column check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
