### PR TITLE
spirv-opt: Fix use-after-free when moving DebugFunctionDefinition in merge-return

### DIFF
--- a/source/opt/merge_return_pass.cpp
+++ b/source/opt/merge_return_pass.cpp
@@ -952,8 +952,12 @@ bool MergeReturnPass::CreateSingleCaseSwitch(BasicBlock* merge_target) {
   for (auto pos = old_block->begin(); pos != old_block->end(); ++pos) {
     if (pos->GetShaderDebugOpcode() ==
         NonSemanticShaderDebugInfoDebugFunctionDefinition) {
-      start_block->AddInstruction(MakeUnique<Instruction>(*pos));
-      pos.Erase();
+      std::unique_ptr<Instruction> clone(pos->Clone(context()));
+      Instruction* moved_inst = clone.get();
+      start_block->AddInstruction(std::move(clone));
+      context()->AnalyzeDefUse(moved_inst);
+      context()->set_instr_block(moved_inst, start_block);
+      context()->KillInst(&*pos);
       break;
     }
   }

--- a/test/opt/pass_merge_return_test.cpp
+++ b/test/opt/pass_merge_return_test.cpp
@@ -2662,6 +2662,84 @@ TEST_F(MergeReturnPassTest, DebugFunctionDefinitionStillInEntryBlock) {
   SinglePassRunAndMatch<MergeReturnPass>(text, true);
 }
 
+TEST_F(MergeReturnPassTest, DebugFunctionDefinitionDefUseRecordsAreUpdated) {
+  // The DebugFunctionDefinition instruction is moved back into the entry block
+  // after the entry block is split.  The def-use records of the original
+  // instruction have to be removed when it is deleted, otherwise later lookups
+  // dereference the freed instruction.
+  const std::string text =
+      R"(
+; CHECK: OpFunction
+; CHECK: OpLabel
+; CHECK: DebugFunctionDefinition
+; CHECK: OpSwitch
+        OpCapability Shader
+        OpExtension "SPV_KHR_non_semantic_info"
+        %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+        OpMemoryModel Logical GLSL450
+        OpEntryPoint GLCompute %main "main"
+        %5 = OpString "test.hlsl"
+        %21 = OpString "uint"
+        %28 = OpString "unnamed"
+        %30 = OpString "RWStructuredBuffer"
+        %36 = OpString "main"
+        %void = OpTypeVoid
+        %4 = OpExtInst %void %2 DebugSource %5
+        %uint = OpTypeInt 32 0
+        %uint_11 = OpConstant %uint 11
+        %uint_5 = OpConstant %uint 5
+        %uint_100 = OpConstant %uint 100
+        %10 = OpExtInst %void %2 DebugCompilationUnit %uint_100 %uint_5 %4 %uint_11
+        %12 = OpTypeFunction %void
+        %_ptr_Function_uint = OpTypePointer Function %uint
+        %uint_32 = OpConstant %uint 32
+        %uint_6 = OpConstant %uint 6
+        %uint_131072 = OpConstant %uint 131072
+        %20 = OpExtInst %void %2 DebugTypeBasic %21 %uint_32 %uint_6 %uint_131072
+        %uint_0 = OpConstant %uint 0
+        %25 = OpExtInst %void %2 DebugTypeArray %20 %uint_0
+        %27 = OpExtInst %void %2 DebugTypeMember %28 %25 %4 %uint_0 %uint_0 %uint_0 %uint_0 %uint_0
+        %uint_1 = OpConstant %uint 1
+        %29 = OpExtInst %void %2 DebugTypeComposite %30 %uint_1 %4 %uint_0 %uint_0 %10 %30 %uint_0 %uint_131072 %27
+        %uint_12 = OpConstant %uint 12
+        %32 = OpExtInst %void %2 DebugTypePointer %29 %uint_12 %uint_131072
+        %34 = OpExtInst %void %2 DebugTypeFunction %uint_0 %void %32 %32
+        %35 = OpExtInst %void %2 DebugFunction %36 %34 %4 %uint_11 %uint_6 %10 %36 %uint_0 %uint_11
+        %bool = OpTypeBool
+        %uint_3 = OpConstant %uint 3
+        %uint_22 = OpConstant %uint 22
+        %main = OpFunction %void None %12
+        %13 = OpLabel
+        %iter = OpVariable %_ptr_Function_uint Function
+        %37 = OpExtInst %void %2 DebugFunctionDefinition %35 %main
+        OpBranch %40
+        %40 = OpLabel
+        OpLoopMerge %47 %51 None
+        OpBranch %41
+        %41 = OpLabel
+        OpBranch %43
+        %43 = OpLabel
+        %111 = OpLoad %uint %iter
+        %iter_1 = OpIAdd %uint %111 %uint_1
+        %124 = OpULessThan %bool %iter_1 %uint_3
+        %126 = OpLogicalNot %bool %124
+        OpSelectionMerge %49 None
+        OpBranchConditional %126 %45 %49
+        %45 = OpLabel
+        OpBranch %47
+        %47 = OpLabel
+        %129 = OpExtInst %void %2 DebugLine %4 %uint_22 %uint_22 %uint_5 %uint_6
+        OpReturn
+        %49 = OpLabel
+        OpBranch %51
+        %51 = OpLabel
+        OpBranch %40
+        OpFunctionEnd
+)";
+
+  SinglePassRunAndMatch<MergeReturnPass>(text, true);
+}
+
 }  // namespace
 }  // namespace opt
 }  // namespace spvtools


### PR DESCRIPTION
## Problem

`MergeReturnPass::CreateSingleCaseSwitch()` splits the entry block and then moves the `DebugFunctionDefinition` instruction back into the entry block:

```cpp
start_block->AddInstruction(MakeUnique<Instruction>(*pos));
pos.Erase();
```

`InstructionList::iterator::Erase()` does a plain `delete node_` and bypasses `IRContext::KillInst()`, so the def-use manager keeps `UserEntry` records whose `user` field points at the freed instruction. Any later def-use update walks `id_to_users_`, and `UserEntryLess` dereferences that dangling pointer to read `unique_id()`:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 4 at ... thread T0
    #0 spvtools::opt::Instruction::unique_id() const                     source/opt/instruction.h:251
    #1 spvtools::opt::analysis::UserEntryLess::operator()(...)           source/opt/def_use_manager.h:70
    #2 std::_Tree<...UserEntry...>::_Eqrange<...>(...)
    #3 std::_Tree<...UserEntry...>::erase(...)
    #4 spvtools::opt::analysis::DefUseManager::EraseUseRecordsOfOperandIds(...)  source/opt/def_use_manager.cpp:255
    #5 spvtools::opt::analysis::DefUseManager::ClearInst(...)            source/opt/def_use_manager.cpp:235
    #6 spvtools::opt::analysis::DefUseManager::AnalyzeInstDef(...)       source/opt/def_use_manager.cpp:28
    #7 spvtools::opt::analysis::DefUseManager::AnalyzeInstDefUse(...)    source/opt/def_use_manager.cpp:67
    #8 spvtools::opt::MergeReturnPass::BranchToBlock(...)                source/opt/merge_return_pass.cpp:286
    #9 spvtools::opt::MergeReturnPass::ProcessStructuredBlock(...)       source/opt/merge_return_pass.cpp:258
   #10 spvtools::opt::MergeReturnPass::ProcessStructured(...)            source/opt/merge_return_pass.cpp:137

freed by thread T0 here:
    #1 spvtools::opt::Instruction::~Instruction()
    #2 spvtools::opt::InstructionList::iterator::Erase()                 source/opt/instruction_list.h:94
    #3 spvtools::opt::MergeReturnPass::CreateSingleCaseSwitch(...)       source/opt/merge_return_pass.cpp:956
    #4 spvtools::opt::MergeReturnPass::AddSingleCaseSwitchAroundFunction()  source/opt/merge_return_pass.cpp:894
    #5 spvtools::opt::MergeReturnPass::ProcessStructured(...)            source/opt/merge_return_pass.cpp:116
```

Two smaller problems come with it:

- `MakeUnique<Instruction>(*pos)` uses the copy constructor, which copies `unique_id_` verbatim, so the new instruction shares its "unique" id with the deleted one.
- The new instruction is never registered with the def-use manager or the instruction-to-block mapping.

In a build with assertions enabled the symptom is usually not an ASan report but an intermittent crash, because whether the freed memory happens to contain zero decides whether `assert(unique_id_ != 0)` in `instruction.h:251` fires:

```
Assertion failed: (unique_id_ != 0), function unique_id, file instruction.h, line 251.
```

The stale record is created on every module that takes this path. Whether it is actually dereferenced depends on the shape of the `id_to_users_` red-black tree, so the failure looks input- and platform-dependent. It began reproducing consistently for us after #6862, which changed the traversal order of the non-const `Module::ForEachInst` and therefore the insertion order into that set.

## Minimal repro

```
spirv-as --target-env spv1.5 --preserve-numeric-ids repro.spvasm -o repro.spv
spirv-opt --merge-return repro.spv -o /dev/null      # ASan build
```

<details>
<summary>repro.spvasm</summary>

```
OpCapability Shader
OpExtension "SPV_KHR_non_semantic_info"
%2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
OpMemoryModel Logical GLSL450
OpEntryPoint GLCompute %main "main"
%5 = OpString "test.hlsl"
%21 = OpString "uint"
%28 = OpString "unnamed"
%30 = OpString "RWStructuredBuffer"
%36 = OpString "main"
%void = OpTypeVoid
%4 = OpExtInst %void %2 DebugSource %5
%uint = OpTypeInt 32 0
%uint_11 = OpConstant %uint 11
%uint_5 = OpConstant %uint 5
%uint_100 = OpConstant %uint 100
%10 = OpExtInst %void %2 DebugCompilationUnit %uint_100 %uint_5 %4 %uint_11
%12 = OpTypeFunction %void
%_ptr_Function_uint = OpTypePointer Function %uint
%uint_32 = OpConstant %uint 32
%uint_6 = OpConstant %uint 6
%uint_131072 = OpConstant %uint 131072
%20 = OpExtInst %void %2 DebugTypeBasic %21 %uint_32 %uint_6 %uint_131072
%uint_0 = OpConstant %uint 0
%25 = OpExtInst %void %2 DebugTypeArray %20 %uint_0
%27 = OpExtInst %void %2 DebugTypeMember %28 %25 %4 %uint_0 %uint_0 %uint_0 %uint_0 %uint_0
%uint_1 = OpConstant %uint 1
%29 = OpExtInst %void %2 DebugTypeComposite %30 %uint_1 %4 %uint_0 %uint_0 %10 %30 %uint_0 %uint_131072 %27
%uint_12 = OpConstant %uint 12
%32 = OpExtInst %void %2 DebugTypePointer %29 %uint_12 %uint_131072
%34 = OpExtInst %void %2 DebugTypeFunction %uint_0 %void %32 %32
%35 = OpExtInst %void %2 DebugFunction %36 %34 %4 %uint_11 %uint_6 %10 %36 %uint_0 %uint_11
%bool = OpTypeBool
%uint_3 = OpConstant %uint 3
%uint_22 = OpConstant %uint 22
%main = OpFunction %void None %12
%13 = OpLabel
%iter = OpVariable %_ptr_Function_uint Function
%37 = OpExtInst %void %2 DebugFunctionDefinition %35 %main
OpBranch %40
%40 = OpLabel
OpLoopMerge %47 %51 None
OpBranch %41
%41 = OpLabel
OpBranch %43
%43 = OpLabel
%111 = OpLoad %uint %iter
%iter_1 = OpIAdd %uint %111 %uint_1
%124 = OpULessThan %bool %iter_1 %uint_3
%126 = OpLogicalNot %bool %124
OpSelectionMerge %49 None
OpBranchConditional %126 %45 %49
%45 = OpLabel
OpBranch %47
%47 = OpLabel
%129 = OpExtInst %void %2 DebugLine %4 %uint_22 %uint_22 %uint_5 %uint_6
OpReturn
%49 = OpLabel
OpBranch %51
%51 = OpLabel
OpBranch %40
OpFunctionEnd
```

</details>

The module above is a reduction of the SPIR-V produced for this compute shader with full debug info (`-g2`). The relevant ingredients are a `do`/`while` loop whose `return` sits inside the loop construct (so `MergeReturnPass` adds the single-case switch) plus a `DebugFunctionDefinition` that follows the entry block's `OpVariable` instructions:

```hlsl
RWStructuredBuffer<uint> input;
RWStructuredBuffer<uint> output;

[numthreads(1, 1, 1)]
void main()
{
    uint step = input[0];
    uint pos = 0u;
    uint iter = 0u;
    do
    {
        output[iter] = pos;
        iter++;
        pos += step;
    } while (iter < 3u);
    output[3] = pos;
}
```

## Fix

Copy the instruction with `Clone()` so that it gets a fresh unique id, register it with the def-use manager and the instruction-to-block mapping, and remove the original with `KillInst()` so its def-use records go away with it.

## Test

`MergeReturnPassTest.DebugFunctionDefinitionDefUseRecordsAreUpdated` uses the module above; it reports the use-after-free under ASan without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
